### PR TITLE
[codex] Add multi-target modeling

### DIFF
--- a/tests/test_config_contracts.py
+++ b/tests/test_config_contracts.py
@@ -93,6 +93,7 @@ class ConfigAndContractsTests(unittest.TestCase):
         snapshot = PredictionSnapshot(
             signal_session_date=pd.Timestamp("2025-02-03"),
             next_session_date=pd.Timestamp("2025-02-04"),
+            target_asset="SPY",
             expected_return_score=0.01,
             feature_version="v1",
             model_version="linear-v1",
@@ -103,6 +104,7 @@ class ConfigAndContractsTests(unittest.TestCase):
         backtest_run = BacktestRun(
             run_id="run-1",
             run_name="test",
+            target_asset="SPY",
             config_hash="hash",
             train_window=60,
             validation_window=20,
@@ -125,7 +127,9 @@ class ConfigAndContractsTests(unittest.TestCase):
         self.assertEqual(post.to_dict()["post_id"], "1")
         self.assertEqual(tracked.to_dict()["status"], "active")
         self.assertEqual(feature_row.to_dict()["post_count"], 2)
+        self.assertEqual(config.to_dict()["target_asset"], "SPY")
         self.assertEqual(config.to_dict()["threshold_grid"], list(config.threshold_grid))
+        self.assertEqual(snapshot.to_dict()["target_asset"], "SPY")
         self.assertEqual(snapshot.to_dict()["stance"], "long")
         self.assertEqual(backtest_run.to_dict()["run_id"], "run-1")
         self.assertEqual(LinearModelArtifact.from_dict(artifact.to_dict()).feature_names, ["x1"])

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -23,10 +23,11 @@ class ExperimentStoreTests(unittest.TestCase):
         self.temp_dir.cleanup()
 
     @staticmethod
-    def _sample_run() -> BacktestRun:
+    def _sample_run(run_id: str = "run-123", target_asset: str = "SPY") -> BacktestRun:
         return BacktestRun(
-            run_id="run-123",
+            run_id=run_id,
             run_name="unit-test-run",
+            target_asset=target_asset,
             config_hash="config-hash",
             train_window=60,
             validation_window=20,
@@ -42,12 +43,13 @@ class ExperimentStoreTests(unittest.TestCase):
     def test_load_methods_return_none_when_no_runs_exist(self) -> None:
         self.assertIsNone(self.experiments.load_run("missing"))
         self.assertIsNone(self.experiments.load_latest_model_artifact())
+        self.assertIsNone(self.experiments.load_latest_model_artifact(target_asset="QQQ"))
 
     def test_save_load_run_and_prediction_snapshots(self) -> None:
         run = self._sample_run()
         saved = self.experiments.save_run(
             run=run,
-            config={"feature_version": "v1"},
+            config={"feature_version": "v1", "target_asset": "SPY"},
             trades=self._sample_frame("trade_id"),
             predictions=self._sample_frame("prediction"),
             windows=self._sample_frame("window"),
@@ -61,7 +63,7 @@ class ExperimentStoreTests(unittest.TestCase):
                 "stds": [1.0],
                 "residual_std": 0.3,
                 "train_rows": 10,
-                "metadata": {"source": "unit-test"},
+                "metadata": {"source": "unit-test", "target_asset": "SPY"},
             },
             feature_contributions=self._sample_frame("contribution"),
             post_attribution=self._sample_frame("post_signal_score"),
@@ -78,6 +80,8 @@ class ExperimentStoreTests(unittest.TestCase):
         self.assertTrue(saved.summary_path.exists())
         self.assertEqual(loaded["metrics"]["robust_score"], 1.23)
         self.assertEqual(loaded["config"]["feature_version"], "v1")
+        self.assertEqual(loaded["config"]["target_asset"], "SPY")
+        self.assertEqual(loaded["run"]["target_asset"], "SPY")
         self.assertEqual(loaded["run"]["run_name"], "unit-test-run")
         self.assertEqual(loaded["model_artifact"].feature_names, ["x1"])
         self.assertFalse(loaded["feature_contributions"].empty)
@@ -93,17 +97,69 @@ class ExperimentStoreTests(unittest.TestCase):
         self.assertEqual(artifact.model_version, "linear-v1")
         self.assertEqual(params["threshold"], 0.001)
 
+        qqq_run = self._sample_run(run_id="run-qqq", target_asset="QQQ")
+        self.experiments.save_run(
+            run=qqq_run,
+            config={"feature_version": "asset-v1", "target_asset": "QQQ"},
+            trades=self._sample_frame("trade_id"),
+            predictions=self._sample_frame("prediction"),
+            windows=self._sample_frame("window"),
+            importance=self._sample_frame("feature"),
+            model_artifact={
+                "model_version": "linear-qqq-v1",
+                "feature_names": ["x1"],
+                "intercept": 0.1,
+                "coefficients": [0.2],
+                "means": [0.0],
+                "stds": [1.0],
+                "residual_std": 0.3,
+                "train_rows": 10,
+                "metadata": {"source": "unit-test", "target_asset": "QQQ"},
+            },
+            feature_contributions=self._sample_frame("contribution"),
+            post_attribution=self._sample_frame("post_signal_score"),
+            account_attribution=self._sample_frame("net_post_signal"),
+            benchmarks=self._sample_frame("benchmark_name"),
+            diagnostics=self._sample_frame("error"),
+            benchmark_curves=self._sample_frame("equity"),
+            leakage_audit={"overall_pass": True},
+        )
+        latest_spy = self.experiments.load_latest_model_artifact(target_asset="SPY")
+        latest_qqq = self.experiments.load_latest_model_artifact(target_asset="QQQ")
+        self.assertIsNotNone(latest_spy)
+        self.assertIsNotNone(latest_qqq)
+        assert latest_spy is not None
+        assert latest_qqq is not None
+        self.assertEqual(latest_spy[0].metadata["target_asset"], "SPY")
+        self.assertEqual(latest_qqq[0].metadata["target_asset"], "QQQ")
+        self.assertIsNone(self.experiments.load_latest_model_artifact(target_asset="XLE"))
+
         self.experiments.save_prediction_snapshots(pd.DataFrame())
         snapshots = pd.DataFrame(
             {
-                "signal_session_date": [pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-03")],
-                "generated_at": [pd.Timestamp("2025-02-03 16:00:00"), pd.Timestamp("2025-02-03 16:00:00")],
-                "expected_return_score": [0.01, 0.02],
+                "signal_session_date": [pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-03")],
+                "generated_at": [
+                    pd.Timestamp("2025-02-03 16:00:00"),
+                    pd.Timestamp("2025-02-03 16:00:00"),
+                    pd.Timestamp("2025-02-03 16:00:00"),
+                ],
+                "target_asset": ["SPY", "SPY", "QQQ"],
+                "expected_return_score": [0.01, 0.02, 0.03],
             },
         )
         self.experiments.save_prediction_snapshots(snapshots)
         stored_snapshots = self.store.read_frame("prediction_snapshots")
-        self.assertEqual(len(stored_snapshots), 1)
+        self.assertEqual(len(stored_snapshots), 2)
+        self.assertSetEqual(set(stored_snapshots["target_asset"].astype(str)), {"SPY", "QQQ"})
+        self.assertAlmostEqual(
+            float(
+                stored_snapshots.loc[
+                    stored_snapshots["target_asset"].astype(str) == "SPY",
+                    "expected_return_score",
+                ].iloc[0],
+            ),
+            0.02,
+        )
 
         saved.benchmarks_path.unlink()
         saved.diagnostics_path.unlink()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -59,6 +59,21 @@ class PipelineTests(unittest.TestCase):
             },
         )
 
+    def _build_asset_market(self, symbols: list[str]) -> pd.DataFrame:
+        base = self._build_market()
+        frames: list[pd.DataFrame] = []
+        for offset, symbol in enumerate(symbols, start=1):
+            frame = base.copy()
+            scale = 1.0 + offset * 0.08
+            frame["symbol"] = symbol
+            frame["open"] = frame["open"] * scale
+            frame["high"] = frame["high"] * scale
+            frame["low"] = frame["low"] * scale
+            frame["close"] = frame["close"] * scale
+            frame["volume"] = frame["volume"] + offset * 10_000
+            frames.append(frame)
+        return pd.concat(frames, ignore_index=True)
+
     def _build_x_csv(self) -> bytes:
         rows = ["timestamp,text,url,is_retweet,author_handle,author_name,author_id,mentions_trump,replies_count,reblogs_count,favourites_count"]
         dates = pd.bdate_range("2025-02-03", periods=140)
@@ -111,6 +126,7 @@ class PipelineTests(unittest.TestCase):
 
         config = ModelRunConfig(
             run_name="unit-test-run",
+            target_asset="SPY",
             llm_enabled=True,
             train_window=60,
             validation_window=20,
@@ -122,9 +138,10 @@ class PipelineTests(unittest.TestCase):
         )
         run, artifacts = self.backtests.run_walk_forward(config, first_dataset)
         self.assertGreater(len(artifacts["trades"]), 0)
+        self.assertEqual(run.target_asset, "SPY")
         self.assertIn("robust_score", run.metrics)
         self.assertTrue(artifacts["leakage_audit"]["overall_pass"])
-        self.assertIn("always_long", artifacts["benchmarks"]["benchmark_name"].tolist())
+        self.assertIn("always_long_spy", artifacts["benchmarks"]["benchmark_name"].tolist())
         self.assertFalse(artifacts["feature_contributions"].empty)
 
         post_attribution = build_post_attribution(prepared_posts)
@@ -169,6 +186,100 @@ class PipelineTests(unittest.TestCase):
         )
         self.assertFalse(replay_bundle["feature_contributions"].empty)
         self.assertFalse(bool(replay_prediction["future_training_leakage"]))
+
+    def test_asset_target_pipeline_supports_non_spy_runs(self) -> None:
+        adapter = XCsvAdapter(
+            settings=self.settings,
+            name="synthetic-x",
+            provenance="unit-test",
+            raw_bytes=self._build_x_csv(),
+        )
+        posts, _ = adapter.fetch_history()
+        posts["raw_text"] = [
+            "Trump says Nasdaq and big tech are leading the market higher." if idx % 2 == 0 else
+            "Trump trade pressure is weighing on energy and financials."
+            for idx in range(len(posts))
+        ]
+        posts["cleaned_text"] = posts["raw_text"]
+        tracked, _ = self.discovery.refresh_accounts(posts, pd.DataFrame(), as_of=posts["post_timestamp"].max(), auto_include_top_n=2)
+        spy_market = self._build_market()
+        asset_market = self._build_asset_market(["QQQ"])
+        asset_universe = pd.DataFrame(
+            [
+                {
+                    "symbol": "QQQ",
+                    "display_name": "Invesco QQQ Trust",
+                    "asset_type": "etf",
+                    "source": "core_etf",
+                },
+            ],
+        )
+
+        prepared_posts = self.features.prepare_session_posts(posts, spy_market, tracked, llm_enabled=True)
+        asset_post_mappings = self.features.build_asset_post_mappings(
+            prepared_posts,
+            asset_universe,
+            llm_enabled=True,
+        )
+        self.assertFalse(asset_post_mappings.loc[asset_post_mappings["asset_symbol"] == "QQQ"].empty)
+
+        asset_dataset = self.features.build_asset_session_dataset(
+            asset_post_mappings=asset_post_mappings,
+            asset_market=asset_market,
+            feature_version="asset-v1",
+            llm_enabled=True,
+            asset_universe=asset_universe,
+        )
+        qqq_dataset = asset_dataset.loc[asset_dataset["asset_symbol"] == "QQQ"].copy()
+        qqq_dataset["target_asset"] = "QQQ"
+        self.assertFalse(qqq_dataset.empty)
+
+        config = ModelRunConfig(
+            run_name="qqq-target-run",
+            target_asset="QQQ",
+            feature_version="asset-v1",
+            llm_enabled=True,
+            train_window=60,
+            validation_window=20,
+            test_window=20,
+            step_size=20,
+            threshold_grid=(0.0, 0.001, 0.002),
+            minimum_signal_grid=(1, 2),
+            account_weight_grid=(0.5, 1.0),
+        )
+        run, artifacts = self.backtests.run_walk_forward(config, qqq_dataset)
+        self.assertEqual(run.target_asset, "QQQ")
+        self.assertIn("always_long_qqq", artifacts["benchmarks"]["benchmark_name"].tolist())
+        self.assertTrue((artifacts["predictions"]["target_asset"].astype(str) == "QQQ").all())
+
+        post_attribution = build_post_attribution(
+            asset_post_mappings.loc[asset_post_mappings["asset_symbol"] == "QQQ"].copy(),
+        )
+        account_attribution = build_account_attribution(post_attribution)
+        self.experiments.save_run(
+            run=run,
+            config=artifacts["config"],
+            trades=artifacts["trades"],
+            predictions=artifacts["predictions"],
+            windows=artifacts["windows"],
+            importance=artifacts["importance"],
+            model_artifact=artifacts["model_artifact"],
+            feature_contributions=artifacts["feature_contributions"],
+            post_attribution=post_attribution,
+            account_attribution=account_attribution,
+            benchmarks=artifacts["benchmarks"],
+            diagnostics=artifacts["diagnostics"],
+            benchmark_curves=artifacts["benchmark_curves"],
+            leakage_audit=artifacts["leakage_audit"],
+        )
+        loaded = self.experiments.load_run(run.run_id)
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        self.assertEqual(loaded["run"]["target_asset"], "QQQ")
+        latest_qqq = self.experiments.load_latest_model_artifact(target_asset="QQQ")
+        self.assertIsNotNone(latest_qqq)
+        assert latest_qqq is not None
+        self.assertEqual(latest_qqq[0].metadata["target_asset"], "QQQ")
 
 
 if __name__ == "__main__":

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -52,6 +52,7 @@ class StorageTests(unittest.TestCase):
         self.store.save_run_record(
             run_id="run-1",
             run_name="coverage test",
+            target_asset="SPY",
             config_hash="hash-1",
             metrics={"sharpe": 1.2},
             selected_params={"threshold": 0.001},
@@ -67,6 +68,7 @@ class StorageTests(unittest.TestCase):
 
         records = self.store.list_run_records()
         self.assertEqual(len(records), 1)
+        self.assertEqual(records.iloc[0]["target_asset"], "SPY")
         self.assertEqual(records.iloc[0]["metrics_json"]["sharpe"], 1.2)
         self.assertEqual(records.iloc[0]["selected_params_json"]["threshold"], 0.001)
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -39,6 +39,7 @@ class UiHelperTests(unittest.TestCase):
     def _run_bundle(
         run_id: str,
         *,
+        target_asset: str = "SPY",
         llm_enabled: bool,
         threshold: float,
         min_post_count: int,
@@ -47,8 +48,9 @@ class UiHelperTests(unittest.TestCase):
         features: list[str],
     ) -> dict[str, object]:
         return {
-            "run": {"run_id": run_id, "run_name": run_id},
+            "run": {"run_id": run_id, "run_name": run_id, "target_asset": target_asset},
             "config": {
+                "target_asset": target_asset,
                 "feature_version": "v1",
                 "llm_enabled": llm_enabled,
                 "train_window": 90,
@@ -83,13 +85,18 @@ class UiHelperTests(unittest.TestCase):
                 stds=[1.0 for _ in features],
                 residual_std=0.3,
                 train_rows=100,
-                metadata={"llm_enabled": llm_enabled},
+                metadata={"llm_enabled": llm_enabled, "target_asset": target_asset},
             ),
             "benchmarks": pd.DataFrame(
                 [
-                    {"benchmark_name": "strategy", "total_return": total_return, "robust_score": robust_score},
-                    {"benchmark_name": "always_long", "total_return": total_return - 0.02, "robust_score": robust_score - 0.1},
-                    {"benchmark_name": "trump_only", "total_return": total_return - 0.01, "robust_score": robust_score - 0.05},
+                    {"benchmark_name": "strategy", "target_asset": target_asset, "total_return": total_return, "robust_score": robust_score},
+                    {
+                        "benchmark_name": f"always_long_{target_asset.lower()}",
+                        "target_asset": target_asset,
+                        "total_return": total_return - 0.02,
+                        "robust_score": robust_score - 0.1,
+                    },
+                    {"benchmark_name": "trump_only", "target_asset": target_asset, "total_return": total_return - 0.01, "robust_score": robust_score - 0.05},
                 ],
             ),
         }
@@ -176,6 +183,7 @@ class UiHelperTests(unittest.TestCase):
         bundles = {
             "base-run": self._run_bundle(
                 "base-run",
+                target_asset="SPY",
                 llm_enabled=False,
                 threshold=0.001,
                 min_post_count=2,
@@ -185,6 +193,7 @@ class UiHelperTests(unittest.TestCase):
             ),
             "alt-run": self._run_bundle(
                 "alt-run",
+                target_asset="QQQ",
                 llm_enabled=True,
                 threshold=0.0025,
                 min_post_count=1,
@@ -201,17 +210,22 @@ class UiHelperTests(unittest.TestCase):
         notes = _summarize_run_changes("base-run", bundles)
 
         self.assertEqual(metric_table.iloc[0]["run_id"], "alt-run")
+        self.assertEqual(metric_table.iloc[0]["target_asset"], "QQQ")
         self.assertAlmostEqual(float(metric_table.iloc[0]["delta_robust_score_vs_base"]), 0.4)
         self.assertIn("deploy_threshold", setting_diff["setting"].tolist())
         self.assertIn("llm_enabled", setting_diff["setting"].tolist())
+        self.assertIn("target_asset", setting_diff["setting"].tolist())
         alt_feature_row = feature_diff.loc[feature_diff["run_id"] == "alt-run"].iloc[0]
+        self.assertEqual(alt_feature_row["target_asset"], "QQQ")
         self.assertEqual(int(alt_feature_row["unique_vs_base_count"]), 1)
         self.assertIn("semantic_market_relevance_avg", str(alt_feature_row["unique_vs_base"]))
         strategy_row = benchmark_diff.loc[
             (benchmark_diff["run_id"] == "alt-run") & (benchmark_diff["benchmark_name"] == "strategy")
         ].iloc[0]
+        self.assertEqual(strategy_row["target_asset"], "QQQ")
         self.assertAlmostEqual(float(strategy_row["delta_total_return_vs_base"]), 0.04)
         self.assertEqual(len(notes), 1)
+        self.assertIn("target asset SPY -> QQQ", notes[0])
         self.assertIn("LLM on vs off", notes[0])
         self.assertIn("threshold 0.001 -> 0.0025", notes[0])
 
@@ -230,6 +244,7 @@ class UiHelperTests(unittest.TestCase):
 
         bundle = self._run_bundle(
             "replay-run",
+            target_asset="QQQ",
             llm_enabled=True,
             threshold=0.0025,
             min_post_count=1,
@@ -240,6 +255,7 @@ class UiHelperTests(unittest.TestCase):
         config = _bundle_to_run_config(bundle)
         self.assertTrue(config.llm_enabled)
         self.assertEqual(config.run_name, "replay-run")
+        self.assertEqual(config.target_asset, "QQQ")
         self.assertEqual(config.threshold_grid, (0.0, 0.001, 0.0025))
 
         replay_row = pd.Series(

--- a/trump_workbench/backtesting.py
+++ b/trump_workbench/backtesting.py
@@ -151,6 +151,8 @@ def build_leakage_audit(feature_rows: pd.DataFrame, window_rows: pd.DataFrame) -
 
 def build_prediction_diagnostics(predictions: pd.DataFrame) -> pd.DataFrame:
     diagnostics = predictions.copy()
+    if "target_asset" not in diagnostics.columns:
+        diagnostics["target_asset"] = "SPY"
     diagnostics["actual_next_session_return"] = diagnostics["target_next_session_return"]
     diagnostics["prediction_error"] = diagnostics["expected_return_score"] - diagnostics["actual_next_session_return"]
     diagnostics["absolute_error"] = diagnostics["prediction_error"].abs()
@@ -159,6 +161,7 @@ def build_prediction_diagnostics(predictions: pd.DataFrame) -> pd.DataFrame:
         == np.sign(diagnostics["actual_next_session_return"].fillna(0.0))
     )
     keep = [
+        "target_asset",
         "signal_session_date",
         "next_session_date",
         "expected_return_score",
@@ -183,10 +186,15 @@ def build_benchmark_suite(
     transaction_cost_bps: float,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     benchmark_inputs = evaluation_rows.dropna(subset=["next_session_open", "next_session_close"]).copy()
+    target_asset = str(
+        benchmark_inputs.get("target_asset", pd.Series(["SPY"])).iloc[0]
+        if not benchmark_inputs.empty
+        else "SPY",
+    ).upper()
     strategies: list[tuple[str, pd.Series, dict[str, float] | None]] = [
         ("strategy", strategy_trades["trade_taken"].astype(bool), strategy_metrics),
         ("always_flat", pd.Series(False, index=benchmark_inputs.index), None),
-        ("always_long", benchmark_inputs["target_available"].fillna(False), None),
+        (f"always_long_{target_asset.lower()}", benchmark_inputs["target_available"].fillna(False), None),
         ("trump_only", (benchmark_inputs["trump_post_count"] > 0) & benchmark_inputs["target_available"].fillna(False), None),
         (
             "tracked_accounts_only",
@@ -207,6 +215,7 @@ def build_benchmark_suite(
         if precomputed_metrics is not None:
             metrics = precomputed_metrics
         row = {"benchmark_name": name, **metrics}
+        row["target_asset"] = target_asset
         row["excess_total_return_vs_strategy"] = float(metrics["total_return"] - strategy_total_return)
         metric_rows.append(row)
         curve[name] = trades["equity_curve"].to_numpy()
@@ -227,6 +236,8 @@ class BacktestService:
     ) -> dict[str, Any]:
         replay_date = pd.Timestamp(replay_session_date).normalize()
         usable = feature_rows.copy()
+        if "target_asset" not in usable.columns:
+            usable["target_asset"] = run_config.target_asset
         if run_config.start_date:
             usable = usable.loc[usable["signal_session_date"] >= pd.Timestamp(run_config.start_date)]
         if run_config.end_date:
@@ -262,7 +273,7 @@ class BacktestService:
         replay_prediction["history_end"] = history["signal_session_date"].max()
         replay_prediction["suggested_stance"] = np.where(
             (replay_prediction["expected_return_score"] > threshold) & (replay_prediction["post_count"] >= min_post_count),
-            "LONG SPY NEXT SESSION",
+            f"LONG {run_config.target_asset.upper()} NEXT SESSION",
             "FLAT",
         )
         replay_prediction["future_training_leakage"] = False
@@ -289,6 +300,8 @@ class BacktestService:
         feature_rows: pd.DataFrame,
     ) -> tuple[BacktestRun, dict[str, Any]]:
         usable = feature_rows.copy()
+        if "target_asset" not in usable.columns:
+            usable["target_asset"] = run_config.target_asset
         if run_config.start_date:
             usable = usable.loc[usable["signal_session_date"] >= pd.Timestamp(run_config.start_date)]
         if run_config.end_date:
@@ -440,6 +453,7 @@ class BacktestService:
         run = BacktestRun(
             run_id=run_id,
             run_name=run_config.run_name,
+            target_asset=run_config.target_asset,
             config_hash=config_hash,
             train_window=train_window,
             validation_window=validation_window,

--- a/trump_workbench/contracts.py
+++ b/trump_workbench/contracts.py
@@ -163,6 +163,7 @@ class SessionFeatureRow:
 @dataclass(frozen=True)
 class ModelRunConfig:
     run_name: str
+    target_asset: str = "SPY"
     feature_version: str = "v1"
     llm_enabled: bool = False
     train_window: int = 90
@@ -190,6 +191,7 @@ class ModelRunConfig:
 class PredictionSnapshot:
     signal_session_date: pd.Timestamp
     next_session_date: Optional[pd.Timestamp]
+    target_asset: str
     expected_return_score: float
     feature_version: str
     model_version: str
@@ -205,6 +207,7 @@ class PredictionSnapshot:
 class BacktestRun:
     run_id: str
     run_name: str
+    target_asset: str
     config_hash: str
     train_window: int
     validation_window: int

--- a/trump_workbench/experiments.py
+++ b/trump_workbench/experiments.py
@@ -69,6 +69,7 @@ class ExperimentStore:
         self.store.save_run_record(
             run_id=run.run_id,
             run_name=run.run_name,
+            target_asset=run.target_asset,
             config_hash=run.config_hash,
             metrics=run.metrics,
             selected_params=run.selected_params,
@@ -129,21 +130,37 @@ class ExperimentStore:
             "leakage_audit": self._read_optional_json(Path(record["summary_path"]).parent / "leakage_audit.json"),
         }
 
-    def load_latest_model_artifact(self) -> tuple[LinearModelArtifact, dict[str, Any]] | None:
+    def load_latest_model_artifact(self, target_asset: str | None = "SPY") -> tuple[LinearModelArtifact, dict[str, Any]] | None:
         runs = self.list_runs()
         if runs.empty:
             return None
-        row = runs.iloc[0]
-        artifact = LinearModelArtifact.from_dict(self._read_json(Path(row["model_path"])))
-        return artifact, row["selected_params_json"]
+        normalized_target = str(target_asset).upper() if target_asset else None
+        for _, row in runs.iterrows():
+            summary_payload = self._read_json(Path(row["summary_path"]))
+            config = summary_payload.get("config", {}) or {}
+            run_meta = summary_payload.get("run", {}) or {}
+            row_target = str(
+                config.get("target_asset")
+                or run_meta.get("target_asset")
+                or row.get("target_asset")
+                or "SPY",
+            ).upper()
+            if normalized_target is not None and row_target != normalized_target:
+                continue
+            artifact = LinearModelArtifact.from_dict(self._read_json(Path(row["model_path"])))
+            return artifact, row["selected_params_json"]
+        return None
 
     def save_prediction_snapshots(self, snapshots: pd.DataFrame) -> None:
         if snapshots.empty:
             return
+        normalized = snapshots.copy()
+        if "target_asset" not in normalized.columns:
+            normalized["target_asset"] = "SPY"
         self.store.append_frame(
             "prediction_snapshots",
-            snapshots,
-            dedupe_on=["signal_session_date", "generated_at"],
+            normalized,
+            dedupe_on=["signal_session_date", "generated_at", "target_asset"],
             metadata={"dataset": "prediction_snapshots"},
         )
 

--- a/trump_workbench/modeling.py
+++ b/trump_workbench/modeling.py
@@ -139,7 +139,7 @@ class ModelService:
             y=train_df["target_next_session_return"].fillna(0.0),
             ridge_alpha=run_config.ridge_alpha,
             model_version=model_version,
-            metadata={"llm_enabled": run_config.llm_enabled},
+            metadata={"llm_enabled": run_config.llm_enabled, "target_asset": run_config.target_asset},
         )
         importance = pd.DataFrame(
             {

--- a/trump_workbench/storage.py
+++ b/trump_workbench/storage.py
@@ -42,6 +42,7 @@ class DuckDBStore:
                 create table if not exists experiment_runs (
                     run_id varchar primary key,
                     run_name varchar,
+                    target_asset varchar,
                     created_at timestamp,
                     config_hash varchar,
                     metrics_json varchar,
@@ -55,6 +56,7 @@ class DuckDBStore:
                 )
                 """,
             )
+            conn.execute("alter table experiment_runs add column if not exists target_asset varchar")
 
     def dataset_path(self, dataset_name: str) -> Path:
         return self.settings.lake_dir / f"{dataset_name}.parquet"
@@ -134,6 +136,7 @@ class DuckDBStore:
         self,
         run_id: str,
         run_name: str,
+        target_asset: str,
         config_hash: str,
         metrics: dict[str, Any],
         selected_params: dict[str, Any],
@@ -144,13 +147,14 @@ class DuckDBStore:
             conn.execute(
                 """
                 insert into experiment_runs
-                (run_id, run_name, created_at, config_hash, metrics_json, selected_params_json,
+                (run_id, run_name, target_asset, created_at, config_hash, metrics_json, selected_params_json,
                  summary_path, trades_path, predictions_path, windows_path, importance_path, model_path)
-                values (?, ?, current_timestamp, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, current_timestamp, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     run_id,
                     run_name,
+                    target_asset,
                     config_hash,
                     json.dumps(metrics, default=str),
                     json.dumps(selected_params, default=str),

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -50,6 +50,91 @@ def _parse_grid(value: str, cast: type[float] | type[int]) -> tuple[float, ...] 
     return tuple(float(part) for part in parts)
 
 
+def _target_asset_options(store: DuckDBStore) -> list[str]:
+    asset_universe = store.read_frame("asset_universe")
+    if asset_universe.empty or "symbol" not in asset_universe.columns:
+        return ["SPY"]
+    symbols = normalize_symbols(asset_universe["symbol"].astype(str).tolist())
+    return ["SPY"] + [symbol for symbol in symbols if symbol != "SPY"]
+
+
+def _target_asset_label(store: DuckDBStore, symbol: str) -> str:
+    normalized = str(symbol).upper()
+    asset_universe = store.read_frame("asset_universe")
+    if asset_universe.empty:
+        return normalized
+    rows = asset_universe.loc[asset_universe["symbol"].astype(str).str.upper() == normalized]
+    if rows.empty:
+        return normalized
+    display_name = str(rows.iloc[0].get("display_name", normalized) or normalized)
+    return f"{normalized} - {display_name}"
+
+
+def _build_model_target_bundle(
+    store: DuckDBStore,
+    feature_service: FeatureService,
+    posts: pd.DataFrame,
+    spy_market: pd.DataFrame,
+    tracked_accounts: pd.DataFrame,
+    llm_enabled: bool,
+    target_asset: str,
+    feature_version: str | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    normalized_target = str(target_asset).upper()
+    resolved_feature_version = feature_version or ("v1" if normalized_target == "SPY" else "asset-v1")
+    asset_universe = store.read_frame("asset_universe")
+    asset_daily = store.read_frame("asset_daily")
+    prepared_posts = feature_service.prepare_session_posts(
+        posts=posts,
+        market_calendar=spy_market,
+        tracked_accounts=tracked_accounts,
+        llm_enabled=llm_enabled,
+    )
+
+    if normalized_target == "SPY":
+        feature_rows = feature_service.build_session_dataset(
+            posts=posts,
+            spy_market=spy_market,
+            tracked_accounts=tracked_accounts,
+            feature_version=resolved_feature_version,
+            llm_enabled=llm_enabled,
+            prepared_posts=prepared_posts,
+        )
+        feature_rows["target_asset"] = "SPY"
+        feature_rows["target_asset_display_name"] = "SPDR S&P 500 ETF Trust"
+        return feature_rows.reset_index(drop=True), prepared_posts.reset_index(drop=True)
+
+    if asset_universe.empty or asset_daily.empty:
+        raise RuntimeError("Refresh datasets first so non-SPY target assets have market and universe data available.")
+
+    asset_post_mappings = feature_service.build_asset_post_mappings(
+        prepared_posts=prepared_posts,
+        asset_universe=asset_universe,
+        llm_enabled=llm_enabled,
+    )
+    asset_feature_rows = feature_service.build_asset_session_dataset(
+        asset_post_mappings=asset_post_mappings,
+        asset_market=asset_daily,
+        feature_version=resolved_feature_version,
+        llm_enabled=llm_enabled,
+        asset_universe=asset_universe,
+    )
+    feature_rows = asset_feature_rows.loc[
+        asset_feature_rows["asset_symbol"].astype(str).str.upper() == normalized_target
+    ].copy()
+    if feature_rows.empty:
+        raise RuntimeError(f"No session feature rows were available for target asset `{normalized_target}`.")
+    asset_rows = asset_universe.loc[asset_universe["symbol"].astype(str).str.upper() == normalized_target]
+    display_name = str(asset_rows.iloc[0].get("display_name", normalized_target)) if not asset_rows.empty else normalized_target
+    feature_rows["target_asset"] = normalized_target
+    feature_rows["target_asset_display_name"] = display_name
+    attribution_posts = asset_post_mappings.loc[
+        asset_post_mappings["asset_symbol"].astype(str).str.upper() == normalized_target
+    ].copy()
+    attribution_posts["target_asset"] = normalized_target
+    return feature_rows.reset_index(drop=True), attribution_posts.reset_index(drop=True)
+
+
 def _watchlist_symbols(store: DuckDBStore) -> list[str]:
     watchlist = store.read_frame("asset_watchlist")
     if watchlist.empty or "symbol" not in watchlist.columns:
@@ -1239,7 +1324,9 @@ def _comparison_settings(run_bundle: dict[str, Any]) -> dict[str, Any]:
     config = run_bundle.get("config", {}) or {}
     selected = run_bundle.get("selected_params", {}) or {}
     artifact = run_bundle.get("model_artifact")
+    run_meta = run_bundle.get("run", {}) or {}
     return {
+        "target_asset": str(config.get("target_asset") or run_meta.get("target_asset") or getattr(artifact, "metadata", {}).get("target_asset", "SPY")),
         "feature_version": config.get("feature_version", "v1"),
         "llm_enabled": bool(config.get("llm_enabled", getattr(artifact, "metadata", {}).get("llm_enabled", False))),
         "train_window": config.get("train_window"),
@@ -1269,6 +1356,7 @@ def _build_metric_comparison_table(base_run_id: str, run_bundles: dict[str, dict
             {
                 "run_id": run_id,
                 "run_name": bundle.get("run", {}).get("run_name", run_id),
+                "target_asset": _comparison_settings(bundle).get("target_asset", "SPY"),
                 "total_return": metrics.get("total_return", 0.0),
                 "sharpe": metrics.get("sharpe", 0.0),
                 "sortino": metrics.get("sortino", 0.0),
@@ -1319,6 +1407,7 @@ def _build_feature_diff_table(base_run_id: str, run_bundles: dict[str, dict[str,
             {
                 "run_id": run_id,
                 "run_name": bundle.get("run", {}).get("run_name", run_id),
+                "target_asset": _comparison_settings(bundle).get("target_asset", "SPY"),
                 "feature_count": len(feature_names),
                 "semantic_features": families.get("semantic", 0),
                 "policy_features": families.get("policy", 0),
@@ -1348,6 +1437,7 @@ def _build_benchmark_delta_table(base_run_id: str, run_bundles: dict[str, dict[s
         benchmarks = bundle.get("benchmarks", pd.DataFrame())
         if benchmarks.empty or "benchmark_name" not in benchmarks.columns:
             continue
+        target_asset = _comparison_settings(bundle).get("target_asset", "SPY")
         lookup = benchmarks.set_index("benchmark_name")
         strategy_return = float(lookup.loc["strategy", "total_return"]) if "strategy" in lookup.index else np.nan
         for benchmark_name in sorted(set(base_lookup.index).union(set(lookup.index))):
@@ -1358,6 +1448,7 @@ def _build_benchmark_delta_table(base_run_id: str, run_bundles: dict[str, dict[s
             rows.append(
                 {
                     "run_id": run_id,
+                    "target_asset": target_asset,
                     "benchmark_name": benchmark_name,
                     "total_return": current_total,
                     "delta_total_return_vs_base": current_total - base_total if pd.notna(current_total) and pd.notna(base_total) else np.nan,
@@ -1387,6 +1478,8 @@ def _summarize_run_changes(base_run_id: str, run_bundles: dict[str, dict[str, An
         ]
         if settings.get("llm_enabled") != base_settings.get("llm_enabled"):
             parts.append(f"LLM {'on' if settings.get('llm_enabled') else 'off'} vs {'on' if base_settings.get('llm_enabled') else 'off'}")
+        if settings.get("target_asset") != base_settings.get("target_asset"):
+            parts.append(f"target asset {base_settings.get('target_asset')} -> {settings.get('target_asset')}")
         if settings.get("deploy_threshold") != base_settings.get("deploy_threshold"):
             parts.append(f"threshold {base_settings.get('deploy_threshold')} -> {settings.get('deploy_threshold')}")
         if settings.get("deploy_min_post_count") != base_settings.get("deploy_min_post_count"):
@@ -1408,6 +1501,7 @@ def _bundle_to_run_config(run_bundle: dict[str, Any]) -> ModelRunConfig:
     run_meta = run_bundle.get("run", {}) or {}
     return ModelRunConfig(
         run_name=str(config.get("run_name") or run_meta.get("run_name") or "historical-replay"),
+        target_asset=str(config.get("target_asset") or run_meta.get("target_asset") or "SPY"),
         feature_version=str(config.get("feature_version", "v1")),
         llm_enabled=bool(config.get("llm_enabled", False)),
         train_window=int(config.get("train_window", 90) or 90),
@@ -1475,7 +1569,10 @@ def render_models_view(
     experiment_store: ExperimentStore,
 ) -> None:
     st.subheader("Models & Backtests")
-    st.caption("Build the session dataset, train a next-session SPY expected-return model, compare saved runs, and inspect benchmark plus leakage diagnostics.")
+    st.caption(
+        "Build the session dataset, train a next-session expected-return model for SPY or a selected asset, "
+        "compare saved runs, and inspect benchmark plus leakage diagnostics.",
+    )
     posts = store.read_frame("normalized_posts")
     spy = store.read_frame("spy_daily")
     tracked_accounts = store.read_frame("tracked_accounts")
@@ -1483,11 +1580,18 @@ def render_models_view(
         st.info("Refresh datasets first so the modeling pipeline has normalized posts and SPY market data.")
         return
 
-    control_cols = st.columns(4)
+    target_asset_options = _target_asset_options(store)
+    control_cols = st.columns(5)
     run_name = control_cols[0].text_input("Run name", value="baseline-research-run")
-    llm_enabled = control_cols[1].checkbox("Enable semantic enrichment", value=False)
-    train_window = control_cols[2].number_input("Train window", min_value=20, max_value=252, value=90, step=5)
-    validation_window = control_cols[3].number_input("Validation window", min_value=10, max_value=126, value=30, step=5)
+    selected_target_asset = control_cols[1].selectbox(
+        "Target asset",
+        options=target_asset_options,
+        index=0,
+        format_func=lambda symbol: _target_asset_label(store, symbol),
+    )
+    llm_enabled = control_cols[2].checkbox("Enable semantic enrichment", value=False)
+    train_window = control_cols[3].number_input("Train window", min_value=20, max_value=252, value=90, step=5)
+    validation_window = control_cols[4].number_input("Validation window", min_value=10, max_value=126, value=30, step=5)
     control_cols2 = st.columns(4)
     test_window = control_cols2[0].number_input("Test window", min_value=10, max_value=126, value=30, step=5)
     step_size = control_cols2[1].number_input("Step size", min_value=5, max_value=126, value=30, step=5)
@@ -1499,64 +1603,80 @@ def render_models_view(
 
     if st.button("Build dataset and run walk-forward backtest", use_container_width=True):
         with st.spinner("Building session features and running walk-forward optimization..."):
-            prepared_posts = feature_service.prepare_session_posts(
-                posts=posts,
-                market_calendar=spy,
-                tracked_accounts=tracked_accounts,
-                llm_enabled=llm_enabled,
-            )
-            feature_rows = feature_service.build_session_dataset(
-                posts=posts,
-                spy_market=spy,
-                tracked_accounts=tracked_accounts,
-                feature_version="v1",
-                llm_enabled=llm_enabled,
-                prepared_posts=prepared_posts,
-            )
-            store.save_frame("session_features_latest", feature_rows, metadata={"llm_enabled": llm_enabled, "row_count": int(len(feature_rows))})
-            config = ModelRunConfig(
-                run_name=run_name,
-                llm_enabled=llm_enabled,
-                train_window=int(train_window),
-                validation_window=int(validation_window),
-                test_window=int(test_window),
-                step_size=int(step_size),
-                threshold_grid=_parse_grid(threshold_text, float),
-                minimum_signal_grid=_parse_grid(min_posts_text, int),
-                account_weight_grid=_parse_grid(account_weight_text, float),
-                ridge_alpha=float(ridge_alpha),
-                transaction_cost_bps=float(transaction_cost_bps),
-            )
-            run, artifacts = backtest_service.run_walk_forward(config, feature_rows)
-            post_attribution = build_post_attribution(prepared_posts)
-            account_attribution = build_account_attribution(post_attribution)
-            predicted_sessions = {
-                session_date
-                for session_date in pd.to_datetime(artifacts["predictions"]["signal_session_date"], errors="coerce").dropna().dt.normalize().tolist()
-            }
-            post_attribution = post_attribution.loc[
-                pd.to_datetime(post_attribution["signal_session_date"], errors="coerce").dt.normalize().isin(predicted_sessions)
-            ].reset_index(drop=True)
-            account_attribution = account_attribution.loc[
-                pd.to_datetime(account_attribution["signal_session_date"], errors="coerce").dt.normalize().isin(predicted_sessions)
-            ].reset_index(drop=True)
-            experiment_store.save_run(
-                run=run,
-                config=artifacts["config"],
-                trades=artifacts["trades"],
-                predictions=artifacts["predictions"],
-                windows=artifacts["windows"],
-                importance=artifacts["importance"],
-                model_artifact=artifacts["model_artifact"],
-                feature_contributions=artifacts["feature_contributions"],
-                post_attribution=post_attribution,
-                account_attribution=account_attribution,
-                benchmarks=artifacts["benchmarks"],
-                diagnostics=artifacts["diagnostics"],
-                benchmark_curves=artifacts["benchmark_curves"],
-                leakage_audit=artifacts["leakage_audit"],
-            )
-        st.success(f"Saved run `{run.run_id}`.")
+            normalized_target_asset = str(selected_target_asset).upper()
+            target_feature_version = "v1" if normalized_target_asset == "SPY" else "asset-v1"
+            try:
+                feature_rows, attribution_posts = _build_model_target_bundle(
+                    store=store,
+                    feature_service=feature_service,
+                    posts=posts,
+                    spy_market=spy,
+                    tracked_accounts=tracked_accounts,
+                    llm_enabled=llm_enabled,
+                    target_asset=normalized_target_asset,
+                    feature_version=target_feature_version,
+                )
+                store.save_frame(
+                    "session_features_latest",
+                    feature_rows,
+                    metadata={
+                        "llm_enabled": llm_enabled,
+                        "row_count": int(len(feature_rows)),
+                        "target_asset": normalized_target_asset,
+                        "feature_version": target_feature_version,
+                    },
+                )
+                config = ModelRunConfig(
+                    run_name=run_name,
+                    target_asset=normalized_target_asset,
+                    feature_version=target_feature_version,
+                    llm_enabled=llm_enabled,
+                    train_window=int(train_window),
+                    validation_window=int(validation_window),
+                    test_window=int(test_window),
+                    step_size=int(step_size),
+                    threshold_grid=_parse_grid(threshold_text, float),
+                    minimum_signal_grid=_parse_grid(min_posts_text, int),
+                    account_weight_grid=_parse_grid(account_weight_text, float),
+                    ridge_alpha=float(ridge_alpha),
+                    transaction_cost_bps=float(transaction_cost_bps),
+                )
+                run, artifacts = backtest_service.run_walk_forward(config, feature_rows)
+                post_attribution = build_post_attribution(attribution_posts)
+                account_attribution = build_account_attribution(post_attribution)
+                predicted_sessions = {
+                    session_date
+                    for session_date in pd.to_datetime(
+                        artifacts["predictions"]["signal_session_date"],
+                        errors="coerce",
+                    ).dropna().dt.normalize().tolist()
+                }
+                post_attribution = post_attribution.loc[
+                    pd.to_datetime(post_attribution["signal_session_date"], errors="coerce").dt.normalize().isin(predicted_sessions)
+                ].reset_index(drop=True)
+                account_attribution = account_attribution.loc[
+                    pd.to_datetime(account_attribution["signal_session_date"], errors="coerce").dt.normalize().isin(predicted_sessions)
+                ].reset_index(drop=True)
+                experiment_store.save_run(
+                    run=run,
+                    config=artifacts["config"],
+                    trades=artifacts["trades"],
+                    predictions=artifacts["predictions"],
+                    windows=artifacts["windows"],
+                    importance=artifacts["importance"],
+                    model_artifact=artifacts["model_artifact"],
+                    feature_contributions=artifacts["feature_contributions"],
+                    post_attribution=post_attribution,
+                    account_attribution=account_attribution,
+                    benchmarks=artifacts["benchmarks"],
+                    diagnostics=artifacts["diagnostics"],
+                    benchmark_curves=artifacts["benchmark_curves"],
+                    leakage_audit=artifacts["leakage_audit"],
+                )
+            except RuntimeError as exc:
+                st.error(str(exc))
+                return
+        st.success(f"Saved run `{run.run_id}` for `{normalized_target_asset}`.")
 
     latest_features = store.read_frame("session_features_latest")
     if not latest_features.empty:
@@ -1570,12 +1690,13 @@ def render_models_view(
         return
 
     leaderboard = runs.copy()
+    leaderboard["target_asset"] = leaderboard["target_asset"].fillna("SPY").replace("", "SPY")
     leaderboard["total_return"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("total_return", 0.0))
     leaderboard["sharpe"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("sharpe", 0.0))
     leaderboard["sortino"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("sortino", 0.0))
     leaderboard["max_drawdown"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("max_drawdown", 0.0))
     leaderboard["robust_score"] = leaderboard["metrics_json"].map(lambda metrics: metrics.get("robust_score", 0.0))
-    keep = ["run_id", "run_name", "created_at", "total_return", "sharpe", "sortino", "max_drawdown", "robust_score"]
+    keep = ["run_id", "run_name", "target_asset", "created_at", "total_return", "sharpe", "sortino", "max_drawdown", "robust_score"]
     st.markdown("**Run leaderboard**")
     st.dataframe(
         leaderboard[keep].sort_values("robust_score", ascending=False),
@@ -1588,6 +1709,7 @@ def render_models_view(
     if loaded is None:
         st.warning("The selected run could not be loaded.")
         return
+    st.caption(f"Selected run target asset: `{_comparison_settings(loaded).get('target_asset', 'SPY')}`")
 
     feature_contributions = loaded["feature_contributions"]
     if feature_contributions.empty:
@@ -1595,14 +1717,22 @@ def render_models_view(
     post_attribution = loaded["post_attribution"]
     account_attribution = loaded["account_attribution"]
     if post_attribution.empty or account_attribution.empty:
-        fallback_posts = feature_service.prepare_session_posts(
-            posts=posts,
-            market_calendar=spy,
-            tracked_accounts=tracked_accounts,
-            llm_enabled=bool(loaded["model_artifact"].metadata.get("llm_enabled", False)),
-        )
-        post_attribution = build_post_attribution(fallback_posts)
-        account_attribution = build_account_attribution(post_attribution)
+        try:
+            _, fallback_posts = _build_model_target_bundle(
+                store=store,
+                feature_service=feature_service,
+                posts=posts,
+                spy_market=spy,
+                tracked_accounts=tracked_accounts,
+                llm_enabled=bool(loaded["model_artifact"].metadata.get("llm_enabled", False)),
+                target_asset=_comparison_settings(loaded).get("target_asset", "SPY"),
+                feature_version=str(loaded.get("config", {}).get("feature_version", "v1")),
+            )
+            post_attribution = build_post_attribution(fallback_posts)
+            account_attribution = build_account_attribution(post_attribution)
+        except RuntimeError:
+            post_attribution = pd.DataFrame()
+            account_attribution = pd.DataFrame()
 
     _metric_row(loaded["metrics"])
     _render_equity_curve(loaded["trades"], title="Walk-forward out-of-sample equity curve")
@@ -1767,7 +1897,7 @@ def render_live_monitor(
             )
         st.success("Polling refresh complete.")
 
-    model_bundle = experiment_store.load_latest_model_artifact()
+    model_bundle = experiment_store.load_latest_model_artifact(target_asset="SPY")
     if model_bundle is None:
         st.info("Run a model in the Models & Backtests page to enable live predictions.")
         return
@@ -1790,6 +1920,7 @@ def render_live_monitor(
         llm_enabled=bool(artifact.metadata.get("llm_enabled", False)),
         prepared_posts=prepared_posts,
     )
+    feature_rows["target_asset"] = "SPY"
     predictions = model_service.predict(artifact, feature_rows)
     feature_contributions = model_service.explain_predictions(artifact, predictions)
     post_attribution = build_post_attribution(prepared_posts)
@@ -1803,6 +1934,7 @@ def render_live_monitor(
             {
                 "signal_session_date": latest["signal_session_date"],
                 "next_session_date": latest["next_session_date"],
+                "target_asset": "SPY",
                 "expected_return_score": latest["expected_return_score"],
                 "feature_version": latest["feature_version"],
                 "model_version": latest["model_version"],
@@ -1829,6 +1961,10 @@ def render_live_monitor(
     )
 
     history = store.read_frame("prediction_snapshots")
+    if not history.empty:
+        if "target_asset" not in history.columns:
+            history["target_asset"] = "SPY"
+        history = history.loc[history["target_asset"].astype(str).str.upper() == "SPY"].copy()
     if not history.empty:
         history = history.sort_values("generated_at")
         fig = go.Figure()
@@ -1884,20 +2020,20 @@ def render_historical_replay_view(
         return
 
     run_config = _bundle_to_run_config(loaded)
-    prepared_posts = feature_service.prepare_session_posts(
-        posts=posts,
-        market_calendar=spy,
-        tracked_accounts=tracked_accounts,
-        llm_enabled=run_config.llm_enabled,
-    )
-    feature_rows = feature_service.build_session_dataset(
-        posts=posts,
-        spy_market=spy,
-        tracked_accounts=tracked_accounts,
-        feature_version=run_config.feature_version,
-        llm_enabled=run_config.llm_enabled,
-        prepared_posts=prepared_posts,
-    )
+    try:
+        feature_rows, attribution_posts = _build_model_target_bundle(
+            store=store,
+            feature_service=feature_service,
+            posts=posts,
+            spy_market=spy,
+            tracked_accounts=tracked_accounts,
+            llm_enabled=run_config.llm_enabled,
+            target_asset=run_config.target_asset,
+            feature_version=run_config.feature_version,
+        )
+    except RuntimeError as exc:
+        st.warning(str(exc))
+        return
     if run_config.start_date:
         feature_rows = feature_rows.loc[feature_rows["signal_session_date"] >= pd.Timestamp(run_config.start_date)].copy()
     if run_config.end_date:
@@ -1924,8 +2060,8 @@ def render_historical_replay_view(
     replay_prediction = replay["prediction"].iloc[0]
     replay_feature_contributions = replay["feature_contributions"]
     session_post_attribution = build_post_attribution(
-        prepared_posts.loc[
-            pd.to_datetime(prepared_posts["session_date"], errors="coerce").dt.normalize()
+        attribution_posts.loc[
+            pd.to_datetime(attribution_posts["session_date"], errors="coerce").dt.normalize()
             == pd.Timestamp(replay_prediction["signal_session_date"]).normalize()
         ].copy(),
     )
@@ -1934,11 +2070,12 @@ def render_historical_replay_view(
     full_history_match = _filter_for_session(loaded["predictions"], _normalize_session_date(replay_prediction["signal_session_date"]))
     full_history_row = full_history_match.iloc[0] if not full_history_match.empty else None
 
-    metric_cols = st.columns(4)
-    metric_cols[0].metric("Replay session", f"{pd.Timestamp(replay_prediction['signal_session_date']):%Y-%m-%d}")
-    metric_cols[1].metric("Replay score", f"{float(replay_prediction['expected_return_score']):+.3%}")
-    metric_cols[2].metric("Replay confidence", f"{float(replay_prediction['prediction_confidence']):.2f}")
-    metric_cols[3].metric("Suggested stance", str(replay_prediction["suggested_stance"]))
+    metric_cols = st.columns(5)
+    metric_cols[0].metric("Target asset", str(run_config.target_asset).upper())
+    metric_cols[1].metric("Replay session", f"{pd.Timestamp(replay_prediction['signal_session_date']):%Y-%m-%d}")
+    metric_cols[2].metric("Replay score", f"{float(replay_prediction['expected_return_score']):+.3%}")
+    metric_cols[3].metric("Replay confidence", f"{float(replay_prediction['prediction_confidence']):.2f}")
+    metric_cols[4].metric("Suggested stance", str(replay_prediction["suggested_stance"]))
 
     if full_history_row is not None:
         delta = float(replay_prediction["expected_return_score"] - full_history_row["expected_return_score"])
@@ -1954,6 +2091,7 @@ def render_historical_replay_view(
     st.json(
         {
             "template_run_id": selected_run_id,
+            "target_asset": str(run_config.target_asset).upper(),
             "history_start": str(pd.Timestamp(replay["history_start"]).date()),
             "history_end": str(pd.Timestamp(replay["history_end"]).date()),
             "training_rows_used": replay["training_rows_used"],
@@ -1993,7 +2131,7 @@ def main() -> None:
     st.title(settings.title)
     st.caption(
         "Single-user web workbench for ingesting Trump-related social data, discovering influential mention accounts, "
-        "building next-session SPY features, and evaluating long/flat strategies with walk-forward testing.",
+        "building next-session features for SPY and watchlist assets, and evaluating long/flat strategies with walk-forward testing.",
     )
 
     store = DuckDBStore(settings)


### PR DESCRIPTION
## Summary
- add target-asset-aware model configs, run persistence, and artifact lookup for SPY and non-SPY runs
- let Models & Backtests train asset-specific datasets, compare cross-asset runs, and preserve target-aware explanations
- update Historical Replay and live monitoring so replay follows the selected asset while the live monitor stays pinned to the newest SPY model

## Why
- issue #7 requires the modeling pipeline to treat SPY and selected assets as first-class prediction targets without leaking future information
- saved runs and comparison views need explicit target-asset metadata so cross-asset experiments remain interpretable

## Validation
- `./.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python -m coverage run -m unittest discover -s tests`
- `./.venv/bin/python -m coverage report -m`
- `./.venv/bin/streamlit run app.py --server.headless true --server.port 8509`

## Issue
Refs #7
