### PR TITLE
[codex] Add historical replay mode

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -153,6 +153,23 @@ class PipelineTests(unittest.TestCase):
         self.assertFalse(loaded["benchmarks"].empty)
         self.assertTrue(bool(loaded["leakage_audit"].get("overall_pass", False)))
 
+        replay_session = pd.Timestamp(first_dataset.loc[first_dataset["target_available"]].iloc[95]["signal_session_date"])
+        replay_bundle = self.backtests.build_historical_replay(
+            config,
+            first_dataset,
+            replay_session_date=replay_session,
+            deployment_params=run.selected_params,
+        )
+        replay_prediction = replay_bundle["prediction"].iloc[0]
+        self.assertEqual(pd.Timestamp(replay_prediction["signal_session_date"]), replay_session)
+        self.assertLess(pd.Timestamp(replay_bundle["history_end"]), replay_session)
+        self.assertEqual(
+            replay_bundle["training_rows_used"],
+            int((first_dataset["signal_session_date"] < replay_session).loc[first_dataset["target_available"]].sum()),
+        )
+        self.assertFalse(replay_bundle["feature_contributions"].empty)
+        self.assertFalse(bool(replay_prediction["future_training_leakage"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -8,10 +8,14 @@ from trump_workbench.contracts import RANKING_HISTORY_COLUMNS
 from trump_workbench.contracts import LinearModelArtifact
 from trump_workbench.ui import (
     _build_benchmark_delta_table,
+    _build_replay_comparison_frame,
     _build_feature_diff_table,
     _build_metric_comparison_table,
     _build_setting_diff_table,
+    _bundle_to_run_config,
+    _eligible_replay_sessions,
     _latest_ranking_snapshot,
+    _replay_option_label,
     _summarize_run_changes,
 )
 
@@ -187,6 +191,54 @@ class UiHelperTests(unittest.TestCase):
         self.assertEqual(len(notes), 1)
         self.assertIn("LLM on vs off", notes[0])
         self.assertIn("threshold 0.001 -> 0.0025", notes[0])
+
+    def test_replay_helpers_build_session_list_config_and_summary(self) -> None:
+        feature_rows = pd.DataFrame(
+            {
+                "signal_session_date": pd.bdate_range("2025-02-03", periods=30),
+                "target_available": [True] * 29 + [False],
+                "post_count": [idx % 5 for idx in range(30)],
+            },
+        )
+        eligible = _eligible_replay_sessions(feature_rows, min_history_rows=20)
+        self.assertEqual(pd.Timestamp(eligible.iloc[0]["signal_session_date"]), pd.Timestamp("2025-03-03"))
+        label = _replay_option_label(eligible.iloc[0])
+        self.assertIn("prior train rows 20", label)
+
+        bundle = self._run_bundle(
+            "replay-run",
+            llm_enabled=True,
+            threshold=0.0025,
+            min_post_count=1,
+            total_return=0.12,
+            robust_score=1.8,
+            features=["sentiment_avg", "semantic_market_relevance_avg"],
+        )
+        config = _bundle_to_run_config(bundle)
+        self.assertTrue(config.llm_enabled)
+        self.assertEqual(config.run_name, "replay-run")
+        self.assertEqual(config.threshold_grid, (0.0, 0.001, 0.0025))
+
+        replay_row = pd.Series(
+            {
+                "expected_return_score": 0.012,
+                "prediction_confidence": 0.61,
+                "deployment_threshold": 0.0025,
+                "deployment_min_post_count": 1,
+                "training_rows_used": 55,
+                "target_next_session_return": 0.009,
+            },
+        )
+        full_history_row = pd.Series(
+            {
+                "expected_return_score": 0.02,
+                "prediction_confidence": 0.7,
+            },
+        )
+        summary = _build_replay_comparison_frame(replay_row, full_history_row)
+        self.assertIn("Replay vs full-history drift", summary["metric"].tolist())
+        drift_value = float(summary.loc[summary["metric"] == "Replay vs full-history drift", "value"].iloc[0])
+        self.assertAlmostEqual(drift_value, -0.008)
 
 
 if __name__ == "__main__":

--- a/trump_workbench/backtesting.py
+++ b/trump_workbench/backtesting.py
@@ -218,6 +218,71 @@ class BacktestService:
     def __init__(self, model_service: ModelService) -> None:
         self.model_service = model_service
 
+    def build_historical_replay(
+        self,
+        run_config: ModelRunConfig,
+        feature_rows: pd.DataFrame,
+        replay_session_date: pd.Timestamp,
+        deployment_params: dict[str, Any],
+    ) -> dict[str, Any]:
+        replay_date = pd.Timestamp(replay_session_date).normalize()
+        usable = feature_rows.copy()
+        if run_config.start_date:
+            usable = usable.loc[usable["signal_session_date"] >= pd.Timestamp(run_config.start_date)]
+        if run_config.end_date:
+            usable = usable.loc[usable["signal_session_date"] <= pd.Timestamp(run_config.end_date)]
+        usable = usable.sort_values("signal_session_date").reset_index(drop=True)
+        signal_dates = pd.to_datetime(usable["signal_session_date"], errors="coerce").dt.normalize()
+        replay_rows = usable.loc[signal_dates == replay_date].copy()
+        if replay_rows.empty:
+            raise RuntimeError("The selected replay session is not available in the session feature dataset.")
+
+        history = usable.loc[(signal_dates < replay_date) & usable["target_available"].fillna(False)].copy()
+        if len(history) < 20:
+            raise RuntimeError("Historical replay needs at least 20 earlier target-available sessions to train a model.")
+
+        account_weight = float(deployment_params.get("account_weight", 1.0) or 1.0)
+        threshold = float(deployment_params.get("threshold", 0.0) or 0.0)
+        min_post_count = int(deployment_params.get("min_post_count", 1) or 1)
+
+        weighted_history = self._apply_account_weight(history, account_weight)
+        weighted_replay = self._apply_account_weight(replay_rows, account_weight)
+        artifact, importance = self.model_service.train(
+            run_config=run_config,
+            feature_rows=weighted_history,
+            model_version=f"{run_config.run_name}-replay-{replay_date:%Y%m%d}",
+        )
+        replay_prediction = self.model_service.predict(artifact, weighted_replay).reset_index(drop=True)
+        replay_prediction["deployment_threshold"] = threshold
+        replay_prediction["deployment_min_post_count"] = min_post_count
+        replay_prediction["deployment_account_weight"] = account_weight
+        replay_prediction["historical_replay"] = True
+        replay_prediction["training_rows_used"] = int(len(weighted_history))
+        replay_prediction["history_start"] = history["signal_session_date"].min()
+        replay_prediction["history_end"] = history["signal_session_date"].max()
+        replay_prediction["suggested_stance"] = np.where(
+            (replay_prediction["expected_return_score"] > threshold) & (replay_prediction["post_count"] >= min_post_count),
+            "LONG SPY NEXT SESSION",
+            "FLAT",
+        )
+        replay_prediction["future_training_leakage"] = False
+        feature_contributions = self.model_service.explain_predictions(artifact, replay_prediction)
+        return {
+            "artifact": artifact,
+            "importance": importance,
+            "prediction": replay_prediction,
+            "feature_contributions": feature_contributions,
+            "training_rows_used": int(len(weighted_history)),
+            "history_start": history["signal_session_date"].min(),
+            "history_end": history["signal_session_date"].max(),
+            "replay_session_date": replay_date,
+            "deployment_params": {
+                "threshold": threshold,
+                "min_post_count": min_post_count,
+                "account_weight": account_weight,
+            },
+        }
+
     def run_walk_forward(
         self,
         run_config: ModelRunConfig,

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -958,6 +958,69 @@ def _summarize_run_changes(base_run_id: str, run_bundles: dict[str, dict[str, An
     return notes
 
 
+def _bundle_to_run_config(run_bundle: dict[str, Any]) -> ModelRunConfig:
+    config = run_bundle.get("config", {}) or {}
+    run_meta = run_bundle.get("run", {}) or {}
+    return ModelRunConfig(
+        run_name=str(config.get("run_name") or run_meta.get("run_name") or "historical-replay"),
+        feature_version=str(config.get("feature_version", "v1")),
+        llm_enabled=bool(config.get("llm_enabled", False)),
+        train_window=int(config.get("train_window", 90) or 90),
+        validation_window=int(config.get("validation_window", 30) or 30),
+        test_window=int(config.get("test_window", 30) or 30),
+        step_size=int(config.get("step_size", 30) or 30),
+        threshold_grid=tuple(float(value) for value in config.get("threshold_grid", [0.0, 0.001, 0.0025, 0.005])),
+        minimum_signal_grid=tuple(int(value) for value in config.get("minimum_signal_grid", [1, 2, 3])),
+        account_weight_grid=tuple(float(value) for value in config.get("account_weight_grid", [0.5, 1.0, 1.5])),
+        ridge_alpha=float(config.get("ridge_alpha", 1.0) or 1.0),
+        transaction_cost_bps=float(config.get("transaction_cost_bps", 2.0) or 2.0),
+        start_date=config.get("start_date"),
+        end_date=config.get("end_date"),
+        notes=str(config.get("notes", "")),
+    )
+
+
+def _eligible_replay_sessions(feature_rows: pd.DataFrame, min_history_rows: int = 20) -> pd.DataFrame:
+    if feature_rows.empty:
+        return pd.DataFrame()
+    eligible = feature_rows.sort_values("signal_session_date").reset_index(drop=True).copy()
+    eligible["history_rows_available"] = eligible["target_available"].fillna(False).astype(int).cumsum().shift(fill_value=0)
+    eligible = eligible.loc[eligible["history_rows_available"] >= min_history_rows].copy()
+    return eligible.reset_index(drop=True)
+
+
+def _replay_option_label(row: pd.Series) -> str:
+    session_date = pd.Timestamp(row["signal_session_date"])
+    return (
+        f"{session_date:%Y-%m-%d} | posts {int(row.get('post_count', 0))} | "
+        f"prior train rows {int(row.get('history_rows_available', 0))}"
+    )
+
+
+def _build_replay_comparison_frame(replay_row: pd.Series, full_history_row: pd.Series | None) -> pd.DataFrame:
+    rows = [
+        {"metric": "Replay score", "value": float(replay_row.get("expected_return_score", 0.0))},
+        {"metric": "Replay confidence", "value": float(replay_row.get("prediction_confidence", 0.0))},
+        {"metric": "Replay threshold", "value": float(replay_row.get("deployment_threshold", 0.0))},
+        {"metric": "Replay min post count", "value": int(replay_row.get("deployment_min_post_count", 1))},
+        {"metric": "Training rows used", "value": int(replay_row.get("training_rows_used", 0))},
+    ]
+    actual = replay_row.get("target_next_session_return")
+    if pd.notna(actual):
+        rows.append({"metric": "Actual next-session return", "value": float(actual)})
+    if full_history_row is not None:
+        full_score = float(full_history_row.get("expected_return_score", 0.0) or 0.0)
+        replay_score = float(replay_row.get("expected_return_score", 0.0) or 0.0)
+        rows.extend(
+            [
+                {"metric": "Full-history score", "value": full_score},
+                {"metric": "Replay vs full-history drift", "value": replay_score - full_score},
+                {"metric": "Full-history confidence", "value": float(full_history_row.get("prediction_confidence", 0.0) or 0.0)},
+            ],
+        )
+    return pd.DataFrame(rows)
+
+
 def render_models_view(
     settings: AppSettings,
     store: DuckDBStore,
@@ -1344,6 +1407,131 @@ def render_live_monitor(
     )
 
 
+def render_historical_replay_view(
+    settings: AppSettings,
+    store: DuckDBStore,
+    feature_service: FeatureService,
+    model_service: ModelService,
+    backtest_service: BacktestService,
+    experiment_store: ExperimentStore,
+) -> None:
+    st.subheader("Historical Replay")
+    st.caption(
+        "Rebuild a signal as of a historical session using only earlier rows for training, then compare it to the saved full-history view.",
+    )
+    runs = experiment_store.list_runs()
+    if runs.empty:
+        st.info("Save at least one experiment run first so Historical Replay has a template configuration to follow.")
+        return
+
+    posts = store.read_frame("normalized_posts")
+    spy = store.read_frame("spy_daily")
+    tracked_accounts = store.read_frame("tracked_accounts")
+    if posts.empty or spy.empty:
+        st.info("Refresh datasets first so replay can rebuild historical features.")
+        return
+
+    selected_run_id = st.selectbox("Replay template run", options=runs["run_id"].tolist(), key="replay-run-id")
+    loaded = experiment_store.load_run(selected_run_id)
+    if loaded is None:
+        st.warning("The selected replay template could not be loaded.")
+        return
+
+    run_config = _bundle_to_run_config(loaded)
+    prepared_posts = feature_service.prepare_session_posts(
+        posts=posts,
+        market_calendar=spy,
+        tracked_accounts=tracked_accounts,
+        llm_enabled=run_config.llm_enabled,
+    )
+    feature_rows = feature_service.build_session_dataset(
+        posts=posts,
+        spy_market=spy,
+        tracked_accounts=tracked_accounts,
+        feature_version=run_config.feature_version,
+        llm_enabled=run_config.llm_enabled,
+        prepared_posts=prepared_posts,
+    )
+    if run_config.start_date:
+        feature_rows = feature_rows.loc[feature_rows["signal_session_date"] >= pd.Timestamp(run_config.start_date)].copy()
+    if run_config.end_date:
+        feature_rows = feature_rows.loc[feature_rows["signal_session_date"] <= pd.Timestamp(run_config.end_date)].copy()
+
+    eligible_sessions = _eligible_replay_sessions(feature_rows)
+    if eligible_sessions.empty:
+        st.info("No replay sessions are eligible yet. Historical replay needs at least 20 earlier target-available sessions.")
+        return
+
+    replay_choices = eligible_sessions.sort_values("signal_session_date", ascending=False).reset_index(drop=True)
+    replay_labels = replay_choices.apply(_replay_option_label, axis=1).tolist()
+    selected_label = st.selectbox("Historical signal session", options=replay_labels, index=0, key="replay-session-label")
+    replay_row = replay_choices.iloc[replay_labels.index(selected_label)]
+
+    with st.spinner("Rebuilding the historical signal without future-data leakage..."):
+        replay = backtest_service.build_historical_replay(
+            run_config=run_config,
+            feature_rows=feature_rows,
+            replay_session_date=pd.Timestamp(replay_row["signal_session_date"]),
+            deployment_params=loaded["selected_params"],
+        )
+
+    replay_prediction = replay["prediction"].iloc[0]
+    replay_feature_contributions = replay["feature_contributions"]
+    session_post_attribution = build_post_attribution(
+        prepared_posts.loc[
+            pd.to_datetime(prepared_posts["session_date"], errors="coerce").dt.normalize()
+            == pd.Timestamp(replay_prediction["signal_session_date"]).normalize()
+        ].copy(),
+    )
+    session_account_attribution = build_account_attribution(session_post_attribution)
+
+    full_history_match = _filter_for_session(loaded["predictions"], _normalize_session_date(replay_prediction["signal_session_date"]))
+    full_history_row = full_history_match.iloc[0] if not full_history_match.empty else None
+
+    metric_cols = st.columns(4)
+    metric_cols[0].metric("Replay session", f"{pd.Timestamp(replay_prediction['signal_session_date']):%Y-%m-%d}")
+    metric_cols[1].metric("Replay score", f"{float(replay_prediction['expected_return_score']):+.3%}")
+    metric_cols[2].metric("Replay confidence", f"{float(replay_prediction['prediction_confidence']):.2f}")
+    metric_cols[3].metric("Suggested stance", str(replay_prediction["suggested_stance"]))
+
+    if full_history_row is not None:
+        delta = float(replay_prediction["expected_return_score"] - full_history_row["expected_return_score"])
+        st.info(
+            "The full-history comparison below is shown for drift analysis only. "
+            "It uses a model fit with future data that would not have been available on the replay date.",
+        )
+        drift_cols = st.columns(3)
+        drift_cols[0].metric("Full-history score", f"{float(full_history_row['expected_return_score']):+.3%}")
+        drift_cols[1].metric("Replay vs full-history", f"{delta:+.3%}")
+        drift_cols[2].metric("Actual next-session return", f"{float(replay_prediction['target_next_session_return']):+.3%}" if pd.notna(replay_prediction["target_next_session_return"]) else "n/a")
+
+    st.json(
+        {
+            "template_run_id": selected_run_id,
+            "history_start": str(pd.Timestamp(replay["history_start"]).date()),
+            "history_end": str(pd.Timestamp(replay["history_end"]).date()),
+            "training_rows_used": replay["training_rows_used"],
+            "deployment_params": replay["deployment_params"],
+            "future_training_leakage": False,
+        },
+    )
+
+    comparison_frame = _build_replay_comparison_frame(replay_prediction, full_history_row)
+    st.markdown("**Replay summary**")
+    st.dataframe(comparison_frame, use_container_width=True, hide_index=True)
+
+    st.markdown("**Replay feature importance**")
+    st.dataframe(replay["importance"].head(25), use_container_width=True, hide_index=True)
+
+    _render_signal_explanation_panel(
+        prediction_row=replay_prediction,
+        feature_contributions=replay_feature_contributions,
+        post_attribution=session_post_attribution,
+        account_attribution=session_account_attribution,
+        heading="Why This Historical Signal?",
+    )
+
+
 def main() -> None:
     settings = AppSettings()
     st.set_page_config(page_title=settings.title, layout="wide")
@@ -1376,7 +1564,7 @@ def main() -> None:
 
     page = st.sidebar.radio(
         "Workbench",
-        options=["Research View", "Datasets", "Discovery", "Models & Backtests", "Live Monitor"],
+        options=["Research View", "Datasets", "Discovery", "Models & Backtests", "Historical Replay", "Live Monitor"],
     )
     st.sidebar.markdown("---")
     st.sidebar.caption("Storage: DuckDB + Parquet")
@@ -1390,6 +1578,8 @@ def main() -> None:
         render_discovery_view(settings, store, discovery_service)
     elif page == "Models & Backtests":
         render_models_view(settings, store, feature_service, model_service, backtest_service, experiment_store)
+    elif page == "Historical Replay":
+        render_historical_replay_view(settings, store, feature_service, model_service, backtest_service, experiment_store)
     else:
         render_live_monitor(
             settings,


### PR DESCRIPTION
## Summary
- add a Historical Replay workbench page that rebuilds a signal using only data available before the chosen session
- compare the replayed score against the saved full-history score for drift analysis
- add tests for replay training, replay helpers, and the end-to-end pipeline

## Why
Historical replay is the next trust-building feature after explainability and run comparison. It lets us answer: what would the system have known on that date, without future-data leakage?

Closes #2.

## Validation
- `./.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python -m coverage run -m unittest discover -s tests`
- `./.venv/bin/python -m coverage report -m`
- `./.venv/bin/streamlit run app.py --server.headless true --server.port 8503`
