### PR TITLE
[codex] Add watchlist asset datasets

### DIFF
--- a/tests/test_config_contracts.py
+++ b/tests/test_config_contracts.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from trump_workbench.config import APP_TITLE, AppSettings, CURRENT_TERM_START, EASTERN
+from trump_workbench.config import APP_TITLE, AppSettings, CURRENT_TERM_START, DEFAULT_ETF_SYMBOLS, EASTERN
 from trump_workbench.contracts import (
     BacktestRun,
     LinearModelArtifact,
@@ -36,6 +36,7 @@ class ConfigAndContractsTests(unittest.TestCase):
             self.assertEqual(settings.local_mentions_path, settings.base_dir / "data" / "influential_x_mentions.csv")
             self.assertEqual(settings.x_template_path, settings.base_dir / "templates" / "x_posts_template.csv")
             self.assertEqual(settings.mention_template_path, settings.base_dir / "templates" / "x_mentions_template.csv")
+            self.assertEqual(DEFAULT_ETF_SYMBOLS, ("SPY", "QQQ", "XLK", "XLF", "XLE", "SMH"))
 
     def test_contracts_round_trip_to_dict_helpers(self) -> None:
         post = NormalizedPost(

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -7,7 +7,14 @@ from unittest import mock
 
 import pandas as pd
 
-from trump_workbench.market import MarketDataService
+from trump_workbench.market import (
+    ASSET_DAILY_COLUMNS,
+    ASSET_INTRADAY_COLUMNS,
+    build_asset_universe,
+    build_watchlist_frame,
+    normalize_symbols,
+    MarketDataService,
+)
 
 
 class _FakeResponse:
@@ -89,12 +96,64 @@ class MarketDataTests(unittest.TestCase):
             result = self.service.load_spy_daily("2025-02-01", "2025-02-05")
 
         self.assertEqual(result.iloc[0]["close"], 100.5)
+        with mock.patch.dict(sys.modules, {"yfinance": yfinance}):
+            generic = self.service.load_asset_daily("QQQ", "2025-02-01", "2025-02-05")
+        self.assertEqual(generic.iloc[0]["symbol"], "QQQ")
+        self.assertEqual(generic.iloc[0]["close"], 100.5)
 
         failing_yfinance = types.ModuleType("yfinance")
         failing_yfinance.download = mock.Mock(side_effect=RuntimeError("spy failed"))
         with mock.patch.dict(sys.modules, {"yfinance": failing_yfinance}):
             with self.assertRaises(RuntimeError):
                 self.service.load_spy_daily("2025-02-01", "2025-02-05")
+
+    def test_asset_universe_and_batch_market_loaders(self) -> None:
+        self.assertEqual(normalize_symbols([" spy ", "QQQ", "spy", "", "MSFT"]), ["SPY", "QQQ", "MSFT"])
+        watchlist = build_watchlist_frame(["msft", "nvda", "SPY"])
+        self.assertEqual(watchlist["symbol"].tolist(), ["MSFT", "NVDA"])
+        universe = build_asset_universe(["msft", "nvda"])
+        self.assertIn("SPY", universe["symbol"].tolist())
+        self.assertIn("MSFT", universe["symbol"].tolist())
+
+        def fake_download(symbol: str, *args, **kwargs) -> pd.DataFrame:
+            if kwargs.get("interval"):
+                frame = pd.DataFrame(
+                    {
+                        "Open": [100.0, 101.0],
+                        "High": [101.0, 102.0],
+                        "Low": [99.5, 100.5],
+                        "Close": [100.5, 101.5],
+                        "Volume": [1000, 1100],
+                    },
+                    index=pd.to_datetime(["2025-02-03 09:30:00", "2025-02-03 09:35:00"]),
+                )
+                frame.index.name = "Datetime"
+                return frame
+            frame = pd.DataFrame(
+                {
+                    "Open": [100.0, 101.0],
+                    "High": [101.0, 102.0],
+                    "Low": [99.0, 100.0],
+                    "Close": [100.5, 101.5],
+                    "Volume": [1_000_000, 1_200_000],
+                },
+                index=pd.to_datetime(["2025-02-03", "2025-02-04"]),
+            )
+            frame.index.name = "Date"
+            return frame
+
+        yfinance = types.ModuleType("yfinance")
+        yfinance.download = mock.Mock(side_effect=fake_download)
+        with mock.patch.dict(sys.modules, {"yfinance": yfinance}):
+            daily, daily_manifest = self.service.load_assets_daily(["SPY", "MSFT"], "2025-02-01", "2025-02-05")
+            intraday, intraday_manifest = self.service.load_assets_intraday(["SPY", "MSFT"], interval="5m", lookback_days=5)
+
+        self.assertListEqual(list(daily.columns), ASSET_DAILY_COLUMNS)
+        self.assertListEqual(list(intraday.columns), ASSET_INTRADAY_COLUMNS)
+        self.assertEqual(sorted(daily["symbol"].unique().tolist()), ["MSFT", "SPY"])
+        self.assertEqual(sorted(intraday["symbol"].unique().tolist()), ["MSFT", "SPY"])
+        self.assertTrue((daily_manifest["status"] == "ok").all())
+        self.assertTrue((intraday_manifest["status"] == "ok").all())
 
     def test_load_spy_intraday_month_handles_csv_and_error_payloads(self) -> None:
         csv_text = (

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
 
 import pandas as pd
 
+from trump_workbench.config import AppSettings
 from trump_workbench.contracts import RANKING_HISTORY_COLUMNS
 from trump_workbench.contracts import LinearModelArtifact
+from trump_workbench.storage import DuckDBStore
 from trump_workbench.ui import (
     _build_benchmark_delta_table,
     _build_replay_comparison_frame,
@@ -16,11 +20,21 @@ from trump_workbench.ui import (
     _eligible_replay_sessions,
     _latest_ranking_snapshot,
     _replay_option_label,
+    _save_watchlist,
     _summarize_run_changes,
+    _watchlist_symbols,
+    _watchlist_text_value,
 )
 
 
 class UiHelperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = DuckDBStore(AppSettings(base_dir=Path(self.temp_dir.name)))
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
     @staticmethod
     def _run_bundle(
         run_id: str,
@@ -148,6 +162,15 @@ class UiHelperTests(unittest.TestCase):
         self.assertEqual(len(snapshot), 2)
         self.assertEqual(snapshot.iloc[0]["author_account_id"], "acct-a")
         self.assertEqual(snapshot.iloc[0]["discovery_score"], 11.0)
+
+    def test_watchlist_helpers_save_symbols_and_build_text(self) -> None:
+        watchlist, asset_universe = _save_watchlist(self.store, [" msft ", "spy", "nvda", "NVDA"])
+
+        self.assertEqual(watchlist["symbol"].tolist(), ["MSFT", "NVDA"])
+        self.assertIn("SPY", asset_universe["symbol"].tolist())
+        self.assertIn("QQQ", asset_universe["symbol"].tolist())
+        self.assertEqual(_watchlist_symbols(self.store), ["MSFT", "NVDA"])
+        self.assertEqual(_watchlist_text_value(self.store), "MSFT, NVDA")
 
     def test_run_comparison_helpers_build_diffs_and_summary(self) -> None:
         bundles = {

--- a/trump_workbench/config.py
+++ b/trump_workbench/config.py
@@ -8,6 +8,7 @@ import pandas as pd
 APP_TITLE = "Trump Social Trading Research Workbench"
 EASTERN = "America/New_York"
 CURRENT_TERM_START = pd.Timestamp("2025-01-20")
+DEFAULT_ETF_SYMBOLS = ("SPY", "QQQ", "XLK", "XLF", "XLE", "SMH")
 
 
 @dataclass

--- a/trump_workbench/market.py
+++ b/trump_workbench/market.py
@@ -7,12 +7,90 @@ from typing import Any
 import pandas as pd
 import requests
 
-from .config import EASTERN
+from .config import DEFAULT_ETF_SYMBOLS, EASTERN
 
 ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
 HTTP_HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; TrumpTradingWorkbench/2.0; +https://example.invalid)",
 }
+WATCHLIST_COLUMNS = ["symbol", "display_name", "asset_type", "source"]
+ASSET_UNIVERSE_COLUMNS = ["symbol", "display_name", "asset_type", "source", "is_default", "is_watchlist"]
+ASSET_DAILY_COLUMNS = ["symbol", "trade_date", "open", "high", "low", "close", "volume"]
+ASSET_INTRADAY_COLUMNS = ["symbol", "timestamp", "open", "high", "low", "close", "volume", "interval"]
+MARKET_MANIFEST_COLUMNS = ["symbol", "dataset_kind", "row_count", "status", "start_at", "end_at", "detail"]
+
+
+def normalize_symbols(values: list[str] | tuple[str, ...]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        symbol = str(value or "").strip().upper()
+        if not symbol or symbol in seen:
+            continue
+        seen.add(symbol)
+        normalized.append(symbol)
+    return normalized
+
+
+def build_watchlist_frame(symbols: list[str] | tuple[str, ...]) -> pd.DataFrame:
+    rows = [
+        {
+            "symbol": symbol,
+            "display_name": symbol,
+            "asset_type": "equity",
+            "source": "watchlist",
+        }
+        for symbol in normalize_symbols(symbols)
+        if symbol not in DEFAULT_ETF_SYMBOLS
+    ]
+    return pd.DataFrame(rows, columns=WATCHLIST_COLUMNS)
+
+
+def build_asset_universe(watchlist_symbols: list[str] | tuple[str, ...]) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for symbol in DEFAULT_ETF_SYMBOLS:
+        rows.append(
+            {
+                "symbol": symbol,
+                "display_name": symbol,
+                "asset_type": "etf",
+                "source": "core_etf",
+                "is_default": True,
+                "is_watchlist": False,
+            },
+        )
+    for symbol in normalize_symbols(watchlist_symbols):
+        if symbol in DEFAULT_ETF_SYMBOLS:
+            continue
+        rows.append(
+            {
+                "symbol": symbol,
+                "display_name": symbol,
+                "asset_type": "equity",
+                "source": "watchlist",
+                "is_default": False,
+                "is_watchlist": True,
+            },
+        )
+    return pd.DataFrame(rows, columns=ASSET_UNIVERSE_COLUMNS)
+
+
+def _standardize_ohlcv_frame(df: pd.DataFrame, symbol: str) -> pd.DataFrame:
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+    df = df.reset_index().rename(columns={"Date": "trade_date"})
+    df.columns = [str(column).lower() for column in df.columns]
+    if "trade_date" not in df.columns:
+        raise RuntimeError(f"{symbol} daily data returned no trade_date column.")
+    keep = ["trade_date", "open", "high", "low", "close", "volume"]
+    for column in keep[1:]:
+        if column not in df.columns:
+            df[column] = pd.NA
+        df[column] = pd.to_numeric(df[column], errors="coerce")
+    df["trade_date"] = pd.to_datetime(df["trade_date"], errors="coerce").dt.normalize()
+    df = df.dropna(subset=["trade_date", "open", "close"]).sort_values("trade_date").reset_index(drop=True)
+    df.insert(0, "symbol", symbol)
+    return df[ASSET_DAILY_COLUMNS]
 
 
 class MarketDataService:
@@ -60,31 +138,138 @@ class MarketDataService:
         raise RuntimeError("Unable to load daily S&P 500 data. " + " | ".join(errors))
 
     def load_spy_daily(self, start: str, end: str) -> pd.DataFrame:
+        return self.load_asset_daily("SPY", start, end).drop(columns=["symbol"])
+
+    def load_asset_daily(self, symbol: str, start: str, end: str) -> pd.DataFrame:
         start_ts = pd.Timestamp(start)
         end_ts = pd.Timestamp(end)
         try:
             import yfinance as yf  # type: ignore
 
             df = yf.download(
-                "SPY",
+                symbol,
                 start=start_ts.strftime("%Y-%m-%d"),
                 end=(end_ts + pd.Timedelta(days=1)).strftime("%Y-%m-%d"),
                 progress=False,
                 auto_adjust=False,
             )
         except Exception as exc:
-            raise RuntimeError(f"Unable to load SPY daily data: {exc}") from exc
+            raise RuntimeError(f"Unable to load {symbol} daily data: {exc}") from exc
+        return _standardize_ohlcv_frame(df, symbol)
+
+    def load_assets_daily(self, symbols: list[str] | tuple[str, ...], start: str, end: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+        rows: list[pd.DataFrame] = []
+        manifest_rows: list[dict[str, Any]] = []
+        for symbol in normalize_symbols(symbols):
+            try:
+                daily = self.load_asset_daily(symbol, start, end)
+                rows.append(daily)
+                manifest_rows.append(
+                    {
+                        "symbol": symbol,
+                        "dataset_kind": "daily",
+                        "row_count": int(len(daily)),
+                        "status": "ok",
+                        "start_at": daily["trade_date"].min() if not daily.empty else pd.NaT,
+                        "end_at": daily["trade_date"].max() if not daily.empty else pd.NaT,
+                        "detail": "",
+                    },
+                )
+            except Exception as exc:
+                manifest_rows.append(
+                    {
+                        "symbol": symbol,
+                        "dataset_kind": "daily",
+                        "row_count": 0,
+                        "status": "error",
+                        "start_at": pd.NaT,
+                        "end_at": pd.NaT,
+                        "detail": str(exc),
+                    },
+                )
+        daily_frame = pd.concat(rows, ignore_index=True) if rows else pd.DataFrame(columns=ASSET_DAILY_COLUMNS)
+        manifest = pd.DataFrame(manifest_rows, columns=MARKET_MANIFEST_COLUMNS)
+        return daily_frame, manifest
+
+    def load_asset_intraday(
+        self,
+        symbol: str,
+        interval: str = "5m",
+        lookback_days: int = 30,
+    ) -> pd.DataFrame:
+        period_days = max(1, min(int(lookback_days), 60))
+        try:
+            import yfinance as yf  # type: ignore
+
+            df = yf.download(
+                symbol,
+                period=f"{period_days}d",
+                interval=interval,
+                progress=False,
+                auto_adjust=False,
+                prepost=False,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Unable to load {symbol} intraday data: {exc}") from exc
 
         if isinstance(df.columns, pd.MultiIndex):
             df.columns = df.columns.get_level_values(0)
-        df = df.reset_index().rename(columns={"Date": "trade_date"})
+        df = df.reset_index().rename(columns={"Datetime": "timestamp", "Date": "timestamp"})
         df.columns = [str(column).lower() for column in df.columns]
-        df["trade_date"] = pd.to_datetime(df["trade_date"]).dt.normalize()
-        keep = ["trade_date", "open", "high", "low", "close", "volume"]
-        for column in keep[1:]:
+        if "timestamp" not in df.columns:
+            raise RuntimeError(f"{symbol} intraday data did not include a timestamp column.")
+        df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+        df = df.dropna(subset=["timestamp"]).copy()
+        df["timestamp"] = df["timestamp"].map(
+            lambda ts: ts.tz_localize(EASTERN) if ts.tzinfo is None else ts.tz_convert(EASTERN),
+        )
+        for column in ["open", "high", "low", "close", "volume"]:
+            if column not in df.columns:
+                df[column] = pd.NA
             df[column] = pd.to_numeric(df[column], errors="coerce")
-        df = df.dropna(subset=["open", "close"]).sort_values("trade_date").reset_index(drop=True)
-        return df[keep]
+        df = df.dropna(subset=["open", "close"]).sort_values("timestamp").reset_index(drop=True)
+        df.insert(0, "symbol", symbol)
+        df["interval"] = interval
+        return df[ASSET_INTRADAY_COLUMNS]
+
+    def load_assets_intraday(
+        self,
+        symbols: list[str] | tuple[str, ...],
+        interval: str = "5m",
+        lookback_days: int = 30,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        rows: list[pd.DataFrame] = []
+        manifest_rows: list[dict[str, Any]] = []
+        for symbol in normalize_symbols(symbols):
+            try:
+                intraday = self.load_asset_intraday(symbol, interval=interval, lookback_days=lookback_days)
+                rows.append(intraday)
+                manifest_rows.append(
+                    {
+                        "symbol": symbol,
+                        "dataset_kind": f"intraday_{interval}",
+                        "row_count": int(len(intraday)),
+                        "status": "ok",
+                        "start_at": intraday["timestamp"].min() if not intraday.empty else pd.NaT,
+                        "end_at": intraday["timestamp"].max() if not intraday.empty else pd.NaT,
+                        "detail": "",
+                    },
+                )
+            except Exception as exc:
+                manifest_rows.append(
+                    {
+                        "symbol": symbol,
+                        "dataset_kind": f"intraday_{interval}",
+                        "row_count": 0,
+                        "status": "error",
+                        "start_at": pd.NaT,
+                        "end_at": pd.NaT,
+                        "detail": str(exc),
+                    },
+                )
+        intraday_frame = pd.concat(rows, ignore_index=True) if rows else pd.DataFrame(columns=ASSET_INTRADAY_COLUMNS)
+        manifest = pd.DataFrame(manifest_rows, columns=MARKET_MANIFEST_COLUMNS)
+        return intraday_frame, manifest
 
     def load_spy_intraday_month(
         self,

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -11,7 +11,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 
 from .backtesting import BacktestService
-from .config import AppSettings
+from .config import AppSettings, DEFAULT_ETF_SYMBOLS
 from .contracts import MANUAL_OVERRIDE_COLUMNS, ModelRunConfig, RANKING_HISTORY_COLUMNS
 from .discovery import DiscoveryService
 from .enrichment import LLMEnrichmentService
@@ -19,7 +19,7 @@ from .explanations import build_account_attribution, build_post_attribution
 from .experiments import ExperimentStore
 from .features import FeatureService, latest_feature_preview, map_posts_to_trade_sessions
 from .ingestion import IngestionService, TruthSocialArchiveAdapter, XCsvAdapter
-from .market import MarketDataService
+from .market import MarketDataService, build_asset_universe, build_watchlist_frame, normalize_symbols
 from .modeling import ModelService, classify_feature_family
 from .research import (
     aggregate_research_sessions,
@@ -40,6 +40,33 @@ def _parse_grid(value: str, cast: type[float] | type[int]) -> tuple[float, ...] 
     if cast is int:
         return tuple(int(part) for part in parts)
     return tuple(float(part) for part in parts)
+
+
+def _watchlist_symbols(store: DuckDBStore) -> list[str]:
+    watchlist = store.read_frame("asset_watchlist")
+    if watchlist.empty or "symbol" not in watchlist.columns:
+        return []
+    return normalize_symbols(watchlist["symbol"].astype(str).tolist())
+
+
+def _save_watchlist(store: DuckDBStore, symbols: list[str] | tuple[str, ...]) -> tuple[pd.DataFrame, pd.DataFrame]:
+    watchlist = build_watchlist_frame(symbols)
+    asset_universe = build_asset_universe(watchlist["symbol"].tolist() if not watchlist.empty else [])
+    store.save_frame("asset_watchlist", watchlist, metadata={"row_count": int(len(watchlist))})
+    store.save_frame(
+        "asset_universe",
+        asset_universe,
+        metadata={
+            "row_count": int(len(asset_universe)),
+            "default_etfs": list(DEFAULT_ETF_SYMBOLS),
+        },
+    )
+    return watchlist, asset_universe
+
+
+def _watchlist_text_value(store: DuckDBStore) -> str:
+    symbols = _watchlist_symbols(store)
+    return ", ".join(symbols)
 
 
 def _build_adapters(
@@ -109,6 +136,20 @@ def _refresh_datasets(
     store.save_frame("sp500_daily", sp500, metadata={"row_count": int(len(sp500))})
     store.save_frame("spy_daily", spy, metadata={"row_count": int(len(spy))})
 
+    watchlist_symbols = _watchlist_symbols(store)
+    watchlist, asset_universe = _save_watchlist(store, watchlist_symbols)
+    asset_symbols = asset_universe["symbol"].astype(str).tolist() if not asset_universe.empty else list(DEFAULT_ETF_SYMBOLS)
+    asset_daily, daily_manifest = market_service.load_assets_daily(asset_symbols, start, end)
+    asset_intraday, intraday_manifest = market_service.load_assets_intraday(asset_symbols, interval="5m", lookback_days=30)
+    asset_market_manifest = pd.concat([daily_manifest, intraday_manifest], ignore_index=True)
+    store.save_frame("asset_daily", asset_daily, metadata={"row_count": int(len(asset_daily)), "symbols": asset_symbols})
+    store.save_frame(
+        "asset_intraday",
+        asset_intraday,
+        metadata={"row_count": int(len(asset_intraday)), "symbols": asset_symbols, "interval": "5m", "lookback_days": 30},
+    )
+    store.save_frame("asset_market_manifest", asset_market_manifest, metadata={"row_count": int(len(asset_market_manifest))})
+
     as_of = posts["post_timestamp"].max() if not posts.empty else pd.Timestamp.now(tz=settings.timezone)
     tracked_accounts, ranking_history = _rebuild_discovery_state(store, discovery_service, posts, as_of)
     return {
@@ -116,6 +157,11 @@ def _refresh_datasets(
         "source_manifest": source_manifest,
         "sp500": sp500,
         "spy": spy,
+        "asset_watchlist": watchlist,
+        "asset_universe": asset_universe,
+        "asset_daily": asset_daily,
+        "asset_intraday": asset_intraday,
+        "asset_market_manifest": asset_market_manifest,
         "tracked_accounts": tracked_accounts,
     }
 
@@ -127,7 +173,15 @@ def _ensure_bootstrap(
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
 ) -> None:
-    if store.read_frame("normalized_posts").empty or store.read_frame("sp500_daily").empty or store.read_frame("spy_daily").empty:
+    if store.read_frame("asset_watchlist").empty and store.read_frame("asset_universe").empty:
+        _save_watchlist(store, [])
+    if (
+        store.read_frame("normalized_posts").empty
+        or store.read_frame("sp500_daily").empty
+        or store.read_frame("spy_daily").empty
+        or store.read_frame("asset_daily").empty
+        or store.read_frame("asset_intraday").empty
+    ):
         _refresh_datasets(
             settings=settings,
             store=store,
@@ -237,6 +291,28 @@ def render_datasets_view(
     st.subheader("Datasets")
     st.caption("Refresh historical sources, store normalized datasets, and inspect the local DuckDB + Parquet catalog.")
 
+    st.markdown("**Asset universe**")
+    st.caption("Manage a small stock watchlist here. The ETF starter set is always included: `SPY`, `QQQ`, `XLK`, `XLF`, `XLE`, `SMH`.")
+    default_text = _watchlist_text_value(store)
+    watchlist_input = st.text_area(
+        "Watchlist symbols",
+        value=st.session_state.get("watchlist_symbols", default_text),
+        help="Enter a comma-separated list of stock tickers such as `AAPL, TSLA, NVDA`.",
+    )
+    st.session_state["watchlist_symbols"] = watchlist_input
+    watchlist_cols = st.columns(2)
+    if watchlist_cols[0].button("Save watchlist", use_container_width=True):
+        symbols = normalize_symbols([part.strip() for part in watchlist_input.replace("\n", ",").split(",") if part.strip()])
+        watchlist, asset_universe = _save_watchlist(store, symbols)
+        st.session_state["watchlist_symbols"] = ", ".join(watchlist["symbol"].tolist()) if not watchlist.empty else ""
+        st.success(f"Saved {len(watchlist):,} watchlist symbols and {len(asset_universe):,} total tracked assets.")
+        st.rerun()
+    if watchlist_cols[1].button("Reset watchlist", use_container_width=True):
+        _save_watchlist(store, [])
+        st.session_state["watchlist_symbols"] = ""
+        st.success("Reset the manual watchlist to the ETF starter set only.")
+        st.rerun()
+
     remote_url = st.text_input(
         "Remote X / mentions CSV URL",
         key="remote_x_url",
@@ -260,7 +336,8 @@ def render_datasets_view(
                 uploaded_files=uploaded_files or [],
             )
         st.success(
-            f"Refreshed {len(summary['posts']):,} normalized posts and {len(summary['tracked_accounts']):,} tracked account versions.",
+            f"Refreshed {len(summary['posts']):,} normalized posts, {len(summary['asset_daily']):,} daily market rows, "
+            f"and {len(summary['tracked_accounts']):,} tracked account versions.",
         )
     if action_cols[1].button("Incremental refresh", use_container_width=True):
         with st.spinner("Polling sources for new data..."):
@@ -274,7 +351,10 @@ def render_datasets_view(
                 uploaded_files=uploaded_files or [],
                 incremental=True,
             )
-        st.success(f"Incremental refresh complete. Total posts stored: {len(summary['posts']):,}.")
+        st.success(
+            f"Incremental refresh complete. Total posts stored: {len(summary['posts']):,}. "
+            f"Asset intraday rows stored: {len(summary['asset_intraday']):,}.",
+        )
 
     registry = store.dataset_registry()
     if not registry.empty:
@@ -287,6 +367,26 @@ def render_datasets_view(
     if not source_manifest.empty:
         st.markdown("**Source Manifest**")
         st.dataframe(source_manifest, use_container_width=True, hide_index=True)
+
+    asset_universe = store.read_frame("asset_universe")
+    if not asset_universe.empty:
+        st.markdown("**Tracked asset universe**")
+        st.dataframe(asset_universe, use_container_width=True, hide_index=True)
+
+    asset_market_manifest = store.read_frame("asset_market_manifest")
+    if not asset_market_manifest.empty:
+        st.markdown("**Asset market manifest**")
+        st.dataframe(asset_market_manifest, use_container_width=True, hide_index=True)
+
+    asset_daily = store.read_frame("asset_daily")
+    if not asset_daily.empty:
+        st.markdown("**Daily asset market sample**")
+        st.dataframe(asset_daily.tail(20), use_container_width=True, hide_index=True)
+
+    asset_intraday = store.read_frame("asset_intraday")
+    if not asset_intraday.empty:
+        st.markdown("**Intraday asset market sample**")
+        st.dataframe(asset_intraday.tail(20), use_container_width=True, hide_index=True)
 
     posts = store.read_frame("normalized_posts")
     if not posts.empty:


### PR DESCRIPTION
## Summary
- add a persisted manual watchlist plus the fixed ETF starter set (`SPY`, `QQQ`, `XLK`, `XLF`, `XLE`, `SMH`)
- generalize market loading so we can store daily and intraday datasets for arbitrary tickers using yfinance
- extend the Datasets page with watchlist management and asset market dataset/manifest previews

## Why
This is the first multi-asset foundation PR from the stock-and-ETF comparison roadmap. It keeps the scope intentionally tight around issue #4 so later PRs can build ticker-aware relevance, research comparisons, and modeling on top of stable market datasets.

Closes #4.

## Validation
- `./.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python -m coverage run -m unittest discover -s tests`
- `./.venv/bin/python -m coverage report -m`
- `./.venv/bin/streamlit run app.py --server.headless true --server.port 8504`
