### PR TITLE
[codex] Add benchmarks and discovery controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ This project is now a modular single-user research workbench for evaluating and 
 - ingests and normalizes Truth Social and X/mention CSV data
 - stores datasets locally in **DuckDB + Parquet**
 - discovers and auto-includes influential X accounts mentioning Trump
+- supports manual `pin` / `suppress` overrides for the discovered account universe
 - builds per-session feature datasets for **next-session SPY expected-return** modeling
 - supports optional cached semantic enrichment on top of deterministic features
 - runs walk-forward backtests for a **long / flat SPY** strategy
+- compares the strategy against benchmark baselines such as always-long, Trump-only, and tracked-accounts-only
+- runs leakage-oriented diagnostics around feature cutoffs and next-session target alignment
 - saves experiment runs, trades, predictions, and model artifacts locally
 - preserves the original descriptive research view with:
   - S&P 500 close overlay

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,36 +15,69 @@ class DiscoveryTests(unittest.TestCase):
                 "2025-02-03 14:00-05:00",
                 "2025-02-04 11:00-05:00",
                 "2025-02-05 11:00-05:00",
+                "2025-02-10 11:00-05:00",
             ],
             utc=True,
         ).tz_convert("America/New_York")
         self.posts = pd.DataFrame(
             {
-                "source_platform": ["X"] * 4,
-                "mentions_trump": [True] * 4,
-                "author_is_trump": [False] * 4,
-                "author_account_id": ["acct-a", "acct-a", "acct-b", "acct-c"],
-                "author_handle": ["macroa", "macroa", "policyb", "newc"],
-                "author_display_name": ["Macro A", "Macro A", "Policy B", "New C"],
-                "post_id": ["1", "2", "3", "4"],
+                "source_platform": ["X"] * 5,
+                "mentions_trump": [True] * 5,
+                "author_is_trump": [False] * 5,
+                "author_account_id": ["acct-a", "acct-a", "acct-b", "acct-c", "acct-b"],
+                "author_handle": ["macroa", "macroa", "policyb", "newc", "policyb"],
+                "author_display_name": ["Macro A", "Macro A", "Policy B", "New C", "Policy B"],
+                "post_id": ["1", "2", "3", "4", "5"],
                 "post_timestamp": timestamps,
-                "engagement_score": [100.0, 80.0, 30.0, 10.0],
-                "sentiment_score": [0.4, 0.2, -0.1, 0.1],
+                "engagement_score": [100.0, 80.0, 30.0, 10.0, 90.0],
+                "sentiment_score": [0.4, 0.2, -0.1, 0.1, 0.5],
             },
         )
         self.service = DiscoveryService()
 
-    def test_rank_candidates_orders_by_discovery_score(self) -> None:
-        ranked = self.service.rank_candidates(self.posts)
+    def test_rank_candidates_respects_as_of_cutoff(self) -> None:
+        ranked = self.service.rank_candidates(self.posts, as_of=pd.Timestamp("2025-02-05 23:59", tz="America/New_York"))
+        self.assertNotIn("5", ranked["mention_count"].astype(str).tolist())
         self.assertEqual(ranked.iloc[0]["author_account_id"], "acct-a")
 
-    def test_refresh_accounts_creates_and_deactivates_versions(self) -> None:
-        tracked, _ = self.service.refresh_accounts(self.posts, pd.DataFrame(), as_of=self.posts["post_timestamp"].max(), auto_include_top_n=2)
-        self.assertEqual(len(tracked), 2)
-        reduced_posts = self.posts.loc[self.posts["author_account_id"].isin(["acct-b"])].copy()
-        tracked2, _ = self.service.refresh_accounts(reduced_posts, tracked, as_of=pd.Timestamp("2025-02-10", tz="America/New_York"), auto_include_top_n=1)
-        inactive = tracked2.loc[tracked2["status"] == "inactive"]
-        self.assertFalse(inactive.empty)
+    def test_refresh_accounts_builds_historical_versions_with_overrides(self) -> None:
+        overrides = self.service.add_manual_override(
+            overrides=pd.DataFrame(),
+            account_id="acct-c",
+            handle="newc",
+            display_name="New C",
+            action="pin",
+            effective_from=pd.Timestamp("2025-02-05"),
+        )
+        tracked, ranking_history = self.service.refresh_accounts(
+            self.posts,
+            pd.DataFrame(),
+            as_of=self.posts["post_timestamp"].max(),
+            auto_include_top_n=1,
+            manual_overrides=overrides,
+        )
+        active = self.service.current_active_accounts(tracked, as_of=pd.Timestamp("2025-02-05"))
+        self.assertIn("acct-c", active["account_id"].astype(str).tolist())
+        self.assertTrue((ranking_history["selected_status"] == "pinned").any())
+
+    def test_suppress_override_removes_account_from_current_universe(self) -> None:
+        overrides = self.service.add_manual_override(
+            overrides=pd.DataFrame(),
+            account_id="acct-a",
+            handle="macroa",
+            display_name="Macro A",
+            action="suppress",
+            effective_from=pd.Timestamp("2025-02-04"),
+        )
+        tracked, _ = self.service.refresh_accounts(
+            self.posts,
+            pd.DataFrame(),
+            as_of=self.posts["post_timestamp"].max(),
+            auto_include_top_n=2,
+            manual_overrides=overrides,
+        )
+        active = self.service.current_active_accounts(tracked, as_of=pd.Timestamp("2025-02-05"))
+        self.assertNotIn("acct-a", active["account_id"].astype(str).tolist())
 
 
 if __name__ == "__main__":

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -76,6 +76,7 @@ class FeatureTests(unittest.TestCase):
         first = feature_rows.iloc[0]
         expected = self.market.iloc[1]["close"] / self.market.iloc[1]["open"] - 1.0
         self.assertAlmostEqual(first["target_next_session_return"], expected)
+        self.assertTrue(bool(feature_rows.loc[feature_rows["signal_session_date"] == pd.Timestamp("2025-02-04"), "feature_cutoff_before_next_open"].iloc[0]))
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -114,6 +114,8 @@ class PipelineTests(unittest.TestCase):
         run, artifacts = self.backtests.run_walk_forward(config, first_dataset)
         self.assertGreater(len(artifacts["trades"]), 0)
         self.assertIn("robust_score", run.metrics)
+        self.assertTrue(artifacts["leakage_audit"]["overall_pass"])
+        self.assertIn("always_long", artifacts["benchmarks"]["benchmark_name"].tolist())
 
         saved = self.experiments.save_run(
             run=run,
@@ -123,10 +125,16 @@ class PipelineTests(unittest.TestCase):
             windows=artifacts["windows"],
             importance=artifacts["importance"],
             model_artifact=artifacts["model_artifact"],
+            benchmarks=artifacts["benchmarks"],
+            diagnostics=artifacts["diagnostics"],
+            benchmark_curves=artifacts["benchmark_curves"],
+            leakage_audit=artifacts["leakage_audit"],
         )
         self.assertTrue(saved.model_path.exists())
         loaded = self.experiments.load_run(run.run_id)
         self.assertIsNotNone(loaded)
+        self.assertFalse(loaded["benchmarks"].empty)
+        self.assertTrue(bool(loaded["leakage_audit"].get("overall_pass", False)))
 
 
 if __name__ == "__main__":

--- a/trump_workbench/backtesting.py
+++ b/trump_workbench/backtesting.py
@@ -9,7 +9,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from .contracts import BacktestRun, LinearModelArtifact, ModelRunConfig
+from .contracts import BacktestRun, ModelRunConfig
 from .modeling import ModelService
 
 
@@ -60,6 +60,27 @@ def compute_metrics(returns: pd.Series, positions: pd.Series) -> dict[str, float
     }
 
 
+def simulate_position_mask(
+    frame: pd.DataFrame,
+    signal_name: str,
+    position_mask: pd.Series,
+    transaction_cost_bps: float,
+) -> tuple[pd.DataFrame, dict[str, float]]:
+    trades = frame.copy()
+    trades = trades.dropna(subset=["next_session_open", "next_session_close"]).copy()
+    position_mask = position_mask.reindex(trades.index).fillna(False)
+    trades["trade_taken"] = position_mask.astype(bool)
+    trades["position"] = trades["trade_taken"].astype(float)
+    trades["gross_return"] = (trades["next_session_close"] / trades["next_session_open"] - 1.0).fillna(0.0)
+    round_trip_cost = (transaction_cost_bps / 10000.0) * 2.0
+    trades["net_return"] = np.where(trades["trade_taken"], trades["gross_return"] - round_trip_cost, 0.0)
+    trades["benchmark_return"] = trades["gross_return"].fillna(0.0)
+    trades["equity_curve"] = (1.0 + trades["net_return"]).cumprod()
+    trades["signal_name"] = signal_name
+    metrics = compute_metrics(trades["net_return"], trades["position"])
+    return trades.reset_index(drop=True), metrics
+
+
 def simulate_long_flat(
     predictions: pd.DataFrame,
     threshold: float,
@@ -67,24 +88,130 @@ def simulate_long_flat(
     transaction_cost_bps: float,
     account_weight: float,
 ) -> tuple[pd.DataFrame, dict[str, float]]:
-    trades = predictions.copy()
-    trades = trades.dropna(subset=["next_session_open", "next_session_close"]).copy()
-    trades["trade_taken"] = (
-        (trades["expected_return_score"] > threshold)
-        & (trades["post_count"] >= min_post_count)
-        & trades["target_available"].fillna(False)
+    signal_mask = (
+        (predictions["expected_return_score"] > threshold)
+        & (predictions["post_count"] >= min_post_count)
+        & predictions["target_available"].fillna(False)
     )
-    trades["position"] = trades["trade_taken"].astype(float)
-    trades["gross_return"] = (trades["next_session_close"] / trades["next_session_open"] - 1.0).fillna(0.0)
-    round_trip_cost = (transaction_cost_bps / 10000.0) * 2.0
-    trades["net_return"] = np.where(trades["trade_taken"], trades["gross_return"] - round_trip_cost, 0.0)
-    trades["benchmark_return"] = trades["gross_return"].fillna(0.0)
-    trades["equity_curve"] = (1.0 + trades["net_return"]).cumprod()
+    trades, metrics = simulate_position_mask(
+        predictions,
+        signal_name="strategy",
+        position_mask=signal_mask,
+        transaction_cost_bps=transaction_cost_bps,
+    )
     trades["threshold"] = threshold
     trades["min_post_count"] = min_post_count
     trades["account_weight"] = account_weight
-    metrics = compute_metrics(trades["net_return"], trades["position"])
-    return trades.reset_index(drop=True), metrics
+    return trades, metrics
+
+
+def build_leakage_audit(feature_rows: pd.DataFrame, window_rows: pd.DataFrame) -> dict[str, Any]:
+    if feature_rows.empty:
+        return {
+            "overall_pass": True,
+            "future_feature_timestamp_violations": 0,
+            "next_session_order_violations": 0,
+            "tradeable_without_target_violations": 0,
+            "window_order_violations": 0,
+        }
+    next_date = pd.to_datetime(feature_rows["next_session_date"], errors="coerce")
+    signal_date = pd.to_datetime(feature_rows["signal_session_date"], errors="coerce")
+    next_open_ts = pd.to_datetime(feature_rows["next_session_open_ts"], errors="coerce", utc=True)
+    feature_max_ts = pd.to_datetime(feature_rows["feature_source_max_ts"], errors="coerce", utc=True)
+    future_feature_violations = int(
+        (feature_max_ts.notna() & next_open_ts.notna() & (feature_max_ts >= next_open_ts)).sum(),
+    )
+    next_session_order_violations = int((next_date.notna() & signal_date.notna() & (next_date <= signal_date)).sum())
+    tradeable_without_target_violations = int((feature_rows["tradeable"].fillna(False) & ~feature_rows["target_available"].fillna(False)).sum())
+    window_order_violations = 0
+    if not window_rows.empty:
+        train_end = pd.to_datetime(window_rows["train_end"], errors="coerce")
+        validation_start = pd.to_datetime(window_rows["validation_start"], errors="coerce")
+        validation_end = pd.to_datetime(window_rows["validation_end"], errors="coerce")
+        test_start = pd.to_datetime(window_rows["test_start"], errors="coerce")
+        window_order_violations = int(((validation_start <= train_end) | (test_start <= validation_end)).sum())
+    overall_pass = all(
+        value == 0
+        for value in [
+            future_feature_violations,
+            next_session_order_violations,
+            tradeable_without_target_violations,
+            window_order_violations,
+        ]
+    )
+    return {
+        "overall_pass": overall_pass,
+        "future_feature_timestamp_violations": future_feature_violations,
+        "next_session_order_violations": next_session_order_violations,
+        "tradeable_without_target_violations": tradeable_without_target_violations,
+        "window_order_violations": window_order_violations,
+        "rows_audited": int(len(feature_rows)),
+    }
+
+
+def build_prediction_diagnostics(predictions: pd.DataFrame) -> pd.DataFrame:
+    diagnostics = predictions.copy()
+    diagnostics["actual_next_session_return"] = diagnostics["target_next_session_return"]
+    diagnostics["prediction_error"] = diagnostics["expected_return_score"] - diagnostics["actual_next_session_return"]
+    diagnostics["absolute_error"] = diagnostics["prediction_error"].abs()
+    diagnostics["direction_correct"] = (
+        np.sign(diagnostics["expected_return_score"].fillna(0.0))
+        == np.sign(diagnostics["actual_next_session_return"].fillna(0.0))
+    )
+    keep = [
+        "signal_session_date",
+        "next_session_date",
+        "expected_return_score",
+        "actual_next_session_return",
+        "prediction_error",
+        "absolute_error",
+        "direction_correct",
+        "post_count",
+        "trump_post_count",
+        "tracked_account_post_count",
+        "sentiment_avg",
+        "feature_cutoff_before_next_open",
+        "model_version",
+    ]
+    return diagnostics[keep].sort_values("signal_session_date").reset_index(drop=True)
+
+
+def build_benchmark_suite(
+    evaluation_rows: pd.DataFrame,
+    strategy_trades: pd.DataFrame,
+    strategy_metrics: dict[str, float],
+    transaction_cost_bps: float,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    benchmark_inputs = evaluation_rows.dropna(subset=["next_session_open", "next_session_close"]).copy()
+    strategies: list[tuple[str, pd.Series, dict[str, float] | None]] = [
+        ("strategy", strategy_trades["trade_taken"].astype(bool), strategy_metrics),
+        ("always_flat", pd.Series(False, index=benchmark_inputs.index), None),
+        ("always_long", benchmark_inputs["target_available"].fillna(False), None),
+        ("trump_only", (benchmark_inputs["trump_post_count"] > 0) & benchmark_inputs["target_available"].fillna(False), None),
+        (
+            "tracked_accounts_only",
+            (benchmark_inputs["tracked_account_post_count"] > 0) & benchmark_inputs["target_available"].fillna(False),
+            None,
+        ),
+    ]
+    metric_rows: list[dict[str, Any]] = []
+    curve = pd.DataFrame({"next_session_date": benchmark_inputs["next_session_date"].tolist()})
+    strategy_total_return = strategy_metrics["total_return"]
+    for name, mask, precomputed_metrics in strategies:
+        trades, metrics = simulate_position_mask(
+            benchmark_inputs,
+            signal_name=name,
+            position_mask=mask,
+            transaction_cost_bps=transaction_cost_bps,
+        )
+        if precomputed_metrics is not None:
+            metrics = precomputed_metrics
+        row = {"benchmark_name": name, **metrics}
+        row["excess_total_return_vs_strategy"] = float(metrics["total_return"] - strategy_total_return)
+        metric_rows.append(row)
+        curve[name] = trades["equity_curve"].to_numpy()
+    benchmarks = pd.DataFrame(metric_rows).sort_values("robust_score", ascending=False).reset_index(drop=True)
+    return benchmarks, curve
 
 
 class BacktestService:
@@ -116,6 +243,7 @@ class BacktestService:
             test_window = run_config.test_window
 
         all_test_trades: list[pd.DataFrame] = []
+        all_test_predictions: list[pd.DataFrame] = []
         window_rows: list[dict[str, Any]] = []
         selected_thresholds: list[float] = []
         selected_min_posts: list[int] = []
@@ -181,6 +309,7 @@ class BacktestService:
             )
             final_importance = importance
             test_predictions = self.model_service.predict(artifact, test_weighted)
+            test_predictions["window_id"] = window_id
             test_trades, test_metrics = simulate_long_flat(
                 test_predictions,
                 threshold=best_params["threshold"],
@@ -189,6 +318,7 @@ class BacktestService:
                 account_weight=best_params["account_weight"],
             )
             test_trades["window_id"] = window_id
+            all_test_predictions.append(test_predictions)
             all_test_trades.append(test_trades)
             window_rows.append(
                 {
@@ -208,6 +338,7 @@ class BacktestService:
             raise RuntimeError("Walk-forward backtest could not produce any evaluation windows.")
 
         combined_test = pd.concat(all_test_trades, ignore_index=True)
+        combined_predictions = pd.concat(all_test_predictions, ignore_index=True)
         combined_metrics = compute_metrics(combined_test["net_return"], combined_test["position"])
         deployment_params = {
             "threshold": float(np.median(selected_thresholds)) if selected_thresholds else float(run_config.threshold_grid[0]),
@@ -221,9 +352,22 @@ class BacktestService:
             feature_rows=final_training_rows,
             model_version=f"{run_config.run_name}-final",
         )
-        full_predictions = self.model_service.predict(final_model, self._apply_account_weight(feature_rows, deployment_params["account_weight"]))
+        full_predictions = self.model_service.predict(
+            final_model,
+            self._apply_account_weight(feature_rows, deployment_params["account_weight"]),
+        )
         full_predictions["deployment_threshold"] = deployment_params["threshold"]
         full_predictions["deployment_min_post_count"] = deployment_params["min_post_count"]
+
+        window_df = pd.DataFrame(window_rows)
+        diagnostics = build_prediction_diagnostics(combined_predictions)
+        benchmarks, benchmark_curves = build_benchmark_suite(
+            evaluation_rows=combined_predictions,
+            strategy_trades=combined_test,
+            strategy_metrics=combined_metrics,
+            transaction_cost_bps=run_config.transaction_cost_bps,
+        )
+        leakage_audit = build_leakage_audit(feature_rows=combined_predictions, window_rows=window_df)
 
         config_hash = hashlib.sha1(str(run_config.to_dict()).encode("utf-8")).hexdigest()[:12]
         run_id = f"{datetime.utcnow().strftime('%Y%m%d%H%M%S')}-{config_hash}"
@@ -242,9 +386,13 @@ class BacktestService:
             "config": run_config.to_dict(),
             "trades": combined_test,
             "predictions": full_predictions,
-            "windows": pd.DataFrame(window_rows),
+            "windows": window_df,
             "importance": final_importance,
             "model_artifact": final_model.to_dict(),
+            "benchmarks": benchmarks,
+            "diagnostics": diagnostics,
+            "benchmark_curves": benchmark_curves,
+            "leakage_audit": leakage_audit,
         }
         return run, artifacts
 

--- a/trump_workbench/contracts.py
+++ b/trump_workbench/contracts.py
@@ -49,6 +49,19 @@ TRACKED_ACCOUNT_COLUMNS = [
     "active_days",
 ]
 
+MANUAL_OVERRIDE_COLUMNS = [
+    "override_id",
+    "account_id",
+    "handle",
+    "display_name",
+    "source_platform",
+    "action",
+    "effective_from",
+    "effective_to",
+    "note",
+    "created_at",
+]
+
 
 class SourceAdapter(Protocol):
     name: str
@@ -215,3 +228,7 @@ class SavedRunArtifacts:
     windows_path: Path
     importance_path: Path
     model_path: Path
+    benchmarks_path: Path
+    diagnostics_path: Path
+    benchmark_curves_path: Path
+    leakage_audit_path: Path

--- a/trump_workbench/discovery.py
+++ b/trump_workbench/discovery.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from .config import EASTERN
-from .contracts import TRACKED_ACCOUNT_COLUMNS, TrackedAccount
+from .contracts import MANUAL_OVERRIDE_COLUMNS, TRACKED_ACCOUNT_COLUMNS, TrackedAccount
 from .utils import ensure_tz_naive_date, stable_text_id
 
 
@@ -16,7 +16,10 @@ class DiscoveryService:
         self,
         posts: pd.DataFrame,
         accounts: pd.DataFrame | None = None,
+        as_of: pd.Timestamp | None = None,
+        lookback_days: int | None = 90,
     ) -> pd.DataFrame:
+        del accounts
         if posts.empty:
             return pd.DataFrame()
 
@@ -25,6 +28,18 @@ class DiscoveryService:
             & posts["mentions_trump"]
             & (~posts["author_is_trump"])
         ].copy()
+        if candidates.empty:
+            return pd.DataFrame()
+
+        if as_of is not None:
+            as_of_ts = as_of.tz_convert(EASTERN) if as_of.tzinfo is not None else as_of.tz_localize(EASTERN)
+            candidates = candidates.loc[candidates["post_timestamp"] <= as_of_ts].copy()
+            if lookback_days is not None:
+                lookback_start = as_of_ts - pd.Timedelta(days=lookback_days)
+                candidates = candidates.loc[candidates["post_timestamp"] >= lookback_start].copy()
+        else:
+            as_of_ts = pd.Timestamp.now(tz=EASTERN)
+
         if candidates.empty:
             return pd.DataFrame()
 
@@ -51,7 +66,7 @@ class DiscoveryService:
             1,
         )
         recency_days = (
-            pd.Timestamp.now(tz=EASTERN).tz_localize(None)
+            as_of_ts.tz_convert(EASTERN).tz_localize(None)
             - grouped["last_seen_at"].dt.tz_convert(EASTERN).dt.tz_localize(None)
         ).dt.days.clip(lower=0)
         grouped["persistence_score"] = grouped["active_days"] / span_days
@@ -63,6 +78,7 @@ class DiscoveryService:
             + grouped["recency_score"] * 3.0
         )
         grouped["discovery_rank"] = grouped["discovery_score"].rank(ascending=False, method="dense").astype(int)
+        grouped["ranked_at"] = ensure_tz_naive_date(as_of_ts)
         return grouped.sort_values(["discovery_score", "mention_count"], ascending=[False, False]).reset_index(drop=True)
 
     def refresh_accounts(
@@ -71,82 +87,134 @@ class DiscoveryService:
         existing_accounts: pd.DataFrame,
         as_of: pd.Timestamp,
         auto_include_top_n: int = 20,
+        manual_overrides: pd.DataFrame | None = None,
+        lookback_days: int = 90,
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        ranked = self.rank_candidates(posts, existing_accounts)
-        if ranked.empty and existing_accounts.empty:
-            return pd.DataFrame(columns=TRACKED_ACCOUNT_COLUMNS), pd.DataFrame()
-
-        tracked = existing_accounts.copy()
-        if tracked.empty:
-            tracked = pd.DataFrame(columns=TRACKED_ACCOUNT_COLUMNS)
-
-        for column in TRACKED_ACCOUNT_COLUMNS:
-            if column not in tracked.columns:
-                tracked[column] = pd.NA
-
+        del existing_accounts
+        overrides = self.normalize_manual_overrides(manual_overrides)
+        candidates = posts.loc[
+            (posts["source_platform"] == "X")
+            & posts["mentions_trump"]
+            & (~posts["author_is_trump"])
+        ].copy()
         as_of_et = as_of.tz_convert(EASTERN) if as_of.tzinfo is not None else as_of.tz_localize(EASTERN)
         as_of_date = ensure_tz_naive_date(as_of_et)
-        active_ranked = ranked.head(auto_include_top_n).copy()
-        active_ids = set(active_ranked["author_account_id"].astype(str))
 
-        currently_active = tracked.loc[
-            tracked["status"].fillna("") == "active",
-        ].copy()
-        if not currently_active.empty:
-            active_mask = currently_active["effective_to"].isna()
-            currently_active = currently_active.loc[active_mask].copy()
+        if candidates.empty and overrides.empty:
+            return pd.DataFrame(columns=TRACKED_ACCOUNT_COLUMNS), pd.DataFrame()
 
-        still_active_ids = set()
-        for idx, row in currently_active.iterrows():
-            account_id = str(row["account_id"])
-            if account_id in active_ids:
-                still_active_ids.add(account_id)
-                ranked_row = active_ranked.loc[active_ranked["author_account_id"].astype(str) == account_id].iloc[0]
-                tracked.loc[idx, "discovery_score"] = float(ranked_row["discovery_score"])
-                tracked.loc[idx, "last_seen_at"] = ranked_row["last_seen_at"]
-                tracked.loc[idx, "mention_count"] = int(ranked_row["mention_count"])
-                tracked.loc[idx, "engagement_mean"] = float(ranked_row["engagement_mean"])
-                tracked.loc[idx, "active_days"] = int(ranked_row["active_days"])
-            else:
-                tracked.loc[idx, "status"] = "inactive"
-                tracked.loc[idx, "effective_to"] = as_of_date
+        candidate_dates = (
+            candidates.loc[candidates["post_timestamp"] <= as_of_et, "post_timestamp"]
+            .dt.tz_convert(EASTERN)
+            .dt.normalize()
+            .dt.tz_localize(None)
+            .drop_duplicates()
+            .sort_values()
+            .tolist()
+        ) if not candidates.empty else []
+        override_dates = []
+        if not overrides.empty:
+            override_dates.extend(pd.to_datetime(overrides["effective_from"], errors="coerce").dropna().dt.normalize().tolist())
+            override_dates.extend(pd.to_datetime(overrides["effective_to"], errors="coerce").dropna().dt.normalize().tolist())
+        rebalance_dates = sorted({date for date in candidate_dates + override_dates if pd.notna(date) and pd.Timestamp(date) <= as_of_date})
+        if not rebalance_dates:
+            rebalance_dates = [as_of_date]
 
-        new_rows: list[dict[str, Any]] = []
-        for _, row in active_ranked.iterrows():
-            account_id = str(row["author_account_id"])
-            if account_id in still_active_ids:
-                continue
-            first_seen = row["first_seen_at"]
-            version_id = stable_text_id(account_id, as_of_date.isoformat())
-            record = TrackedAccount(
-                version_id=version_id,
-                account_id=account_id,
-                handle=str(row["author_handle"]),
-                display_name=str(row["author_display_name"]),
-                source_platform=str(row["source_platform"]),
-                discovery_score=float(row["discovery_score"]),
-                status="active",
-                first_seen_at=first_seen,
-                last_seen_at=row["last_seen_at"],
-                effective_from=as_of_date,
-                effective_to=None,
-                auto_included=True,
-                provenance="discovery_auto_include",
-                mention_count=int(row["mention_count"]),
-                engagement_mean=float(row["engagement_mean"]),
-                active_days=int(row["active_days"]),
+        open_rows: dict[str, dict[str, Any]] = {}
+        tracked_rows: list[dict[str, Any]] = []
+        current_keys: dict[str, tuple[str, str]] = {}
+        ranking_rows: list[dict[str, Any]] = []
+
+        for rank_date in rebalance_dates:
+            rank_ts = pd.Timestamp(f"{pd.Timestamp(rank_date).date()} 23:59", tz=EASTERN)
+            ranked = self.rank_candidates(
+                posts=posts,
+                as_of=rank_ts,
+                lookback_days=lookback_days,
             )
-            new_rows.append(asdict(record))
+            active_overrides = self.overrides_in_effect(overrides, pd.Timestamp(rank_date))
+            suppressed_ids = set(active_overrides.loc[active_overrides["action"] == "suppress", "account_id"].astype(str))
+            pinned_rows = active_overrides.loc[active_overrides["action"] == "pin"].copy()
 
-        if new_rows:
-            new_rows_df = pd.DataFrame(new_rows)
-            tracked = new_rows_df if tracked.empty else pd.concat([tracked, new_rows_df], ignore_index=True)
+            selected_meta: dict[str, dict[str, Any]] = {}
+            for _, row in ranked.head(auto_include_top_n).iterrows():
+                account_id = str(row["author_account_id"])
+                if account_id in suppressed_ids:
+                    continue
+                selected_meta[account_id] = self._make_interval_meta(
+                    account_id=account_id,
+                    handle=str(row["author_handle"]),
+                    display_name=str(row["author_display_name"]),
+                    source_platform=str(row["source_platform"]),
+                    discovery_score=float(row["discovery_score"]),
+                    status="active",
+                    first_seen_at=row["first_seen_at"],
+                    last_seen_at=row["last_seen_at"],
+                    auto_included=True,
+                    provenance="discovery_auto_include",
+                    mention_count=int(row["mention_count"]),
+                    engagement_mean=float(row["engagement_mean"]),
+                    active_days=int(row["active_days"]),
+                    effective_from=pd.Timestamp(rank_date),
+                )
 
-        ranking_history = active_ranked.copy()
-        ranking_history["ranked_at"] = as_of_date
-        ranking_history["auto_included"] = ranking_history["author_account_id"].astype(str).isin(active_ids)
-        tracked = tracked[TRACKED_ACCOUNT_COLUMNS].copy().reset_index(drop=True)
-        return tracked, ranking_history.reset_index(drop=True)
+            for _, override_row in pinned_rows.iterrows():
+                account_id = str(override_row["account_id"])
+                pinned_meta = self._account_meta_for_override(
+                    posts=posts,
+                    account_id=account_id,
+                    as_of=rank_ts,
+                    override_row=override_row,
+                )
+                selected_meta[account_id] = pinned_meta
+
+            next_keys = {
+                account_id: (meta["status"], meta["provenance"])
+                for account_id, meta in selected_meta.items()
+            }
+
+            for account_id, open_row in list(open_rows.items()):
+                if account_id not in next_keys:
+                    open_row["effective_to"] = pd.Timestamp(rank_date)
+                    tracked_rows.append(open_row)
+                    del open_rows[account_id]
+                    del current_keys[account_id]
+
+            for account_id, meta in selected_meta.items():
+                current_key = current_keys.get(account_id)
+                next_key = next_keys[account_id]
+                if current_key == next_key:
+                    open_row = open_rows[account_id]
+                    for key, value in meta.items():
+                        if key != "effective_from":
+                            open_row[key] = value
+                else:
+                    if account_id in open_rows:
+                        previous = open_rows.pop(account_id)
+                        previous["effective_to"] = pd.Timestamp(rank_date)
+                        tracked_rows.append(previous)
+                    open_rows[account_id] = meta
+                    current_keys[account_id] = next_key
+
+            ranking_rows.extend(
+                self._build_ranking_rows(
+                    ranked=ranked,
+                    selected_meta=selected_meta,
+                    suppressed_ids=suppressed_ids,
+                    rank_date=pd.Timestamp(rank_date),
+                ),
+            )
+
+        for open_row in open_rows.values():
+            tracked_rows.append(open_row)
+
+        tracked = pd.DataFrame(tracked_rows, columns=TRACKED_ACCOUNT_COLUMNS).reset_index(drop=True)
+        ranking_history = pd.DataFrame(ranking_rows).reset_index(drop=True)
+        if tracked.empty:
+            tracked = pd.DataFrame(columns=TRACKED_ACCOUNT_COLUMNS)
+        if ranking_history.empty:
+            ranking_history = pd.DataFrame()
+        return tracked, ranking_history
 
     def current_active_accounts(self, tracked_accounts: pd.DataFrame, as_of: pd.Timestamp) -> pd.DataFrame:
         if tracked_accounts.empty:
@@ -154,5 +222,230 @@ class DiscoveryService:
         as_of_date = ensure_tz_naive_date(as_of)
         start = pd.to_datetime(tracked_accounts["effective_from"], errors="coerce")
         end = pd.to_datetime(tracked_accounts["effective_to"], errors="coerce")
-        mask = (start <= as_of_date) & (end.isna() | (end > as_of_date))
-        return tracked_accounts.loc[mask].copy().sort_values("discovery_score", ascending=False)
+        status = tracked_accounts["status"].fillna("")
+        mask = (
+            (start <= as_of_date)
+            & (end.isna() | (end > as_of_date))
+            & status.isin(["active", "pinned"])
+        )
+        return tracked_accounts.loc[mask].copy().sort_values(["status", "discovery_score"], ascending=[True, False])
+
+    def normalize_manual_overrides(self, overrides: pd.DataFrame | None) -> pd.DataFrame:
+        if overrides is None or overrides.empty:
+            return pd.DataFrame(columns=MANUAL_OVERRIDE_COLUMNS)
+        out = overrides.copy()
+        for column in MANUAL_OVERRIDE_COLUMNS:
+            if column not in out.columns:
+                out[column] = pd.NA
+        out["override_id"] = out["override_id"].fillna("").astype(str)
+        blank_ids = out["override_id"].str.strip() == ""
+        out.loc[blank_ids, "override_id"] = out.loc[blank_ids].apply(
+            lambda row: stable_text_id(row["account_id"], row["action"], row["effective_from"], row["created_at"]),
+            axis=1,
+        )
+        out["account_id"] = out["account_id"].fillna("").astype(str)
+        out["handle"] = out["handle"].fillna("").astype(str)
+        out["display_name"] = out["display_name"].fillna("").astype(str)
+        out["source_platform"] = out["source_platform"].fillna("X").astype(str)
+        out["action"] = out["action"].fillna("").astype(str).str.lower()
+        out["note"] = out["note"].fillna("").astype(str)
+        out["effective_from"] = pd.to_datetime(out["effective_from"], errors="coerce").dt.normalize()
+        out["effective_to"] = pd.to_datetime(out["effective_to"], errors="coerce").dt.normalize()
+        out["created_at"] = pd.to_datetime(out["created_at"], errors="coerce")
+        out = out.dropna(subset=["effective_from"]).copy()
+        out = out.loc[out["action"].isin(["pin", "suppress"])].copy()
+        return out[MANUAL_OVERRIDE_COLUMNS].sort_values(["effective_from", "created_at", "account_id"]).reset_index(drop=True)
+
+    def add_manual_override(
+        self,
+        overrides: pd.DataFrame,
+        account_id: str,
+        handle: str,
+        display_name: str,
+        action: str,
+        effective_from: pd.Timestamp,
+        effective_to: pd.Timestamp | None = None,
+        note: str = "",
+        source_platform: str = "X",
+    ) -> pd.DataFrame:
+        normalized = self.normalize_manual_overrides(overrides)
+        created_at = pd.Timestamp.utcnow()
+        row = pd.DataFrame(
+            [
+                {
+                    "override_id": stable_text_id(account_id, action, effective_from, created_at),
+                    "account_id": account_id,
+                    "handle": handle,
+                    "display_name": display_name,
+                    "source_platform": source_platform,
+                    "action": action,
+                    "effective_from": pd.Timestamp(effective_from).normalize(),
+                    "effective_to": pd.Timestamp(effective_to).normalize() if effective_to is not None else pd.NaT,
+                    "note": note,
+                    "created_at": created_at,
+                },
+            ],
+        )
+        combined = row if normalized.empty else pd.concat([normalized, row], ignore_index=True)
+        return self.normalize_manual_overrides(combined)
+
+    def remove_manual_override(self, overrides: pd.DataFrame, override_id: str) -> pd.DataFrame:
+        normalized = self.normalize_manual_overrides(overrides)
+        if normalized.empty:
+            return normalized
+        return normalized.loc[normalized["override_id"].astype(str) != str(override_id)].reset_index(drop=True)
+
+    def overrides_in_effect(self, overrides: pd.DataFrame, as_of_date: pd.Timestamp) -> pd.DataFrame:
+        normalized = self.normalize_manual_overrides(overrides)
+        if normalized.empty:
+            return normalized
+        as_of = pd.Timestamp(as_of_date).normalize()
+        start = pd.to_datetime(normalized["effective_from"], errors="coerce")
+        end = pd.to_datetime(normalized["effective_to"], errors="coerce")
+        mask = (start <= as_of) & (end.isna() | (end > as_of))
+        return normalized.loc[mask].copy()
+
+    def _account_meta_for_override(
+        self,
+        posts: pd.DataFrame,
+        account_id: str,
+        as_of: pd.Timestamp,
+        override_row: pd.Series,
+    ) -> dict[str, Any]:
+        history = posts.loc[
+            (posts["author_account_id"].astype(str) == account_id)
+            & (posts["post_timestamp"] <= as_of),
+        ].sort_values("post_timestamp")
+        if history.empty:
+            handle = str(override_row.get("handle", ""))
+            display_name = str(override_row.get("display_name", ""))
+            first_seen = pd.Timestamp(override_row["effective_from"]).tz_localize(EASTERN)
+            last_seen = first_seen
+            mention_count = 0
+            engagement_mean = 0.0
+            active_days = 0
+            discovery_score = 0.0
+        else:
+            ranked = self.rank_candidates(history, as_of=as_of, lookback_days=None)
+            match = ranked.loc[ranked["author_account_id"].astype(str) == account_id]
+            row = match.iloc[0] if not match.empty else history.iloc[-1]
+            handle = str(row.get("author_handle", override_row.get("handle", "")))
+            display_name = str(row.get("author_display_name", override_row.get("display_name", "")))
+            first_seen = pd.to_datetime(row.get("first_seen_at", history["post_timestamp"].min()))
+            last_seen = pd.to_datetime(row.get("last_seen_at", history["post_timestamp"].max()))
+            mention_count = int(row.get("mention_count", len(history)))
+            engagement_mean = float(row.get("engagement_mean", history["engagement_score"].mean()))
+            active_days = int(row.get("active_days", history["post_timestamp"].dt.tz_convert(EASTERN).dt.normalize().nunique()))
+            discovery_score = float(row.get("discovery_score", 0.0))
+
+        return self._make_interval_meta(
+            account_id=account_id,
+            handle=handle,
+            display_name=display_name,
+            source_platform=str(override_row.get("source_platform", "X")),
+            discovery_score=discovery_score,
+            status="pinned",
+            first_seen_at=first_seen,
+            last_seen_at=last_seen,
+            auto_included=False,
+            provenance="manual_override:pin",
+            mention_count=mention_count,
+            engagement_mean=engagement_mean,
+            active_days=active_days,
+            effective_from=pd.Timestamp(override_row["effective_from"]).normalize(),
+        )
+
+    def _make_interval_meta(
+        self,
+        account_id: str,
+        handle: str,
+        display_name: str,
+        source_platform: str,
+        discovery_score: float,
+        status: str,
+        first_seen_at: pd.Timestamp,
+        last_seen_at: pd.Timestamp,
+        auto_included: bool,
+        provenance: str,
+        mention_count: int,
+        engagement_mean: float,
+        active_days: int,
+        effective_from: pd.Timestamp,
+    ) -> dict[str, Any]:
+        version_id = stable_text_id(account_id, effective_from.isoformat(), status, provenance)
+        record = TrackedAccount(
+            version_id=version_id,
+            account_id=account_id,
+            handle=handle,
+            display_name=display_name,
+            source_platform=source_platform,
+            discovery_score=float(discovery_score),
+            status=status,
+            first_seen_at=pd.to_datetime(first_seen_at),
+            last_seen_at=pd.to_datetime(last_seen_at),
+            effective_from=pd.Timestamp(effective_from).normalize(),
+            effective_to=None,
+            auto_included=auto_included,
+            provenance=provenance,
+            mention_count=int(mention_count),
+            engagement_mean=float(engagement_mean),
+            active_days=int(active_days),
+        )
+        return asdict(record)
+
+    def _build_ranking_rows(
+        self,
+        ranked: pd.DataFrame,
+        selected_meta: dict[str, dict[str, Any]],
+        suppressed_ids: set[str],
+        rank_date: pd.Timestamp,
+    ) -> list[dict[str, Any]]:
+        if ranked.empty and not selected_meta:
+            return []
+        rows: list[dict[str, Any]] = []
+        included_ids = set(selected_meta)
+        for _, row in ranked.head(max(len(selected_meta), 20) or 20).iterrows():
+            account_id = str(row["author_account_id"])
+            selected = selected_meta.get(account_id)
+            rows.append(
+                {
+                    "author_account_id": account_id,
+                    "author_handle": str(row["author_handle"]),
+                    "author_display_name": str(row["author_display_name"]),
+                    "source_platform": str(row["source_platform"]),
+                    "discovery_score": float(row["discovery_score"]),
+                    "mention_count": int(row["mention_count"]),
+                    "engagement_mean": float(row["engagement_mean"]),
+                    "active_days": int(row["active_days"]),
+                    "ranked_at": pd.Timestamp(rank_date).normalize(),
+                    "discovery_rank": int(row["discovery_rank"]),
+                    "final_selected": account_id in included_ids,
+                    "selected_status": selected["status"] if selected else "excluded",
+                    "suppressed_by_override": account_id in suppressed_ids,
+                    "pinned_by_override": bool(selected and selected["status"] == "pinned"),
+                },
+            )
+
+        ranked_ids = {str(row["author_account_id"]) for _, row in ranked.iterrows()}
+        for account_id, selected in selected_meta.items():
+            if account_id in ranked_ids:
+                continue
+            rows.append(
+                {
+                    "author_account_id": account_id,
+                    "author_handle": selected["handle"],
+                    "author_display_name": selected["display_name"],
+                    "source_platform": selected["source_platform"],
+                    "discovery_score": float(selected["discovery_score"]),
+                    "mention_count": int(selected["mention_count"]),
+                    "engagement_mean": float(selected["engagement_mean"]),
+                    "active_days": int(selected["active_days"]),
+                    "ranked_at": pd.Timestamp(rank_date).normalize(),
+                    "discovery_rank": -1,
+                    "final_selected": True,
+                    "selected_status": selected["status"],
+                    "suppressed_by_override": False,
+                    "pinned_by_override": selected["status"] == "pinned",
+                },
+            )
+        return rows

--- a/trump_workbench/experiments.py
+++ b/trump_workbench/experiments.py
@@ -23,6 +23,10 @@ class ExperimentStore:
         windows: pd.DataFrame,
         importance: pd.DataFrame,
         model_artifact: dict[str, Any],
+        benchmarks: pd.DataFrame,
+        diagnostics: pd.DataFrame,
+        benchmark_curves: pd.DataFrame,
+        leakage_audit: dict[str, Any],
     ) -> SavedRunArtifacts:
         run_dir = self.store.artifact_path("runs", run.run_id)
         run_dir.mkdir(parents=True, exist_ok=True)
@@ -33,6 +37,10 @@ class ExperimentStore:
         windows_path = run_dir / "windows.parquet"
         importance_path = run_dir / "importance.parquet"
         model_path = run_dir / "model.json"
+        benchmarks_path = run_dir / "benchmarks.parquet"
+        diagnostics_path = run_dir / "diagnostics.parquet"
+        benchmark_curves_path = run_dir / "benchmark_curves.parquet"
+        leakage_audit_path = run_dir / "leakage_audit.json"
 
         summary_payload = {
             "run": run.to_dict(),
@@ -44,6 +52,10 @@ class ExperimentStore:
         windows.to_parquet(windows_path, index=False)
         importance.to_parquet(importance_path, index=False)
         model_path.write_text(json.dumps(model_artifact, indent=2, default=str), encoding="utf-8")
+        benchmarks.to_parquet(benchmarks_path, index=False)
+        diagnostics.to_parquet(diagnostics_path, index=False)
+        benchmark_curves.to_parquet(benchmark_curves_path, index=False)
+        leakage_audit_path.write_text(json.dumps(leakage_audit, indent=2, default=str), encoding="utf-8")
 
         self.store.save_run_record(
             run_id=run.run_id,
@@ -67,6 +79,10 @@ class ExperimentStore:
             windows_path=windows_path,
             importance_path=importance_path,
             model_path=model_path,
+            benchmarks_path=benchmarks_path,
+            diagnostics_path=diagnostics_path,
+            benchmark_curves_path=benchmark_curves_path,
+            leakage_audit_path=leakage_audit_path,
         )
 
     def list_runs(self) -> pd.DataFrame:
@@ -89,6 +105,10 @@ class ExperimentStore:
             "model_artifact": LinearModelArtifact.from_dict(self._read_json(Path(record["model_path"]))),
             "metrics": record["metrics_json"],
             "selected_params": record["selected_params_json"],
+            "benchmarks": self._read_optional_parquet(Path(record["summary_path"]).parent / "benchmarks.parquet"),
+            "diagnostics": self._read_optional_parquet(Path(record["summary_path"]).parent / "diagnostics.parquet"),
+            "benchmark_curves": self._read_optional_parquet(Path(record["summary_path"]).parent / "benchmark_curves.parquet"),
+            "leakage_audit": self._read_optional_json(Path(record["summary_path"]).parent / "leakage_audit.json"),
         }
 
     def load_latest_model_artifact(self) -> tuple[LinearModelArtifact, dict[str, Any]] | None:
@@ -111,4 +131,16 @@ class ExperimentStore:
 
     @staticmethod
     def _read_json(path: Path) -> dict[str, Any]:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _read_optional_parquet(path: Path) -> pd.DataFrame:
+        if not path.exists():
+            return pd.DataFrame()
+        return pd.read_parquet(path)
+
+    @staticmethod
+    def _read_optional_json(path: Path) -> dict[str, Any]:
+        if not path.exists():
+            return {}
         return json.loads(path.read_text(encoding="utf-8"))

--- a/trump_workbench/features.py
+++ b/trump_workbench/features.py
@@ -116,14 +116,18 @@ class FeatureService:
         if mapped.empty:
             mapped["is_active_tracked_account"] = pd.Series(dtype=bool)
             mapped["tracked_discovery_score"] = pd.Series(dtype=float)
+            mapped["tracked_account_status"] = pd.Series(dtype=str)
+            mapped["tracked_account_provenance"] = pd.Series(dtype=str)
             return mapped
 
         if tracked_accounts.empty:
             mapped["is_active_tracked_account"] = False
             mapped["tracked_discovery_score"] = 0.0
+            mapped["tracked_account_status"] = "none"
+            mapped["tracked_account_provenance"] = ""
             return mapped
 
-        intervals: dict[str, list[tuple[pd.Timestamp, pd.Timestamp | None, float]]] = {}
+        intervals: dict[str, list[tuple[pd.Timestamp, pd.Timestamp | None, float, str, str]]] = {}
         for _, row in tracked_accounts.iterrows():
             account_id = str(row.get("account_id", ""))
             if not account_id:
@@ -131,28 +135,54 @@ class FeatureService:
             start = pd.to_datetime(row.get("effective_from"), errors="coerce")
             end = pd.to_datetime(row.get("effective_to"), errors="coerce")
             score = float(row.get("discovery_score", 0.0) or 0.0)
+            status = str(row.get("status", "") or "")
+            provenance = str(row.get("provenance", "") or "")
             if pd.isna(start):
                 continue
-            intervals.setdefault(account_id, []).append((ensure_tz_naive_date(start), ensure_tz_naive_date(end) if pd.notna(end) else None, score))
+            intervals.setdefault(account_id, []).append(
+                (
+                    ensure_tz_naive_date(start),
+                    ensure_tz_naive_date(end) if pd.notna(end) else None,
+                    score,
+                    status,
+                    provenance,
+                ),
+            )
 
         active_flags: list[bool] = []
         active_scores: list[float] = []
+        active_statuses: list[str] = []
+        active_provenance: list[str] = []
         for _, row in mapped.iterrows():
             account_id = str(row["author_account_id"])
             session_date = ensure_tz_naive_date(row["session_date"])
             intervals_for_account = intervals.get(account_id, [])
             score = 0.0
             active = False
-            for start, end, interval_score in intervals_for_account:
+            selected_status = "none"
+            selected_provenance = ""
+            for start, end, interval_score, status, provenance in intervals_for_account:
                 if start <= session_date and (end is None or session_date < end):
-                    active = True
+                    if status == "suppressed":
+                        active = False
+                        score = 0.0
+                        selected_status = status
+                        selected_provenance = provenance
+                        break
+                    active = status in {"active", "pinned"}
                     score = max(score, interval_score)
+                    selected_status = status
+                    selected_provenance = provenance
             active_flags.append(active)
             active_scores.append(score)
+            active_statuses.append(selected_status)
+            active_provenance.append(selected_provenance)
 
         mapped = mapped.copy()
         mapped["is_active_tracked_account"] = active_flags
         mapped["tracked_discovery_score"] = active_scores
+        mapped["tracked_account_status"] = active_statuses
+        mapped["tracked_account_provenance"] = active_provenance
         return mapped
 
     def _build_session_row(
@@ -170,6 +200,10 @@ class FeatureService:
                 "next_session_close": market_row["next_session_close"],
                 "feature_version": feature_version,
                 "llm_enabled": llm_enabled,
+                "feature_source_min_ts": pd.NaT,
+                "feature_source_max_ts": pd.NaT,
+                "next_session_open_ts": pd.Timestamp(f"{pd.Timestamp(market_row['next_session_date']).date()} 09:30", tz=EASTERN) if pd.notna(market_row["next_session_date"]) else pd.NaT,
+                "feature_cutoff_before_next_open": True,
                 "has_posts": False,
                 "post_count": 0,
                 "trump_post_count": 0,
@@ -234,6 +268,10 @@ class FeatureService:
             "next_session_close": market_row["next_session_close"],
             "feature_version": feature_version,
             "llm_enabled": llm_enabled,
+            "feature_source_min_ts": group["post_timestamp"].min(),
+            "feature_source_max_ts": group["post_timestamp"].max(),
+            "next_session_open_ts": pd.Timestamp(f"{pd.Timestamp(market_row['next_session_date']).date()} 09:30", tz=EASTERN) if pd.notna(market_row["next_session_date"]) else pd.NaT,
+            "feature_cutoff_before_next_open": True,
             "has_posts": True,
             "post_count": int(len(group)),
             "trump_post_count": int(group["author_is_trump"].sum()),
@@ -283,6 +321,8 @@ class FeatureService:
             "target_next_session_return": market_row["target_next_session_return"],
             "target_available": market_row["target_available"],
         }
+        if pd.notna(row["next_session_open_ts"]) and pd.notna(row["feature_source_max_ts"]):
+            row["feature_cutoff_before_next_open"] = bool(row["feature_source_max_ts"] < row["next_session_open_ts"])
         return row
 
 

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -10,7 +10,7 @@ import streamlit.components.v1 as components
 
 from .backtesting import BacktestService
 from .config import AppSettings
-from .contracts import ModelRunConfig
+from .contracts import MANUAL_OVERRIDE_COLUMNS, ModelRunConfig
 from .discovery import DiscoveryService
 from .enrichment import LLMEnrichmentService
 from .experiments import ExperimentStore
@@ -106,17 +106,8 @@ def _refresh_datasets(
     store.save_frame("sp500_daily", sp500, metadata={"row_count": int(len(sp500))})
     store.save_frame("spy_daily", spy, metadata={"row_count": int(len(spy))})
 
-    tracked_existing = store.read_frame("tracked_accounts")
     as_of = posts["post_timestamp"].max() if not posts.empty else pd.Timestamp.now(tz=settings.timezone)
-    tracked_accounts, ranking_history = discovery_service.refresh_accounts(posts, tracked_existing, as_of=as_of)
-    store.save_frame("tracked_accounts", tracked_accounts, metadata={"row_count": int(len(tracked_accounts))})
-    if not ranking_history.empty:
-        store.append_frame(
-            "account_rankings",
-            ranking_history,
-            dedupe_on=["author_account_id", "ranked_at"],
-            metadata={"row_count": int(len(ranking_history))},
-        )
+    tracked_accounts, ranking_history = _rebuild_discovery_state(store, discovery_service, posts, as_of)
     return {
         "posts": posts,
         "source_manifest": source_manifest,
@@ -146,6 +137,28 @@ def _ensure_bootstrap(
         )
 
 
+def _rebuild_discovery_state(
+    store: DuckDBStore,
+    discovery_service: DiscoveryService,
+    posts: pd.DataFrame,
+    as_of: pd.Timestamp,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    overrides = store.read_frame("manual_account_overrides")
+    normalized_overrides = discovery_service.normalize_manual_overrides(overrides)
+    if normalized_overrides.empty:
+        normalized_overrides = pd.DataFrame(columns=MANUAL_OVERRIDE_COLUMNS)
+    tracked_accounts, ranking_history = discovery_service.refresh_accounts(
+        posts=posts,
+        existing_accounts=pd.DataFrame(),
+        as_of=as_of,
+        manual_overrides=normalized_overrides,
+    )
+    store.save_frame("manual_account_overrides", normalized_overrides, metadata={"row_count": int(len(normalized_overrides))})
+    store.save_frame("tracked_accounts", tracked_accounts, metadata={"row_count": int(len(tracked_accounts))})
+    store.save_frame("account_rankings", ranking_history, metadata={"row_count": int(len(ranking_history))})
+    return tracked_accounts, ranking_history
+
+
 def _metric_row(metrics: dict[str, Any]) -> None:
     cols = st.columns(6)
     cols[0].metric("Total return", f"{metrics.get('total_return', 0.0):+.2%}")
@@ -173,6 +186,23 @@ def _render_equity_curve(trades: pd.DataFrame, title: str) -> None:
             name="Strategy equity",
         ),
     )
+    fig.update_layout(title=title, xaxis_title="Trade date", yaxis_title="Equity", margin={"l": 20, "r": 20, "t": 60, "b": 20})
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def _render_equity_curve_comparison(curves_by_run: dict[str, pd.DataFrame], title: str) -> None:
+    fig = go.Figure()
+    for run_id, curve in curves_by_run.items():
+        if curve.empty:
+            continue
+        fig.add_trace(
+            go.Scatter(
+                x=curve["next_session_date"],
+                y=curve["equity_curve"],
+                mode="lines",
+                name=run_id,
+            ),
+        )
     fig.update_layout(title=title, xaxis_title="Trade date", yaxis_title="Equity", margin={"l": 20, "r": 20, "t": 60, "b": 20})
     st.plotly_chart(fig, use_container_width=True)
 
@@ -254,14 +284,16 @@ def render_datasets_view(
 
 
 def render_discovery_view(
+    settings: AppSettings,
     store: DuckDBStore,
     discovery_service: DiscoveryService,
 ) -> None:
     st.subheader("Discovery")
-    st.caption("Dynamic discovery ranks X accounts mentioning Trump and auto-includes the top candidates into the tracked universe.")
+    st.caption("Dynamic discovery ranks X accounts mentioning Trump, auto-includes the strongest candidates, and lets you pin or suppress accounts manually.")
     posts = store.read_frame("normalized_posts")
     tracked_accounts = store.read_frame("tracked_accounts")
     ranking_history = store.read_frame("account_rankings")
+    overrides = discovery_service.normalize_manual_overrides(store.read_frame("manual_account_overrides"))
 
     if posts.empty:
         st.info("Refresh datasets first so the workbench has posts to analyze.")
@@ -276,6 +308,7 @@ def render_discovery_view(
         keep = [
             "handle",
             "display_name",
+            "status",
             "discovery_score",
             "mention_count",
             "engagement_mean",
@@ -299,12 +332,74 @@ def render_discovery_view(
             "engagement_mean",
             "active_days",
             "ranked_at",
+            "selected_status",
+            "suppressed_by_override",
+            "pinned_by_override",
         ]
         st.dataframe(
             latest_rankings[keep].sort_values("discovery_score", ascending=False),
             use_container_width=True,
             hide_index=True,
         )
+
+        st.markdown("**Manual overrides**")
+        override_cols = st.columns([3, 2, 2, 2])
+        option_rows = latest_rankings[["author_account_id", "author_handle", "author_display_name"]].drop_duplicates().copy()
+        option_rows["label"] = option_rows.apply(
+            lambda row: f"@{row['author_handle'] or '[unknown]'} | {row['author_display_name'] or row['author_account_id']}",
+            axis=1,
+        )
+        selected_label = override_cols[0].selectbox("Account", options=option_rows["label"].tolist())
+        selected_row = option_rows.loc[option_rows["label"] == selected_label].iloc[0]
+        action = override_cols[1].selectbox("Action", options=["pin", "suppress"])
+        effective_from = override_cols[2].date_input(
+            "Effective from",
+            value=posts["post_timestamp"].max().tz_convert(settings.timezone).date(),
+            min_value=settings.term_start.date(),
+            max_value=posts["post_timestamp"].max().tz_convert(settings.timezone).date(),
+            key="override_effective_from",
+        )
+        note = override_cols[3].text_input("Note", value="", key="override_note")
+        no_end_date = st.checkbox("No end date", value=True)
+        effective_to = None
+        if not no_end_date:
+            effective_to = st.date_input(
+                "Effective to",
+                value=posts["post_timestamp"].max().tz_convert(settings.timezone).date(),
+                min_value=effective_from,
+                key="override_effective_to",
+            )
+        if st.button("Save override", use_container_width=True):
+            updated = discovery_service.add_manual_override(
+                overrides=overrides,
+                account_id=str(selected_row["author_account_id"]),
+                handle=str(selected_row["author_handle"]),
+                display_name=str(selected_row["author_display_name"]),
+                action=action,
+                effective_from=pd.Timestamp(effective_from),
+                effective_to=pd.Timestamp(effective_to) if effective_to is not None else None,
+                note=note,
+            )
+            store.save_frame("manual_account_overrides", updated, metadata={"row_count": int(len(updated))})
+            _rebuild_discovery_state(store, discovery_service, posts, posts["post_timestamp"].max())
+            st.success(f"Saved {action} override for @{selected_row['author_handle']}.")
+            st.rerun()
+
+    if not overrides.empty:
+        st.markdown("**Override history**")
+        st.dataframe(overrides, use_container_width=True, hide_index=True)
+        remove_options = overrides.apply(
+            lambda row: f"{row['override_id']} | {row['action']} | @{row['handle'] or row['account_id']} | from {pd.Timestamp(row['effective_from']).date()}",
+            axis=1,
+        ).tolist()
+        remove_choice = st.selectbox("Remove override", options=remove_options)
+        remove_id = remove_choice.split(" | ", 1)[0]
+        if st.button("Delete selected override", use_container_width=True):
+            updated = discovery_service.remove_manual_override(overrides, remove_id)
+            store.save_frame("manual_account_overrides", updated, metadata={"row_count": int(len(updated))})
+            _rebuild_discovery_state(store, discovery_service, posts, posts["post_timestamp"].max())
+            st.success("Removed override.")
+            st.rerun()
 
     if not ranking_history.empty:
         chart_data = latest_rankings.head(15).sort_values("discovery_score")
@@ -456,7 +551,7 @@ def render_models_view(
     experiment_store: ExperimentStore,
 ) -> None:
     st.subheader("Models & Backtests")
-    st.caption("Build the session dataset, train a next-session SPY expected-return model, and evaluate it with walk-forward backtests.")
+    st.caption("Build the session dataset, train a next-session SPY expected-return model, compare saved runs, and inspect benchmark plus leakage diagnostics.")
     posts = store.read_frame("normalized_posts")
     spy = store.read_frame("spy_daily")
     tracked_accounts = store.read_frame("tracked_accounts")
@@ -510,6 +605,10 @@ def render_models_view(
                 windows=artifacts["windows"],
                 importance=artifacts["importance"],
                 model_artifact=artifacts["model_artifact"],
+                benchmarks=artifacts["benchmarks"],
+                diagnostics=artifacts["diagnostics"],
+                benchmark_curves=artifacts["benchmark_curves"],
+                leakage_audit=artifacts["leakage_audit"],
             )
         st.success(f"Saved run `{run.run_id}`.")
 
@@ -524,6 +623,20 @@ def render_models_view(
         st.info("No experiment runs have been saved yet.")
         return
 
+    leaderboard = runs.copy()
+    leaderboard["total_return"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("total_return", 0.0))
+    leaderboard["sharpe"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("sharpe", 0.0))
+    leaderboard["sortino"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("sortino", 0.0))
+    leaderboard["max_drawdown"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("max_drawdown", 0.0))
+    leaderboard["robust_score"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("robust_score", 0.0))
+    keep = ["run_id", "run_name", "created_at", "total_return", "sharpe", "sortino", "max_drawdown", "robust_score"]
+    st.markdown("**Run leaderboard**")
+    st.dataframe(
+        leaderboard[keep].sort_values("robust_score", ascending=False),
+        use_container_width=True,
+        hide_index=True,
+    )
+
     selected_run_id = st.selectbox("Saved runs", options=runs["run_id"].tolist())
     loaded = experiment_store.load_run(selected_run_id)
     if loaded is None:
@@ -533,10 +646,80 @@ def render_models_view(
     _metric_row(loaded["metrics"])
     _render_equity_curve(loaded["trades"], title="Walk-forward out-of-sample equity curve")
 
+    compare_ids = st.multiselect(
+        "Compare runs",
+        options=runs["run_id"].tolist(),
+        default=[selected_run_id],
+    )
+    if len(compare_ids) > 1:
+        comparison_rows: list[dict[str, Any]] = []
+        curves: dict[str, pd.DataFrame] = {}
+        for run_id in compare_ids:
+            run_bundle = experiment_store.load_run(run_id)
+            if run_bundle is None:
+                continue
+            metrics = run_bundle["metrics"]
+            comparison_rows.append(
+                {
+                    "run_id": run_id,
+                    "total_return": metrics.get("total_return", 0.0),
+                    "sharpe": metrics.get("sharpe", 0.0),
+                    "sortino": metrics.get("sortino", 0.0),
+                    "max_drawdown": metrics.get("max_drawdown", 0.0),
+                    "robust_score": metrics.get("robust_score", 0.0),
+                },
+            )
+            curves[run_id] = run_bundle["trades"][["next_session_date", "equity_curve"]].copy()
+        if comparison_rows:
+            st.markdown("**Run comparison**")
+            st.dataframe(pd.DataFrame(comparison_rows).sort_values("robust_score", ascending=False), use_container_width=True, hide_index=True)
+            _render_equity_curve_comparison(curves, title="Selected run equity curves")
+
+    if not loaded["benchmarks"].empty:
+        st.markdown("**Benchmark suite**")
+        st.dataframe(loaded["benchmarks"], use_container_width=True, hide_index=True)
+    if not loaded["benchmark_curves"].empty:
+        curve_fig = go.Figure()
+        curves = loaded["benchmark_curves"].copy()
+        for column in curves.columns:
+            if column == "next_session_date":
+                continue
+            curve_fig.add_trace(go.Scatter(x=curves["next_session_date"], y=curves[column], mode="lines", name=column))
+        curve_fig.update_layout(title="Strategy vs. benchmark equity curves", xaxis_title="Trade date", yaxis_title="Equity")
+        st.plotly_chart(curve_fig, use_container_width=True)
+
+    if loaded["leakage_audit"]:
+        st.markdown("**Leakage audit**")
+        st.json(loaded["leakage_audit"])
+
     st.markdown("**Window summary**")
     st.dataframe(loaded["windows"], use_container_width=True, hide_index=True)
     st.markdown("**Feature importance**")
     st.dataframe(loaded["importance"].head(25), use_container_width=True, hide_index=True)
+    if not loaded["diagnostics"].empty:
+        diagnostics = loaded["diagnostics"].copy()
+        diag_fig = go.Figure()
+        diag_fig.add_trace(
+            go.Scatter(
+                x=diagnostics["expected_return_score"],
+                y=diagnostics["actual_next_session_return"],
+                mode="markers",
+                marker={"size": 8, "opacity": 0.65},
+                name="Predictions",
+            ),
+        )
+        diag_fig.update_layout(
+            title="Prediction diagnostics: expected vs actual next-session return",
+            xaxis_title="Expected return score",
+            yaxis_title="Actual next-session return",
+        )
+        st.plotly_chart(diag_fig, use_container_width=True)
+        st.markdown("**Largest prediction misses**")
+        st.dataframe(
+            diagnostics.sort_values("absolute_error", ascending=False).head(20),
+            use_container_width=True,
+            hide_index=True,
+        )
     with st.expander("Trades", expanded=False):
         st.dataframe(loaded["trades"], use_container_width=True, hide_index=True)
 
@@ -697,7 +880,7 @@ def main() -> None:
     elif page == "Datasets":
         render_datasets_view(settings, store, ingestion_service, market_service, discovery_service)
     elif page == "Discovery":
-        render_discovery_view(store, discovery_service)
+        render_discovery_view(settings, store, discovery_service)
     elif page == "Models & Backtests":
         render_models_view(settings, store, feature_service, backtest_service, experiment_store)
     else:


### PR DESCRIPTION
## What changed
- rebuild the discovery flow around point-in-time rankings so tracked accounts only become active when they would have been known historically
- add manual `pin` and `suppress` account overrides plus a Discovery UI for managing them
- add benchmark suites, leakage audit output, and prediction diagnostics to the backtest and experiment views
- persist benchmark, diagnostics, benchmark curve, and leakage-audit artifacts with each saved run

## Why
This makes the workbench much more trustworthy before adding more model complexity. We can now inspect lookahead risk, compare against simple baselines, and control the discovered universe directly from the app.

## Impact
- experiments now save richer artifacts for comparison and review
- the Discovery page supports manual universe control with historical effective dates
- the Models & Backtests page shows benchmark tables, equity-curve comparisons, leakage audit details, and miss diagnostics

## Validation
- `./.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/streamlit run app.py --server.headless true --server.port 8502`
