### PR TITLE
[codex] Add ticker-aware asset relevance scaffolding

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -9,6 +9,7 @@ import pandas as pd
 from trump_workbench.config import AppSettings
 from trump_workbench.enrichment import LLMEnrichmentService
 from trump_workbench.features import (
+    ASSET_POST_MAPPING_COLUMNS,
     FeatureService,
     latest_feature_preview,
     map_posts_to_trade_sessions,
@@ -174,6 +175,220 @@ class FeatureTests(unittest.TestCase):
         text_preview = preview_post_texts(self.posts, max_items=2)
         self.assertIn("@realDonaldTrump", text_preview)
         self.assertEqual(preview_post_texts(pd.DataFrame()), "")
+
+    def test_build_asset_post_mappings_supports_rule_and_semantic_matches(self) -> None:
+        prepared_posts = pd.DataFrame(
+            [
+                {
+                    "session_date": pd.Timestamp("2025-02-03"),
+                    "post_id": "post-1",
+                    "post_timestamp": pd.Timestamp("2025-02-03 10:00", tz="America/New_York"),
+                    "author_account_id": "acct-1",
+                    "author_handle": "macro1",
+                    "author_display_name": "Macro One",
+                    "author_is_trump": False,
+                    "source_platform": "X",
+                    "cleaned_text": "NVIDIA keeps winning the AI chip race.",
+                    "mentions_trump": True,
+                    "engagement_score": 15.0,
+                    "sentiment_score": 0.7,
+                    "sentiment_label": "positive",
+                    "semantic_topic": "markets",
+                    "semantic_policy_bucket": "economy",
+                    "semantic_market_relevance": 0.9,
+                    "semantic_urgency": 0.2,
+                    "is_active_tracked_account": True,
+                    "tracked_discovery_score": 4.2,
+                    "tracked_account_status": "active",
+                },
+                {
+                    "session_date": pd.Timestamp("2025-02-04"),
+                    "post_id": "post-2",
+                    "post_timestamp": pd.Timestamp("2025-02-04 11:00", tz="America/New_York"),
+                    "author_account_id": "acct-2",
+                    "author_handle": "macro2",
+                    "author_display_name": "Macro Two",
+                    "author_is_trump": False,
+                    "source_platform": "X",
+                    "cleaned_text": "Tariff pressure is rising after another Trump trade warning.",
+                    "mentions_trump": True,
+                    "engagement_score": 20.0,
+                    "sentiment_score": -0.1,
+                    "sentiment_label": "negative",
+                    "semantic_topic": "trade",
+                    "semantic_policy_bucket": "trade",
+                    "semantic_market_relevance": 0.8,
+                    "semantic_urgency": 0.4,
+                    "is_active_tracked_account": False,
+                    "tracked_discovery_score": 0.0,
+                    "tracked_account_status": "none",
+                },
+            ],
+        )
+        asset_universe = pd.DataFrame(
+            [
+                {"symbol": "SPY", "display_name": "SPDR S&P 500 ETF Trust", "asset_type": "etf", "source": "core_etf"},
+                {"symbol": "QQQ", "display_name": "Invesco QQQ Trust", "asset_type": "etf", "source": "core_etf"},
+                {"symbol": "XLE", "display_name": "Energy Select Sector SPDR Fund", "asset_type": "etf", "source": "core_etf"},
+                {"symbol": "SMH", "display_name": "VanEck Semiconductor ETF", "asset_type": "etf", "source": "core_etf"},
+                {"symbol": "NVDA", "display_name": "NVIDIA Corporation", "asset_type": "equity", "source": "watchlist"},
+            ],
+        )
+
+        mappings = self.feature_service.build_asset_post_mappings(prepared_posts, asset_universe, llm_enabled=True)
+
+        nvda_post = mappings.loc[(mappings["post_id"] == "post-1") & (mappings["asset_symbol"] == "NVDA")].iloc[0]
+        smh_post = mappings.loc[(mappings["post_id"] == "post-1") & (mappings["asset_symbol"] == "SMH")].iloc[0]
+        xle_post = mappings.loc[(mappings["post_id"] == "post-2") & (mappings["asset_symbol"] == "XLE")].iloc[0]
+
+        self.assertGreater(float(nvda_post["rule_match_score"]), 0.0)
+        self.assertGreater(float(nvda_post["semantic_match_score"]), 0.0)
+        self.assertIn("rule:nvidia", str(nvda_post["match_reasons"]).lower())
+        self.assertEqual(int(nvda_post["match_rank"]), 1)
+        self.assertTrue(bool(nvda_post["is_primary_asset"]))
+        self.assertGreater(float(smh_post["rule_match_score"]), 0.0)
+        self.assertEqual(float(xle_post["rule_match_score"]), 0.0)
+        self.assertGreater(float(xle_post["semantic_match_score"]), 0.0)
+        self.assertFalse(
+            bool(
+                (
+                    (mappings["post_id"] == "post-2")
+                    & (mappings["asset_symbol"] == "NVDA")
+                ).any()
+            ),
+        )
+
+    def test_build_asset_session_dataset_generates_rows_per_asset(self) -> None:
+        asset_post_mappings = pd.DataFrame(
+            [
+                {
+                    "asset_symbol": "NVDA",
+                    "asset_display_name": "NVIDIA Corporation",
+                    "asset_type": "equity",
+                    "asset_source": "watchlist",
+                    "session_date": pd.Timestamp("2025-02-03"),
+                    "post_id": "post-1",
+                    "post_timestamp": pd.Timestamp("2025-02-03 10:00", tz="America/New_York"),
+                    "author_account_id": "acct-1",
+                    "author_handle": "macro1",
+                    "author_display_name": "Macro One",
+                    "author_is_trump": False,
+                    "source_platform": "X",
+                    "cleaned_text": "NVIDIA keeps winning the AI chip race.",
+                    "mentions_trump": True,
+                    "engagement_score": 15.0,
+                    "sentiment_score": 0.7,
+                    "sentiment_label": "positive",
+                    "semantic_topic": "markets",
+                    "semantic_policy_bucket": "economy",
+                    "semantic_market_relevance": 0.9,
+                    "semantic_urgency": 0.2,
+                    "is_active_tracked_account": True,
+                    "tracked_discovery_score": 4.2,
+                    "tracked_account_status": "active",
+                    "rule_match_score": 0.6,
+                    "semantic_match_score": 0.18,
+                    "asset_relevance_score": 0.78,
+                    "match_reasons": "rule:nvidia, topic:markets",
+                    "match_rank": 1,
+                    "is_primary_asset": True,
+                },
+                {
+                    "asset_symbol": "SPY",
+                    "asset_display_name": "SPDR S&P 500 ETF Trust",
+                    "asset_type": "etf",
+                    "asset_source": "core_etf",
+                    "session_date": pd.Timestamp("2025-02-03"),
+                    "post_id": "post-2",
+                    "post_timestamp": pd.Timestamp("2025-02-03 11:00", tz="America/New_York"),
+                    "author_account_id": "acct-2",
+                    "author_handle": "macro2",
+                    "author_display_name": "Macro Two",
+                    "author_is_trump": False,
+                    "source_platform": "X",
+                    "cleaned_text": "Tariffs are starting to hit the broad market.",
+                    "mentions_trump": True,
+                    "engagement_score": 12.0,
+                    "sentiment_score": -0.2,
+                    "sentiment_label": "negative",
+                    "semantic_topic": "trade",
+                    "semantic_policy_bucket": "trade",
+                    "semantic_market_relevance": 0.8,
+                    "semantic_urgency": 0.3,
+                    "is_active_tracked_account": False,
+                    "tracked_discovery_score": 0.0,
+                    "tracked_account_status": "none",
+                    "rule_match_score": 0.6,
+                    "semantic_match_score": 0.47,
+                    "asset_relevance_score": 1.0,
+                    "match_reasons": "rule:broad market, topic:trade, policy:trade",
+                    "match_rank": 1,
+                    "is_primary_asset": True,
+                },
+            ],
+            columns=ASSET_POST_MAPPING_COLUMNS,
+        )
+        asset_market = pd.DataFrame(
+            [
+                {"symbol": "NVDA", "trade_date": pd.Timestamp("2025-02-03"), "open": 200.0, "high": 203.0, "low": 199.0, "close": 202.0, "volume": 1_000_000.0},
+                {"symbol": "NVDA", "trade_date": pd.Timestamp("2025-02-04"), "open": 205.0, "high": 207.0, "low": 204.0, "close": 206.0, "volume": 1_100_000.0},
+                {"symbol": "NVDA", "trade_date": pd.Timestamp("2025-02-05"), "open": 207.0, "high": 208.0, "low": 205.0, "close": 205.0, "volume": 1_050_000.0},
+                {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-03"), "open": 100.0, "high": 101.0, "low": 99.5, "close": 100.5, "volume": 2_000_000.0},
+                {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-04"), "open": 101.0, "high": 102.0, "low": 100.0, "close": 101.5, "volume": 2_100_000.0},
+                {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-05"), "open": 102.0, "high": 103.0, "low": 101.0, "close": 102.5, "volume": 2_050_000.0},
+            ],
+        )
+        asset_universe = pd.DataFrame(
+            [
+                {"symbol": "NVDA", "display_name": "NVIDIA Corporation", "asset_type": "equity", "source": "watchlist"},
+                {"symbol": "SPY", "display_name": "SPDR S&P 500 ETF Trust", "asset_type": "etf", "source": "core_etf"},
+            ],
+        )
+
+        dataset = self.feature_service.build_asset_session_dataset(
+            asset_post_mappings=asset_post_mappings,
+            asset_market=asset_market,
+            feature_version="asset-v1",
+            llm_enabled=True,
+            asset_universe=asset_universe,
+        )
+
+        self.assertEqual(len(dataset), 6)
+        nvda_row = dataset.loc[
+            (dataset["asset_symbol"] == "NVDA") & (dataset["signal_session_date"] == pd.Timestamp("2025-02-03"))
+        ].iloc[0]
+        self.assertEqual(int(nvda_row["post_count"]), 1)
+        self.assertEqual(int(nvda_row["rule_matched_post_count"]), 1)
+        self.assertEqual(int(nvda_row["primary_match_post_count"]), 1)
+        self.assertAlmostEqual(float(nvda_row["asset_relevance_score_avg"]), 0.78)
+        self.assertAlmostEqual(float(nvda_row["target_next_session_return"]), 206.0 / 205.0 - 1.0)
+        self.assertTrue(bool(nvda_row["tradeable"]))
+
+        nvda_empty_row = dataset.loc[
+            (dataset["asset_symbol"] == "NVDA") & (dataset["signal_session_date"] == pd.Timestamp("2025-02-05"))
+        ].iloc[0]
+        self.assertFalse(bool(nvda_empty_row["has_posts"]))
+        self.assertEqual(int(nvda_empty_row["post_count"]), 0)
+        self.assertFalse(bool(nvda_empty_row["tradeable"]))
+
+    def test_build_asset_session_dataset_handles_empty_mappings_schema(self) -> None:
+        asset_market = pd.DataFrame(
+            [
+                {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-03"), "open": 100.0, "high": 101.0, "low": 99.5, "close": 100.5, "volume": 2_000_000.0},
+                {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-04"), "open": 101.0, "high": 102.0, "low": 100.0, "close": 101.5, "volume": 2_100_000.0},
+            ],
+        )
+
+        dataset = self.feature_service.build_asset_session_dataset(
+            asset_post_mappings=pd.DataFrame(),
+            asset_market=asset_market,
+            feature_version="asset-v1",
+            llm_enabled=False,
+        )
+
+        self.assertEqual(len(dataset), 2)
+        self.assertTrue((dataset["post_count"] == 0).all())
+        self.assertFalse(bool(dataset.iloc[-1]["tradeable"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -114,6 +114,10 @@ class MarketDataTests(unittest.TestCase):
         universe = build_asset_universe(["msft", "nvda"])
         self.assertIn("SPY", universe["symbol"].tolist())
         self.assertIn("MSFT", universe["symbol"].tolist())
+        self.assertEqual(
+            universe.loc[universe["symbol"] == "SPY", "display_name"].iloc[0],
+            "SPDR S&P 500 ETF Trust",
+        )
 
         def fake_download(symbol: str, *args, **kwargs) -> pd.DataFrame:
             if kwargs.get("interval"):

--- a/trump_workbench/features.py
+++ b/trump_workbench/features.py
@@ -1,16 +1,104 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import numpy as np
 import pandas as pd
 
-from .config import EASTERN
+from .config import DEFAULT_ETF_SYMBOLS, EASTERN
 from .enrichment import LLMEnrichmentService
 from .utils import business_minutes_until_close, ensure_tz_naive_date, truncate_text
 
 REGULAR_OPEN_MINUTE = 9 * 60 + 30
 REGULAR_CLOSE_MINUTE = 16 * 60
+ASSET_POST_MAPPING_COLUMNS = [
+    "asset_symbol",
+    "asset_display_name",
+    "asset_type",
+    "asset_source",
+    "session_date",
+    "post_id",
+    "post_timestamp",
+    "author_account_id",
+    "author_handle",
+    "author_display_name",
+    "author_is_trump",
+    "source_platform",
+    "cleaned_text",
+    "mentions_trump",
+    "engagement_score",
+    "sentiment_score",
+    "sentiment_label",
+    "semantic_topic",
+    "semantic_policy_bucket",
+    "semantic_market_relevance",
+    "semantic_urgency",
+    "is_active_tracked_account",
+    "tracked_discovery_score",
+    "tracked_account_status",
+    "rule_match_score",
+    "semantic_match_score",
+    "asset_relevance_score",
+    "match_reasons",
+    "match_rank",
+    "is_primary_asset",
+]
+CORE_ASSET_ALIAS_TERMS = {
+    "SPY": ["s&p 500", "s&p", "sp500", "broad market", "stock market"],
+    "QQQ": ["nasdaq", "nasdaq 100", "big tech", "tech stocks"],
+    "XLK": ["technology sector", "tech sector", "software", "hardware"],
+    "XLF": ["financial sector", "financials", "banks", "banking"],
+    "XLE": ["energy sector", "oil", "gas", "crude", "drilling"],
+    "SMH": ["semiconductor", "semiconductors", "chip", "chips", "ai chip", "ai chips"],
+}
+SEMANTIC_TOPIC_ASSETS = {
+    "markets": {"SPY", "QQQ", "XLK"},
+    "trade": {"SPY", "XLE", "XLF"},
+    "geopolitics": {"SPY", "XLE"},
+    "immigration": {"SPY"},
+    "judiciary": {"SPY"},
+    "campaign": {"SPY", "QQQ"},
+}
+SEMANTIC_POLICY_ASSETS = {
+    "economy": {"SPY", "QQQ", "XLF"},
+    "trade": {"SPY", "XLE"},
+    "foreign_policy": {"SPY", "XLE"},
+    "immigration": {"SPY"},
+    "legal": {"SPY"},
+}
+ALIAS_TOKEN_BLACKLIST = {
+    "class",
+    "common",
+    "corp",
+    "corporation",
+    "company",
+    "fund",
+    "etf",
+    "trust",
+    "select",
+    "sector",
+    "spdr",
+    "invesco",
+    "vaneck",
+}
+
+
+def _alias_terms_for_asset(symbol: str, display_name: str) -> list[str]:
+    lowered_symbol = symbol.lower()
+    terms = {lowered_symbol}
+    normalized_name = re.sub(r"[^a-z0-9&+ ]+", " ", str(display_name or "").lower()).strip()
+    if normalized_name and normalized_name != lowered_symbol:
+        terms.add(normalized_name)
+        for token in normalized_name.split():
+            if len(token) >= 4 and token not in ALIAS_TOKEN_BLACKLIST:
+                terms.add(token)
+    terms.update(CORE_ASSET_ALIAS_TERMS.get(symbol, []))
+    return sorted(term for term in terms if term)
+
+
+def _text_contains_term(text: str, term: str) -> bool:
+    return bool(re.search(rf"(?<!\\w){re.escape(term)}(?!\\w)", text))
 
 
 def map_posts_to_trade_sessions(posts: pd.DataFrame, market: pd.DataFrame) -> pd.DataFrame:
@@ -84,6 +172,186 @@ class FeatureService:
         mapped = self.enrichment_service.enrich_posts(mapped, enabled=llm_enabled)
         mapped = self._flag_tracked_posts(mapped, tracked_accounts)
         return mapped
+
+    def build_asset_post_mappings(
+        self,
+        prepared_posts: pd.DataFrame,
+        asset_universe: pd.DataFrame,
+        llm_enabled: bool,
+    ) -> pd.DataFrame:
+        if prepared_posts.empty or asset_universe.empty:
+            return pd.DataFrame(columns=ASSET_POST_MAPPING_COLUMNS)
+
+        assets = asset_universe.copy()
+        if "display_name" not in assets.columns:
+            assets["display_name"] = assets["symbol"]
+        if "asset_type" not in assets.columns:
+            assets["asset_type"] = np.where(assets["symbol"].isin(DEFAULT_ETF_SYMBOLS), "etf", "equity")
+        if "source" not in assets.columns:
+            assets["source"] = np.where(assets["symbol"].isin(DEFAULT_ETF_SYMBOLS), "core_etf", "watchlist")
+
+        asset_terms = {
+            str(row["symbol"]): _alias_terms_for_asset(str(row["symbol"]), str(row.get("display_name", row["symbol"])))
+            for _, row in assets.iterrows()
+        }
+
+        mapping_rows: list[dict[str, Any]] = []
+        for row_idx, (_, post) in enumerate(prepared_posts.iterrows(), start=1):
+            text = str(post.get("cleaned_text", "") or "").lower()
+            semantic_topic = str(post.get("semantic_topic", "") or "")
+            semantic_policy = str(post.get("semantic_policy_bucket", "") or "")
+            market_relevance = float(post.get("semantic_market_relevance", 0.0) or 0.0)
+            post_id = str(post.get("post_id", "") or f"row-{row_idx}")
+            candidates: list[dict[str, Any]] = []
+
+            for _, asset in assets.iterrows():
+                symbol = str(asset["symbol"])
+                matched_terms = [term for term in asset_terms[symbol] if _text_contains_term(text, term)]
+                rule_score = min(1.0, 0.45 + 0.15 * len(matched_terms) + (0.15 if symbol.lower() in matched_terms else 0.0)) if matched_terms else 0.0
+
+                semantic_score = 0.0
+                semantic_reasons: list[str] = []
+                if llm_enabled:
+                    if symbol in SEMANTIC_TOPIC_ASSETS.get(semantic_topic, set()):
+                        semantic_score += 0.2 + market_relevance * 0.2
+                        semantic_reasons.append(f"topic:{semantic_topic}")
+                    if symbol in SEMANTIC_POLICY_ASSETS.get(semantic_policy, set()):
+                        semantic_score += 0.15 + market_relevance * 0.15
+                        semantic_reasons.append(f"policy:{semantic_policy}")
+                    if str(asset.get("asset_type", "")) == "equity" and rule_score > 0.0:
+                        semantic_score += market_relevance * 0.2
+                    if str(asset.get("asset_type", "")) == "equity" and rule_score <= 0.0:
+                        semantic_score = 0.0
+                        semantic_reasons = []
+
+                asset_relevance_score = min(1.0, rule_score + semantic_score)
+                if asset_relevance_score <= 0.0:
+                    continue
+
+                reasons = [f"rule:{term}" for term in matched_terms]
+                reasons.extend(semantic_reasons)
+                candidates.append(
+                    {
+                        "asset_symbol": symbol,
+                        "asset_display_name": str(asset.get("display_name", symbol)),
+                        "asset_type": str(asset.get("asset_type", "")),
+                        "asset_source": str(asset.get("source", "")),
+                        "session_date": post["session_date"],
+                        "post_id": post_id,
+                        "post_timestamp": post["post_timestamp"],
+                        "author_account_id": post["author_account_id"],
+                        "author_handle": post["author_handle"],
+                        "author_display_name": post["author_display_name"],
+                        "author_is_trump": bool(post["author_is_trump"]),
+                        "source_platform": post["source_platform"],
+                        "cleaned_text": post["cleaned_text"],
+                        "mentions_trump": bool(post["mentions_trump"]),
+                        "engagement_score": float(post["engagement_score"]),
+                        "sentiment_score": float(post["sentiment_score"]),
+                        "sentiment_label": str(post["sentiment_label"]),
+                        "semantic_topic": semantic_topic,
+                        "semantic_policy_bucket": semantic_policy,
+                        "semantic_market_relevance": market_relevance,
+                        "semantic_urgency": float(post.get("semantic_urgency", 0.0) or 0.0),
+                        "is_active_tracked_account": bool(post.get("is_active_tracked_account", False)),
+                        "tracked_discovery_score": float(post.get("tracked_discovery_score", 0.0) or 0.0),
+                        "tracked_account_status": str(post.get("tracked_account_status", "none") or "none"),
+                        "rule_match_score": float(rule_score),
+                        "semantic_match_score": float(semantic_score),
+                        "asset_relevance_score": float(asset_relevance_score),
+                        "match_reasons": ", ".join(reasons),
+                    },
+                )
+
+            candidates = sorted(
+                candidates,
+                key=lambda item: (
+                    item["asset_relevance_score"],
+                    item["rule_match_score"],
+                    item["semantic_match_score"],
+                    item["asset_symbol"] not in DEFAULT_ETF_SYMBOLS,
+                ),
+                reverse=True,
+            )
+            for match_rank, candidate in enumerate(candidates, start=1):
+                candidate["match_rank"] = match_rank
+                candidate["is_primary_asset"] = match_rank == 1
+                mapping_rows.append(candidate)
+
+        return pd.DataFrame(mapping_rows, columns=ASSET_POST_MAPPING_COLUMNS)
+
+    def build_asset_session_dataset(
+        self,
+        asset_post_mappings: pd.DataFrame,
+        asset_market: pd.DataFrame,
+        feature_version: str,
+        llm_enabled: bool,
+        asset_universe: pd.DataFrame | None = None,
+    ) -> pd.DataFrame:
+        if asset_market.empty:
+            return pd.DataFrame()
+
+        mappings = asset_post_mappings.copy() if not asset_post_mappings.empty else pd.DataFrame(columns=ASSET_POST_MAPPING_COLUMNS)
+        for column in ASSET_POST_MAPPING_COLUMNS:
+            if column not in mappings.columns:
+                mappings[column] = pd.Series(dtype=object)
+        mappings["session_date"] = pd.to_datetime(mappings["session_date"], errors="coerce").dt.normalize()
+
+        market = asset_market.sort_values(["symbol", "trade_date"]).reset_index(drop=True).copy()
+        grouped_market = market.groupby("symbol", sort=False)
+        market["session_return"] = grouped_market["close"].pct_change().fillna(0.0)
+        market["prev_return_1d"] = grouped_market["close"].pct_change(1).fillna(0.0)
+        market["prev_return_3d"] = grouped_market["close"].pct_change(3).fillna(0.0)
+        market["prev_return_5d"] = grouped_market["close"].pct_change(5).fillna(0.0)
+        market["rolling_vol_5d"] = grouped_market["close"].transform(lambda series: series.pct_change().rolling(5).std().fillna(0.0))
+        market["close_ma_5"] = grouped_market["close"].transform(lambda series: series.rolling(5).mean().bfill().fillna(series))
+        market["close_vs_ma_5"] = (market["close"] / market["close_ma_5"] - 1.0).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+        market["volume_ma_5"] = grouped_market["volume"].transform(lambda series: series.rolling(5).mean().bfill().fillna(series))
+        market["volume_z_5"] = (
+            (market["volume"] - market["volume_ma_5"])
+            / grouped_market["volume"].transform(lambda series: series.rolling(5).std(ddof=0)).replace(0, np.nan)
+        ).fillna(0.0)
+        market["next_session_date"] = grouped_market["trade_date"].shift(-1)
+        market["next_session_open"] = grouped_market["open"].shift(-1)
+        market["next_session_close"] = grouped_market["close"].shift(-1)
+        market["target_next_session_return"] = (market["next_session_close"] / market["next_session_open"] - 1.0).replace([np.inf, -np.inf], np.nan)
+        market["target_available"] = market["next_session_open"].notna() & market["next_session_close"].notna()
+
+        asset_lookup = (
+            asset_universe.set_index("symbol").to_dict(orient="index")
+            if asset_universe is not None and not asset_universe.empty and "symbol" in asset_universe.columns
+            else {}
+        )
+        rows: list[dict[str, Any]] = []
+        for _, session in market.iterrows():
+            symbol = str(session["symbol"])
+            session_date = pd.Timestamp(session["trade_date"])
+            group = mappings.loc[
+                (mappings["asset_symbol"] == symbol)
+                & (mappings["session_date"] == session_date)
+            ].copy()
+            group = group.sort_values("post_timestamp").reset_index(drop=True)
+            row = self._build_session_row(group, session, feature_version, llm_enabled)
+            asset_meta = asset_lookup.get(symbol, {})
+            row.update(
+                {
+                    "asset_symbol": symbol,
+                    "asset_display_name": asset_meta.get("display_name", symbol),
+                    "asset_type": asset_meta.get("asset_type", "equity"),
+                    "asset_source": asset_meta.get("source", "watchlist"),
+                    "rule_matched_post_count": int((group["rule_match_score"] > 0.0).sum()) if not group.empty else 0,
+                    "semantic_matched_post_count": int((group["semantic_match_score"] > 0.0).sum()) if not group.empty else 0,
+                    "primary_match_post_count": int(group["is_primary_asset"].fillna(False).sum()) if not group.empty else 0,
+                    "asset_relevance_score_avg": float(group["asset_relevance_score"].mean()) if not group.empty else 0.0,
+                    "asset_rule_match_score_avg": float(group["rule_match_score"].mean()) if not group.empty else 0.0,
+                    "asset_semantic_match_score_avg": float(group["semantic_match_score"].mean()) if not group.empty else 0.0,
+                },
+            )
+            rows.append(row)
+        dataset = pd.DataFrame(rows).sort_values(["asset_symbol", "signal_session_date"]).reset_index(drop=True)
+        if not dataset.empty and "target_available" in dataset.columns:
+            dataset["tradeable"] = dataset["target_available"].fillna(False)
+        return dataset
 
     def build_session_dataset(
         self,

--- a/trump_workbench/market.py
+++ b/trump_workbench/market.py
@@ -18,6 +18,14 @@ ASSET_UNIVERSE_COLUMNS = ["symbol", "display_name", "asset_type", "source", "is_
 ASSET_DAILY_COLUMNS = ["symbol", "trade_date", "open", "high", "low", "close", "volume"]
 ASSET_INTRADAY_COLUMNS = ["symbol", "timestamp", "open", "high", "low", "close", "volume", "interval"]
 MARKET_MANIFEST_COLUMNS = ["symbol", "dataset_kind", "row_count", "status", "start_at", "end_at", "detail"]
+CORE_ASSET_DISPLAY_NAMES = {
+    "SPY": "SPDR S&P 500 ETF Trust",
+    "QQQ": "Invesco QQQ Trust",
+    "XLK": "Technology Select Sector SPDR Fund",
+    "XLF": "Financial Select Sector SPDR Fund",
+    "XLE": "Energy Select Sector SPDR Fund",
+    "SMH": "VanEck Semiconductor ETF",
+}
 
 
 def normalize_symbols(values: list[str] | tuple[str, ...]) -> list[str]:
@@ -52,7 +60,7 @@ def build_asset_universe(watchlist_symbols: list[str] | tuple[str, ...]) -> pd.D
         rows.append(
             {
                 "symbol": symbol,
-                "display_name": symbol,
+                "display_name": CORE_ASSET_DISPLAY_NAMES.get(symbol, symbol),
                 "asset_type": "etf",
                 "source": "core_etf",
                 "is_default": True,

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -113,6 +113,7 @@ def _refresh_datasets(
     ingestion_service: IngestionService,
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
+    feature_service: FeatureService,
     remote_url: str,
     uploaded_files: list[Any],
     incremental: bool = False,
@@ -152,6 +153,34 @@ def _refresh_datasets(
 
     as_of = posts["post_timestamp"].max() if not posts.empty else pd.Timestamp.now(tz=settings.timezone)
     tracked_accounts, ranking_history = _rebuild_discovery_state(store, discovery_service, posts, as_of)
+    prepared_posts = feature_service.prepare_session_posts(
+        posts=posts,
+        market_calendar=spy,
+        tracked_accounts=tracked_accounts,
+        llm_enabled=True,
+    )
+    asset_post_mappings = feature_service.build_asset_post_mappings(
+        prepared_posts=prepared_posts,
+        asset_universe=asset_universe,
+        llm_enabled=True,
+    )
+    asset_session_features = feature_service.build_asset_session_dataset(
+        asset_post_mappings=asset_post_mappings,
+        asset_market=asset_daily,
+        feature_version="asset-v1",
+        llm_enabled=True,
+        asset_universe=asset_universe,
+    )
+    store.save_frame(
+        "asset_post_mappings",
+        asset_post_mappings,
+        metadata={"row_count": int(len(asset_post_mappings)), "match_mode": "rules_plus_semantic"},
+    )
+    store.save_frame(
+        "asset_session_features",
+        asset_session_features,
+        metadata={"row_count": int(len(asset_session_features)), "feature_version": "asset-v1"},
+    )
     return {
         "posts": posts,
         "source_manifest": source_manifest,
@@ -162,6 +191,8 @@ def _refresh_datasets(
         "asset_daily": asset_daily,
         "asset_intraday": asset_intraday,
         "asset_market_manifest": asset_market_manifest,
+        "asset_post_mappings": asset_post_mappings,
+        "asset_session_features": asset_session_features,
         "tracked_accounts": tracked_accounts,
     }
 
@@ -172,6 +203,7 @@ def _ensure_bootstrap(
     ingestion_service: IngestionService,
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
+    feature_service: FeatureService,
 ) -> None:
     if store.read_frame("asset_watchlist").empty and store.read_frame("asset_universe").empty:
         _save_watchlist(store, [])
@@ -181,6 +213,8 @@ def _ensure_bootstrap(
         or store.read_frame("spy_daily").empty
         or store.read_frame("asset_daily").empty
         or store.read_frame("asset_intraday").empty
+        or store.read_frame("asset_post_mappings").empty
+        or store.read_frame("asset_session_features").empty
     ):
         _refresh_datasets(
             settings=settings,
@@ -188,6 +222,7 @@ def _ensure_bootstrap(
             ingestion_service=ingestion_service,
             market_service=market_service,
             discovery_service=discovery_service,
+            feature_service=feature_service,
             remote_url=st.session_state.get("remote_x_url", ""),
             uploaded_files=[],
             incremental=False,
@@ -287,6 +322,7 @@ def render_datasets_view(
     ingestion_service: IngestionService,
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
+    feature_service: FeatureService,
 ) -> None:
     st.subheader("Datasets")
     st.caption("Refresh historical sources, store normalized datasets, and inspect the local DuckDB + Parquet catalog.")
@@ -332,6 +368,7 @@ def render_datasets_view(
                 ingestion_service=ingestion_service,
                 market_service=market_service,
                 discovery_service=discovery_service,
+                feature_service=feature_service,
                 remote_url=remote_url,
                 uploaded_files=uploaded_files or [],
             )
@@ -347,6 +384,7 @@ def render_datasets_view(
                 ingestion_service=ingestion_service,
                 market_service=market_service,
                 discovery_service=discovery_service,
+                feature_service=feature_service,
                 remote_url=remote_url,
                 uploaded_files=uploaded_files or [],
                 incremental=True,
@@ -387,6 +425,35 @@ def render_datasets_view(
     if not asset_intraday.empty:
         st.markdown("**Intraday asset market sample**")
         st.dataframe(asset_intraday.tail(20), use_container_width=True, hide_index=True)
+
+    asset_post_mappings = store.read_frame("asset_post_mappings")
+    if not asset_post_mappings.empty:
+        st.markdown("**Asset post mappings sample**")
+        keep = [
+            "asset_symbol",
+            "session_date",
+            "author_handle",
+            "asset_relevance_score",
+            "rule_match_score",
+            "semantic_match_score",
+            "match_reasons",
+            "cleaned_text",
+        ]
+        st.dataframe(asset_post_mappings[keep].tail(20), use_container_width=True, hide_index=True)
+
+    asset_session_features = store.read_frame("asset_session_features")
+    if not asset_session_features.empty:
+        st.markdown("**Per-asset session feature sample**")
+        keep = [
+            "asset_symbol",
+            "signal_session_date",
+            "post_count",
+            "asset_relevance_score_avg",
+            "rule_matched_post_count",
+            "semantic_matched_post_count",
+            "target_next_session_return",
+        ]
+        st.dataframe(asset_session_features[keep].tail(20), use_container_width=True, hide_index=True)
 
     posts = store.read_frame("normalized_posts")
     if not posts.empty:
@@ -1415,6 +1482,7 @@ def render_live_monitor(
                 ingestion_service=ingestion_service,
                 market_service=market_service,
                 discovery_service=discovery_service,
+                feature_service=feature_service,
                 remote_url=remote_url,
                 uploaded_files=[],
                 incremental=True,
@@ -1660,7 +1728,7 @@ def main() -> None:
     backtest_service = BacktestService(model_service)
     experiment_store = ExperimentStore(store)
 
-    _ensure_bootstrap(settings, store, ingestion_service, market_service, discovery_service)
+    _ensure_bootstrap(settings, store, ingestion_service, market_service, discovery_service, feature_service)
 
     page = st.sidebar.radio(
         "Workbench",
@@ -1673,7 +1741,7 @@ def main() -> None:
     if page == "Research View":
         render_research_view(settings, store, market_service, feature_service)
     elif page == "Datasets":
-        render_datasets_view(settings, store, ingestion_service, market_service, discovery_service)
+        render_datasets_view(settings, store, ingestion_service, market_service, discovery_service, feature_service)
     elif page == "Discovery":
         render_discovery_view(settings, store, discovery_service)
     elif page == "Models & Backtests":


### PR DESCRIPTION
## Summary
- add ticker-aware asset post mappings from prepared social posts into the tracked stock and ETF universe
- build per-asset session feature rows with asset-specific match and target fields
- surface the new mapping/session datasets in the Datasets view so the multi-asset research flow is inspectable

## Why
Issue #5 is the bridge between the new watchlist asset datasets and the upcoming multi-asset Research View and modeling work. The app needed a rules-first, semantics-assisted way to decide which posts matter to `NVDA` versus `SPY` versus sector ETFs, and it needed those mappings persisted into per-asset session datasets.

This PR is intentionally stacked on top of #11 because it depends on the asset-universe and market-dataset groundwork from that branch.

## What changed
- added asset alias rules plus ETF/topic-policy semantic boosts in `FeatureService.build_asset_post_mappings(...)`
- added `FeatureService.build_asset_session_dataset(...)` to generate per-symbol session features and next-session targets
- persisted `asset_post_mappings` and `asset_session_features` during dataset refresh/bootstrap
- added Datasets page previews for the new asset-aware datasets
- expanded tests for rule/semantic matching, per-asset session aggregation, and the richer asset-universe display names

## Validation
- `./.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `./.venv/bin/python -m unittest tests.test_features tests.test_market tests.test_ui -v`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python -m coverage run -m unittest discover -s tests`
- `./.venv/bin/python -m coverage report -m`
- `./.venv/bin/streamlit run app.py --server.headless true --server.port 8505`

Closes #5 when the stack lands.
