### PR TITLE
[codex] Add multi-asset research comparison view

### DIFF
--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -7,11 +7,15 @@ import pandas as pd
 from trump_workbench.research import (
     _format_post_summary,
     aggregate_research_sessions,
+    build_asset_comparison_chart,
+    build_asset_comparison_frame,
     build_combined_chart,
     build_event_frame,
     build_intraday_chart,
     filter_posts,
     get_intraday_window,
+    make_asset_mapping_table,
+    make_asset_session_table,
     make_post_table,
     make_session_table,
 )
@@ -49,6 +53,48 @@ class ResearchTests(unittest.TestCase):
             {
                 "trade_date": pd.to_datetime(["2025-02-03", "2025-02-04", "2025-02-05"]),
                 "close": [100.0, 101.0, 102.0],
+            },
+        )
+        self.asset_market = pd.DataFrame(
+            {
+                "symbol": ["SPY", "SPY", "SPY", "NVDA", "NVDA", "NVDA"],
+                "trade_date": pd.to_datetime(
+                    ["2025-02-03", "2025-02-04", "2025-02-05", "2025-02-03", "2025-02-04", "2025-02-05"],
+                ),
+                "close": [100.0, 101.0, 102.0, 200.0, 210.0, 205.0],
+            },
+        )
+        self.asset_session_features = pd.DataFrame(
+            {
+                "asset_symbol": ["NVDA", "NVDA"],
+                "signal_session_date": pd.to_datetime(["2025-02-03", "2025-02-04"]),
+                "post_count": [2, 1],
+                "rule_matched_post_count": [2, 1],
+                "semantic_matched_post_count": [1, 1],
+                "primary_match_post_count": [2, 1],
+                "asset_relevance_score_avg": [0.72, 0.61],
+                "sentiment_avg": [0.3, -0.1],
+                "target_next_session_return": [0.05, -0.01],
+                "target_available": [True, True],
+            },
+        )
+        self.asset_post_mappings = pd.DataFrame(
+            {
+                "asset_symbol": ["NVDA", "NVDA"],
+                "session_date": pd.to_datetime(["2025-02-03", "2025-02-04"]),
+                "post_timestamp": pd.to_datetime(
+                    ["2025-02-03 10:00-05:00", "2025-02-04 11:00-05:00"],
+                    utc=True,
+                ).tz_convert("America/New_York"),
+                "author_handle": ["macroalpha", "macrobeta"],
+                "author_display_name": ["Macro Alpha", "Macro Beta"],
+                "asset_relevance_score": [0.8, 0.55],
+                "rule_match_score": [0.6, 0.4],
+                "semantic_match_score": [0.2, 0.15],
+                "match_rank": [1, 1],
+                "is_primary_asset": [True, True],
+                "match_reasons": ["rule:nvidia, topic:markets", "rule:semiconductor, policy:economy"],
+                "cleaned_text": ["NVIDIA keeps rallying after strong AI demand.", "Semiconductor policy talk is picking up."],
             },
         )
 
@@ -101,6 +147,34 @@ class ResearchTests(unittest.TestCase):
         post_table = make_post_table(self.posts)
         self.assertIn("post_text", post_table.columns)
         self.assertEqual(post_table.iloc[0]["session_date"].isoformat(), "2025-02-03")
+
+    def test_asset_comparison_helpers_and_tables(self) -> None:
+        comparison = build_asset_comparison_frame(
+            self.asset_market,
+            "NVDA",
+            date_start=pd.Timestamp("2025-02-03"),
+            date_end=pd.Timestamp("2025-02-05"),
+        )
+        self.assertEqual(len(comparison), 3)
+        self.assertAlmostEqual(float(comparison.iloc[-1]["spy_normalized_return"]), 0.02)
+        self.assertAlmostEqual(float(comparison.iloc[-1]["asset_normalized_return"]), 0.025)
+
+        price_chart = build_asset_comparison_chart(comparison, "NVDA", mode="price")
+        normalized_chart = build_asset_comparison_chart(comparison, "NVDA", mode="normalized")
+        self.assertEqual(price_chart.layout.title.text, "SPY vs. NVDA price overlay")
+        self.assertEqual(normalized_chart.layout.title.text, "SPY vs. NVDA normalized returns")
+        self.assertEqual(len(price_chart.data), 2)
+        self.assertEqual(len(normalized_chart.data), 2)
+
+        asset_session_table = make_asset_session_table(self.asset_session_features, "NVDA")
+        self.assertIn("trade_date", asset_session_table.columns)
+        self.assertIn("next_session_return", asset_session_table.columns)
+        self.assertEqual(len(asset_session_table), 2)
+
+        asset_mapping_table = make_asset_mapping_table(self.asset_post_mappings, "NVDA")
+        self.assertIn("post_text", asset_mapping_table.columns)
+        self.assertIn("match_reasons", asset_mapping_table.columns)
+        self.assertEqual(asset_mapping_table.iloc[0]["asset_symbol"], "NVDA")
 
     def test_intraday_helpers(self) -> None:
         intraday = pd.DataFrame(

--- a/trump_workbench/research.py
+++ b/trump_workbench/research.py
@@ -111,6 +111,124 @@ def build_event_frame(sp500_market: pd.DataFrame, sessions: pd.DataFrame) -> pd.
     return events
 
 
+def build_asset_comparison_frame(
+    asset_market: pd.DataFrame,
+    selected_symbol: str,
+    date_start: pd.Timestamp | None = None,
+    date_end: pd.Timestamp | None = None,
+) -> pd.DataFrame:
+    if asset_market.empty or not str(selected_symbol or "").strip():
+        return pd.DataFrame()
+
+    market = asset_market.copy()
+    market["trade_date"] = pd.to_datetime(market["trade_date"], errors="coerce").dt.normalize()
+    market = market.dropna(subset=["trade_date"]).copy()
+    if date_start is not None:
+        market = market.loc[market["trade_date"] >= pd.Timestamp(date_start).normalize()].copy()
+    if date_end is not None:
+        market = market.loc[market["trade_date"] <= pd.Timestamp(date_end).normalize()].copy()
+
+    symbol = str(selected_symbol).upper()
+    spy = market.loc[market["symbol"] == "SPY", ["trade_date", "close"]].rename(columns={"close": "spy_close"})
+    asset = market.loc[market["symbol"] == symbol, ["trade_date", "close"]].rename(columns={"close": "asset_close"})
+    comparison = spy.merge(asset, on="trade_date", how="inner").sort_values("trade_date").reset_index(drop=True)
+    if comparison.empty:
+        return comparison
+
+    comparison["asset_symbol"] = symbol
+    comparison["spy_daily_return"] = comparison["spy_close"].pct_change().fillna(0.0)
+    comparison["asset_daily_return"] = comparison["asset_close"].pct_change().fillna(0.0)
+    comparison["spy_normalized_return"] = comparison["spy_close"] / comparison["spy_close"].iloc[0] - 1.0
+    comparison["asset_normalized_return"] = comparison["asset_close"] / comparison["asset_close"].iloc[0] - 1.0
+    return comparison
+
+
+def build_asset_comparison_chart(
+    comparison: pd.DataFrame,
+    selected_symbol: str,
+    mode: str,
+) -> go.Figure:
+    symbol = str(selected_symbol).upper()
+    fig = make_subplots(specs=[[{"secondary_y": mode == "price"}]])
+    if comparison.empty:
+        fig.update_layout(
+            title=f"SPY vs. {symbol} comparison",
+            margin={"l": 20, "r": 20, "t": 60, "b": 20},
+        )
+        return fig
+
+    if mode == "normalized":
+        fig.add_trace(
+            go.Scatter(
+                x=comparison["trade_date"],
+                y=comparison["spy_normalized_return"],
+                mode="lines",
+                name="SPY normalized return",
+                line={"color": "#8ecae6", "width": 3},
+                hovertemplate="<b>%{x|%Y-%m-%d}</b><br>SPY: %{y:+.2%}<extra></extra>",
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=comparison["trade_date"],
+                y=comparison["asset_normalized_return"],
+                mode="lines",
+                name=f"{symbol} normalized return",
+                line={"color": "#f59e0b", "width": 2.5},
+                hovertemplate=f"<b>%{{x|%Y-%m-%d}}</b><br>{symbol}: %{{y:+.2%}}<extra></extra>",
+            ),
+            row=1,
+            col=1,
+        )
+        fig.update_yaxes(title_text="Return since range start", tickformat=".0%", row=1, col=1)
+        title = f"SPY vs. {symbol} normalized returns"
+    else:
+        fig.add_trace(
+            go.Scatter(
+                x=comparison["trade_date"],
+                y=comparison["spy_close"],
+                mode="lines",
+                name="SPY close",
+                line={"color": "#8ecae6", "width": 3},
+                customdata=comparison["spy_daily_return"],
+                hovertemplate="<b>%{x|%Y-%m-%d}</b><br>SPY close: %{y:,.2f}<br>Daily return: %{customdata:+.2%}<extra></extra>",
+            ),
+            row=1,
+            col=1,
+            secondary_y=False,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=comparison["trade_date"],
+                y=comparison["asset_close"],
+                mode="lines",
+                name=f"{symbol} close",
+                line={"color": "#f59e0b", "width": 2.5},
+                customdata=comparison["asset_daily_return"],
+                hovertemplate=f"<b>%{{x|%Y-%m-%d}}</b><br>{symbol} close: %{{y:,.2f}}<br>Daily return: %{{customdata:+.2%}}<extra></extra>",
+            ),
+            row=1,
+            col=1,
+            secondary_y=True,
+        )
+        fig.update_yaxes(title_text="SPY close", row=1, col=1, secondary_y=False)
+        fig.update_yaxes(title_text=f"{symbol} close", row=1, col=1, secondary_y=True)
+        title = f"SPY vs. {symbol} price overlay"
+
+    fig.update_xaxes(title_text="Trading session", dtick="M3", tickformat="%b %Y", row=1, col=1)
+    fig.update_layout(
+        title=title,
+        hovermode="x unified",
+        legend={"orientation": "h", "yanchor": "bottom", "y": 1.02, "xanchor": "left", "x": 0.0},
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        margin={"l": 20, "r": 20, "t": 80, "b": 20},
+    )
+    return fig
+
+
 def build_combined_chart(events: pd.DataFrame, scale_markers: bool) -> go.Figure:
     plot_events = events.sort_values("trade_date").reset_index(drop=True).copy()
     fig = make_subplots(
@@ -309,6 +427,35 @@ def make_session_table(events: pd.DataFrame) -> pd.DataFrame:
     )
 
 
+def make_asset_session_table(asset_session_features: pd.DataFrame, selected_symbol: str) -> pd.DataFrame:
+    if asset_session_features.empty:
+        return asset_session_features.copy()
+
+    symbol = str(selected_symbol).upper()
+    table = asset_session_features.copy()
+    table = table.loc[table["asset_symbol"].astype(str).str.upper() == symbol].copy()
+    if table.empty:
+        return table
+    table["signal_session_date"] = pd.to_datetime(table["signal_session_date"]).dt.date
+    keep = [
+        "signal_session_date",
+        "post_count",
+        "rule_matched_post_count",
+        "semantic_matched_post_count",
+        "primary_match_post_count",
+        "asset_relevance_score_avg",
+        "sentiment_avg",
+        "target_next_session_return",
+        "target_available",
+    ]
+    return table[keep].rename(
+        columns={
+            "signal_session_date": "trade_date",
+            "target_next_session_return": "next_session_return",
+        },
+    )
+
+
 def make_post_table(mapped_posts: pd.DataFrame) -> pd.DataFrame:
     if mapped_posts.empty:
         return mapped_posts
@@ -331,6 +478,37 @@ def make_post_table(mapped_posts: pd.DataFrame) -> pd.DataFrame:
         "post_url",
     ]
     return table[keep].rename(columns={"preview": "post_text"})
+
+
+def make_asset_mapping_table(asset_post_mappings: pd.DataFrame, selected_symbol: str) -> pd.DataFrame:
+    if asset_post_mappings.empty:
+        return asset_post_mappings.copy()
+
+    symbol = str(selected_symbol).upper()
+    table = asset_post_mappings.copy()
+    table = table.loc[table["asset_symbol"].astype(str).str.upper() == symbol].copy()
+    if table.empty:
+        return table
+    table["post_time_et"] = pd.to_datetime(table["post_timestamp"], errors="coerce").dt.tz_convert(EASTERN).dt.strftime("%Y-%m-%d %H:%M")
+    table["session_date"] = pd.to_datetime(table["session_date"], errors="coerce").dt.date
+    table["preview"] = table["cleaned_text"].map(lambda x: truncate_text(str(x), max_chars=180))
+    keep = [
+        "asset_symbol",
+        "session_date",
+        "post_time_et",
+        "author_handle",
+        "author_display_name",
+        "asset_relevance_score",
+        "rule_match_score",
+        "semantic_match_score",
+        "match_rank",
+        "is_primary_asset",
+        "match_reasons",
+        "preview",
+    ]
+    return table.sort_values(["session_date", "match_rank", "post_time_et"], ascending=[False, True, True])[keep].rename(
+        columns={"preview": "post_text"},
+    )
 
 
 def build_intraday_chart(intraday: pd.DataFrame, anchor_ts: pd.Timestamp, title: str) -> go.Figure:

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -23,11 +23,15 @@ from .market import MarketDataService, build_asset_universe, build_watchlist_fra
 from .modeling import ModelService, classify_feature_family
 from .research import (
     aggregate_research_sessions,
+    build_asset_comparison_chart,
+    build_asset_comparison_frame,
     build_combined_chart,
     build_event_frame,
     build_intraday_chart,
     filter_posts,
     get_intraday_window,
+    make_asset_mapping_table,
+    make_asset_session_table,
     make_post_table,
     make_session_table,
 )
@@ -634,6 +638,10 @@ def render_research_view(
     st.caption("Preserved descriptive market overlay plus cleaned-up post/session tables and intraday drill-down.")
     posts = store.read_frame("normalized_posts")
     sp500 = store.read_frame("sp500_daily")
+    asset_universe = store.read_frame("asset_universe")
+    asset_daily = store.read_frame("asset_daily")
+    asset_post_mappings = store.read_frame("asset_post_mappings")
+    asset_session_features = store.read_frame("asset_session_features")
     tracked_accounts = store.read_frame("tracked_accounts")
     if posts.empty or sp500.empty:
         st.info("Refresh datasets first so the research view has source data.")
@@ -702,6 +710,107 @@ def render_research_view(
     if not post_table.empty:
         with st.expander("Underlying posts", expanded=False):
             st.dataframe(post_table, use_container_width=True, hide_index=True)
+
+    st.markdown("**Multi-Asset Comparison**")
+    st.caption("Compare `SPY` with one tracked stock or ETF over the same date range, then inspect which posts mapped to that asset.")
+    if asset_universe.empty or asset_daily.empty:
+        st.info("Refresh datasets first to populate the tracked asset universe and daily asset market data.")
+    else:
+        comparison_candidates = asset_universe.loc[asset_universe["symbol"].astype(str).str.upper() != "SPY"].copy()
+        if comparison_candidates.empty:
+            st.info("Add at least one non-`SPY` asset to the tracked universe to enable asset comparison.")
+        else:
+            comparison_candidates["symbol"] = comparison_candidates["symbol"].astype(str).str.upper()
+            comparison_candidates["display_name"] = comparison_candidates["display_name"].fillna(comparison_candidates["symbol"]).astype(str)
+            candidate_symbols = comparison_candidates["symbol"].tolist()
+            candidate_labels = {
+                row["symbol"]: f"{row['symbol']} - {row['display_name']}"
+                for _, row in comparison_candidates.iterrows()
+            }
+            watchlist_symbols = comparison_candidates.loc[
+                comparison_candidates["source"].astype(str) == "watchlist",
+                "symbol",
+            ].tolist()
+            default_asset = watchlist_symbols[0] if watchlist_symbols else candidate_symbols[0]
+
+            asset_controls = st.columns([1.6, 1.2, 1.2])
+            selected_asset = asset_controls[0].selectbox(
+                "Selected asset",
+                options=candidate_symbols,
+                index=candidate_symbols.index(default_asset),
+                format_func=lambda symbol: candidate_labels.get(symbol, symbol),
+                key="research_selected_asset",
+            )
+            comparison_mode = asset_controls[1].radio(
+                "View",
+                options=["price", "normalized"],
+                format_func=lambda value: "Price overlay" if value == "price" else "Normalized returns",
+                horizontal=True,
+                key="research_asset_comparison_mode",
+            )
+
+            comparison = build_asset_comparison_frame(
+                asset_market=asset_daily,
+                selected_symbol=selected_asset,
+                date_start=start_date,
+                date_end=end_date,
+            )
+            asset_feature_view = asset_session_features.copy()
+            if not asset_feature_view.empty and "signal_session_date" in asset_feature_view.columns:
+                asset_feature_view["signal_session_date"] = pd.to_datetime(asset_feature_view["signal_session_date"], errors="coerce").dt.normalize()
+                asset_feature_view = asset_feature_view.loc[
+                    (asset_feature_view["signal_session_date"] >= start_date.normalize())
+                    & (asset_feature_view["signal_session_date"] <= end_date.normalize())
+                ].copy()
+            asset_mapping_view = asset_post_mappings.copy()
+            if not asset_mapping_view.empty and "session_date" in asset_mapping_view.columns:
+                asset_mapping_view["session_date"] = pd.to_datetime(asset_mapping_view["session_date"], errors="coerce").dt.normalize()
+                asset_mapping_view = asset_mapping_view.loc[
+                    (asset_mapping_view["session_date"] >= start_date.normalize())
+                    & (asset_mapping_view["session_date"] <= end_date.normalize())
+                ].copy()
+
+            if comparison.empty:
+                st.info(f"No overlapping daily market data was found for `SPY` and `{selected_asset}` in the current date range.")
+            else:
+                asset_metric_cols = st.columns(4)
+                asset_metric_cols[0].metric("Sessions in range", f"{len(comparison):,}")
+                asset_metric_cols[1].metric("SPY move", f"{comparison['spy_normalized_return'].iloc[-1]:+.2%}")
+                asset_metric_cols[2].metric(f"{selected_asset} move", f"{comparison['asset_normalized_return'].iloc[-1]:+.2%}")
+                asset_metric_cols[3].metric(
+                    f"{selected_asset} vs SPY spread",
+                    f"{(comparison['asset_normalized_return'].iloc[-1] - comparison['spy_normalized_return'].iloc[-1]):+.2%}",
+                )
+                st.plotly_chart(
+                    build_asset_comparison_chart(comparison, selected_asset, comparison_mode),
+                    use_container_width=True,
+                )
+
+            asset_session_table = make_asset_session_table(asset_feature_view, selected_asset)
+            if not asset_session_table.empty:
+                st.markdown("**Per-asset session summary**")
+                st.dataframe(
+                    asset_session_table.sort_values(["post_count", "trade_date"], ascending=[False, False]),
+                    use_container_width=True,
+                    hide_index=True,
+                )
+
+            asset_mapping_table = make_asset_mapping_table(asset_mapping_view, selected_asset)
+            if asset_mapping_table.empty:
+                st.info(f"No mapped posts for `{selected_asset}` were found in the current date range.")
+            else:
+                session_options = sorted(asset_mapping_table["session_date"].dropna().unique().tolist(), reverse=True)
+                selected_asset_session = asset_controls[2].selectbox(
+                    "Matched session",
+                    options=session_options,
+                    format_func=lambda value: value.isoformat(),
+                    key="research_asset_mapping_session",
+                )
+                session_mapping_table = asset_mapping_table.loc[
+                    asset_mapping_table["session_date"] == selected_asset_session
+                ].copy()
+                st.markdown(f"**Matched posts for {selected_asset} on {selected_asset_session.isoformat()}**")
+                st.dataframe(session_mapping_table, use_container_width=True, hide_index=True)
 
     with st.expander("Intraday SPY drill-down", expanded=False):
         alpha_vantage_key = st.text_input(


### PR DESCRIPTION
## Summary
- add a first multi-asset comparison section to the Research View
- support `SPY` vs selected-asset price overlays and normalized-return comparisons
- surface per-asset session summaries and selected-session mapped-post details in the Research workflow

## Why
This is the first implementation slice for #6. Now that the app has a tracked asset universe, multi-asset market datasets, and ticker-aware relevance scaffolding, the Research View needs a user-facing way to inspect how `SPY` compares with a selected stock or ETF over the same date range.

This PR is intentionally stacked on top of #12 because it depends on the ticker-aware asset datasets introduced there.

## What changed
- added shared research helpers to build `SPY` vs selected-asset comparison frames and charts
- added asset-specific session and mapping tables for the Research page drill-down flow
- extended the Research View UI with:
  - selected asset control
  - price overlay / normalized return mode switch
  - per-asset session summary table
  - selected-session mapped-post table with match reasons and relevance scores
- expanded research tests to cover the new comparison helpers and tables

## Validation
- `./.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `./.venv/bin/python -m unittest tests.test_research tests.test_ui -v`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python -m coverage run -m unittest discover -s tests`
- `./.venv/bin/python -m coverage report -m`
- `./.venv/bin/streamlit run app.py --server.headless true --server.port 8506`

Advances #6.
