### PR TITLE
[codex] Add live multi-asset decision console

### DIFF
--- a/tests/test_config_contracts.py
+++ b/tests/test_config_contracts.py
@@ -10,6 +10,8 @@ from trump_workbench.config import APP_TITLE, AppSettings, CURRENT_TERM_START, D
 from trump_workbench.contracts import (
     BacktestRun,
     LinearModelArtifact,
+    LiveMonitorConfig,
+    LiveMonitorPinnedRun,
     ModelRunConfig,
     NormalizedPost,
     PredictionSnapshot,
@@ -123,6 +125,18 @@ class ConfigAndContractsTests(unittest.TestCase):
             train_rows=10,
             metadata={"source": "unit-test"},
         )
+        live_config = LiveMonitorConfig(
+            fallback_mode="FLAT",
+            pinned_runs=[
+                LiveMonitorPinnedRun(
+                    asset_symbol="SPY",
+                    run_id="run-1",
+                    run_name="SPY baseline",
+                    model_version="linear-v1",
+                    pinned_at="2026-04-14T01:02:03",
+                ),
+            ],
+        )
 
         self.assertEqual(post.to_dict()["post_id"], "1")
         self.assertEqual(tracked.to_dict()["status"], "active")
@@ -132,6 +146,7 @@ class ConfigAndContractsTests(unittest.TestCase):
         self.assertEqual(snapshot.to_dict()["target_asset"], "SPY")
         self.assertEqual(snapshot.to_dict()["stance"], "long")
         self.assertEqual(backtest_run.to_dict()["run_id"], "run-1")
+        self.assertEqual(LiveMonitorConfig.from_dict(live_config.to_dict()).pinned_runs[0].asset_symbol, "SPY")
         self.assertEqual(LinearModelArtifact.from_dict(artifact.to_dict()).feature_names, ["x1"])
 
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from trump_workbench.config import AppSettings
-from trump_workbench.contracts import BacktestRun
+from trump_workbench.contracts import BacktestRun, LiveMonitorConfig, LiveMonitorPinnedRun
 from trump_workbench.experiments import ExperimentStore
 from trump_workbench.storage import DuckDBStore
 
@@ -160,6 +160,73 @@ class ExperimentStoreTests(unittest.TestCase):
             ),
             0.02,
         )
+
+        live_config = LiveMonitorConfig(
+            fallback_mode="FLAT",
+            pinned_runs=[
+                LiveMonitorPinnedRun(
+                    asset_symbol="SPY",
+                    run_id="run-123",
+                    run_name="unit-test-run",
+                    model_version="linear-v1",
+                    pinned_at="2026-04-14T04:00:00",
+                ),
+            ],
+        )
+        config_path = self.experiments.save_live_monitor_config(live_config)
+        self.assertTrue(config_path.exists())
+        loaded_config = self.experiments.load_live_monitor_config()
+        self.assertIsNotNone(loaded_config)
+        assert loaded_config is not None
+        self.assertEqual(loaded_config.fallback_mode, "FLAT")
+        self.assertEqual(loaded_config.pinned_runs[0].asset_symbol, "SPY")
+
+        asset_snapshots = pd.DataFrame(
+            {
+                "generated_at": [pd.Timestamp("2025-02-03 16:00:00"), pd.Timestamp("2025-02-03 16:00:00")],
+                "signal_session_date": [pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-03")],
+                "next_session_date": [pd.Timestamp("2025-02-04"), pd.Timestamp("2025-02-04")],
+                "asset_symbol": ["SPY", "QQQ"],
+                "run_id": ["run-123", "run-qqq"],
+                "run_name": ["unit-test-run", "unit-test-run"],
+                "feature_version": ["v1", "asset-v1"],
+                "model_version": ["linear-v1", "linear-qqq-v1"],
+                "expected_return_score": [0.01, 0.02],
+                "confidence": [0.6, 0.7],
+                "threshold": [0.001, 0.001],
+                "min_post_count": [1, 1],
+                "post_count": [5, 6],
+                "qualifies": [True, True],
+                "eligible_rank": [2, 1],
+                "is_winner": [False, True],
+                "decision_source": ["eligible", "eligible"],
+                "stance": ["FLAT", "LONG QQQ NEXT SESSION"],
+            },
+        )
+        decision_snapshots = pd.DataFrame(
+            {
+                "generated_at": [pd.Timestamp("2025-02-03 16:00:00")],
+                "signal_session_date": [pd.Timestamp("2025-02-03")],
+                "winning_asset": ["QQQ"],
+                "winning_run_id": ["run-qqq"],
+                "decision_source": ["eligible"],
+                "fallback_mode": ["SPY"],
+                "stance": ["LONG QQQ NEXT SESSION"],
+                "eligible_asset_count": [2],
+                "runner_up_asset": ["SPY"],
+                "winner_score": [0.02],
+                "runner_up_score": [0.01],
+            },
+        )
+        self.experiments.save_live_asset_snapshots(asset_snapshots)
+        self.experiments.save_live_asset_snapshots(asset_snapshots)
+        self.experiments.save_live_decision_snapshots(decision_snapshots)
+        self.experiments.save_live_decision_snapshots(decision_snapshots)
+        stored_asset_snapshots = self.store.read_frame("live_asset_snapshots")
+        stored_decision_snapshots = self.store.read_frame("live_decision_snapshots")
+        self.assertEqual(len(stored_asset_snapshots), 2)
+        self.assertEqual(len(stored_decision_snapshots), 1)
+        self.assertEqual(stored_decision_snapshots.iloc[0]["winning_asset"], "QQQ")
 
         saved.benchmarks_path.unlink()
         saved.diagnostics_path.unlink()

--- a/tests/test_live_monitor.py
+++ b/tests/test_live_monitor.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from trump_workbench.backtesting import BacktestService
+from trump_workbench.config import AppSettings
+from trump_workbench.contracts import BacktestRun, LiveMonitorConfig, LiveMonitorPinnedRun, ModelRunConfig
+from trump_workbench.discovery import DiscoveryService
+from trump_workbench.enrichment import LLMEnrichmentService
+from trump_workbench.experiments import ExperimentStore
+from trump_workbench.explanations import build_account_attribution, build_post_attribution
+from trump_workbench.features import FeatureService
+from trump_workbench.ingestion import XCsvAdapter
+from trump_workbench.live_monitor import rank_live_asset_snapshots, seed_live_monitor_config, validate_live_monitor_config
+from trump_workbench.modeling import ModelService
+from trump_workbench.storage import DuckDBStore
+from trump_workbench.ui import _build_live_monitor_state, _build_live_runner_up_frame
+
+
+class LiveMonitorLogicTests(unittest.TestCase):
+    def test_seed_live_monitor_config_uses_latest_run_per_asset(self) -> None:
+        runs = pd.DataFrame(
+            [
+                {
+                    "run_id": "qqq-new",
+                    "run_name": "QQQ newer",
+                    "target_asset": "QQQ",
+                    "created_at": pd.Timestamp("2026-04-14 10:00:00"),
+                },
+                {
+                    "run_id": "spy-run",
+                    "run_name": "SPY baseline",
+                    "target_asset": "SPY",
+                    "created_at": pd.Timestamp("2026-04-14 09:00:00"),
+                },
+                {
+                    "run_id": "qqq-old",
+                    "run_name": "QQQ older",
+                    "target_asset": "QQQ",
+                    "created_at": pd.Timestamp("2026-04-13 09:00:00"),
+                },
+            ],
+        )
+
+        config = seed_live_monitor_config(runs)
+
+        self.assertIsNotNone(config)
+        assert config is not None
+        self.assertEqual(config.pinned_runs[0].asset_symbol, "SPY")
+        self.assertEqual(config.pinned_runs[1].run_id, "qqq-new")
+
+    def test_validate_live_monitor_config_rejects_missing_spy_duplicate_assets_and_mismatch(self) -> None:
+        runs = pd.DataFrame(
+            [
+                {"run_id": "spy-run", "run_name": "SPY", "target_asset": "SPY"},
+                {"run_id": "qqq-run", "run_name": "QQQ", "target_asset": "QQQ"},
+            ],
+        )
+        bad_config = LiveMonitorConfig(
+            fallback_mode="INVALID",
+            pinned_runs=[
+                LiveMonitorPinnedRun(asset_symbol="QQQ", run_id="qqq-run"),
+                LiveMonitorPinnedRun(asset_symbol="QQQ", run_id="spy-run"),
+            ],
+        )
+
+        errors = validate_live_monitor_config(bad_config, runs)
+
+        self.assertTrue(any("Fallback mode" in error for error in errors))
+        self.assertTrue(any("Only one pinned run" in error for error in errors))
+        self.assertTrue(any("Exactly one pinned `SPY`" in error for error in errors))
+
+    def test_rank_live_asset_snapshots_multiple_assets_choose_highest_eligible_score(self) -> None:
+        board, decision = rank_live_asset_snapshots(
+            pd.DataFrame(
+                [
+                    {
+                        "generated_at": pd.Timestamp("2026-04-14 10:00:00"),
+                        "signal_session_date": pd.Timestamp("2026-04-14"),
+                        "next_session_date": pd.Timestamp("2026-04-15"),
+                        "asset_symbol": "SPY",
+                        "run_id": "spy-run",
+                        "run_name": "SPY",
+                        "feature_version": "v1",
+                        "model_version": "spy-model",
+                        "expected_return_score": 0.010,
+                        "confidence": 0.60,
+                        "threshold": 0.001,
+                        "min_post_count": 1,
+                        "post_count": 5,
+                    },
+                    {
+                        "generated_at": pd.Timestamp("2026-04-14 10:00:00"),
+                        "signal_session_date": pd.Timestamp("2026-04-14"),
+                        "next_session_date": pd.Timestamp("2026-04-15"),
+                        "asset_symbol": "QQQ",
+                        "run_id": "qqq-run",
+                        "run_name": "QQQ",
+                        "feature_version": "asset-v1",
+                        "model_version": "qqq-model",
+                        "expected_return_score": 0.015,
+                        "confidence": 0.55,
+                        "threshold": 0.001,
+                        "min_post_count": 1,
+                        "post_count": 5,
+                    },
+                ],
+            ),
+            fallback_mode="SPY",
+        )
+
+        self.assertEqual(decision.iloc[0]["winning_asset"], "QQQ")
+        self.assertEqual(decision.iloc[0]["decision_source"], "eligible")
+        self.assertTrue(bool(board.loc[board["asset_symbol"] == "QQQ", "is_winner"].iloc[0]))
+
+    def test_rank_live_asset_snapshots_only_spy_qualifies(self) -> None:
+        board, decision = rank_live_asset_snapshots(
+            pd.DataFrame(
+                [
+                    {
+                        "generated_at": pd.Timestamp("2026-04-14 10:00:00"),
+                        "signal_session_date": pd.Timestamp("2026-04-14"),
+                        "next_session_date": pd.Timestamp("2026-04-15"),
+                        "asset_symbol": "SPY",
+                        "run_id": "spy-run",
+                        "run_name": "SPY",
+                        "feature_version": "v1",
+                        "model_version": "spy-model",
+                        "expected_return_score": 0.004,
+                        "confidence": 0.60,
+                        "threshold": 0.001,
+                        "min_post_count": 1,
+                        "post_count": 5,
+                    },
+                    {
+                        "generated_at": pd.Timestamp("2026-04-14 10:00:00"),
+                        "signal_session_date": pd.Timestamp("2026-04-14"),
+                        "next_session_date": pd.Timestamp("2026-04-15"),
+                        "asset_symbol": "QQQ",
+                        "run_id": "qqq-run",
+                        "run_name": "QQQ",
+                        "feature_version": "asset-v1",
+                        "model_version": "qqq-model",
+                        "expected_return_score": 0.0005,
+                        "confidence": 0.55,
+                        "threshold": 0.001,
+                        "min_post_count": 1,
+                        "post_count": 5,
+                    },
+                ],
+            ),
+            fallback_mode="SPY",
+        )
+
+        self.assertEqual(decision.iloc[0]["winning_asset"], "SPY")
+        self.assertEqual(decision.iloc[0]["decision_source"], "eligible")
+        self.assertTrue(bool(board.loc[board["asset_symbol"] == "SPY", "qualifies"].iloc[0]))
+        self.assertFalse(bool(board.loc[board["asset_symbol"] == "QQQ", "qualifies"].iloc[0]))
+
+    def test_rank_live_asset_snapshots_fallback_spy_when_nothing_qualifies(self) -> None:
+        board, decision = rank_live_asset_snapshots(
+            pd.DataFrame(
+                [
+                    {
+                        "generated_at": pd.Timestamp("2026-04-14 10:00:00"),
+                        "signal_session_date": pd.Timestamp("2026-04-14"),
+                        "next_session_date": pd.Timestamp("2026-04-15"),
+                        "asset_symbol": "SPY",
+                        "run_id": "spy-run",
+                        "run_name": "SPY",
+                        "feature_version": "v1",
+                        "model_version": "spy-model",
+                        "expected_return_score": -0.001,
+                        "confidence": 0.60,
+                        "threshold": 0.005,
+                        "min_post_count": 10,
+                        "post_count": 1,
+                    },
+                    {
+                        "generated_at": pd.Timestamp("2026-04-14 10:00:00"),
+                        "signal_session_date": pd.Timestamp("2026-04-14"),
+                        "next_session_date": pd.Timestamp("2026-04-15"),
+                        "asset_symbol": "QQQ",
+                        "run_id": "qqq-run",
+                        "run_name": "QQQ",
+                        "feature_version": "asset-v1",
+                        "model_version": "qqq-model",
+                        "expected_return_score": 0.001,
+                        "confidence": 0.55,
+                        "threshold": 0.005,
+                        "min_post_count": 10,
+                        "post_count": 1,
+                    },
+                ],
+            ),
+            fallback_mode="SPY",
+        )
+
+        self.assertEqual(decision.iloc[0]["winning_asset"], "SPY")
+        self.assertEqual(decision.iloc[0]["decision_source"], "fallback")
+        self.assertEqual(decision.iloc[0]["stance"], "LONG SPY NEXT SESSION")
+        self.assertTrue(bool(board.loc[board["asset_symbol"] == "SPY", "is_winner"].iloc[0]))
+
+    def test_rank_live_asset_snapshots_fallback_flat_when_nothing_qualifies(self) -> None:
+        board, decision = rank_live_asset_snapshots(
+            pd.DataFrame(
+                [
+                    {
+                        "generated_at": pd.Timestamp("2026-04-14 10:00:00"),
+                        "signal_session_date": pd.Timestamp("2026-04-14"),
+                        "next_session_date": pd.Timestamp("2026-04-15"),
+                        "asset_symbol": "SPY",
+                        "run_id": "spy-run",
+                        "run_name": "SPY",
+                        "feature_version": "v1",
+                        "model_version": "spy-model",
+                        "expected_return_score": 0.0005,
+                        "confidence": 0.60,
+                        "threshold": 0.005,
+                        "min_post_count": 10,
+                        "post_count": 1,
+                    },
+                ],
+            ),
+            fallback_mode="FLAT",
+        )
+
+        self.assertEqual(decision.iloc[0]["winning_asset"], "")
+        self.assertEqual(decision.iloc[0]["decision_source"], "fallback")
+        self.assertEqual(decision.iloc[0]["stance"], "FLAT")
+        self.assertFalse(bool(board["is_winner"].any()))
+
+
+class LiveMonitorStateIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.settings = AppSettings(base_dir=Path(self.temp_dir.name))
+        self.store = DuckDBStore(self.settings)
+        self.discovery = DiscoveryService()
+        self.enrichment = LLMEnrichmentService(self.store)
+        self.features = FeatureService(self.enrichment)
+        self.model_service = ModelService()
+        self.backtests = BacktestService(self.model_service)
+        self.experiments = ExperimentStore(self.store)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _build_market(self) -> pd.DataFrame:
+        dates = pd.bdate_range("2025-02-03", periods=140)
+        opens = []
+        closes = []
+        volumes = []
+        price = 100.0
+        for idx, _ in enumerate(dates):
+            daily_signal = 0.004 if idx % 4 in (0, 1) else -0.002
+            open_price = price
+            close_price = open_price * (1.0 + daily_signal)
+            opens.append(open_price)
+            closes.append(close_price)
+            volumes.append(1_000_000 + idx * 1_000)
+            price = close_price
+        return pd.DataFrame(
+            {
+                "trade_date": dates,
+                "open": opens,
+                "high": [value * 1.01 for value in closes],
+                "low": [value * 0.99 for value in opens],
+                "close": closes,
+                "volume": volumes,
+            },
+        )
+
+    def _build_asset_market(self, symbols: list[str]) -> pd.DataFrame:
+        base = self._build_market()
+        frames: list[pd.DataFrame] = []
+        for offset, symbol in enumerate(symbols, start=1):
+            frame = base.copy()
+            scale = 1.0 + offset * 0.08
+            frame["symbol"] = symbol
+            frame["open"] = frame["open"] * scale
+            frame["high"] = frame["high"] * scale
+            frame["low"] = frame["low"] * scale
+            frame["close"] = frame["close"] * scale
+            frame["volume"] = frame["volume"] + offset * 10_000
+            frames.append(frame)
+        return pd.concat(frames, ignore_index=True)
+
+    def _build_x_csv(self) -> bytes:
+        rows = ["timestamp,text,url,is_retweet,author_handle,author_name,author_id,mentions_trump,replies_count,reblogs_count,favourites_count"]
+        dates = pd.bdate_range("2025-02-03", periods=140)
+        for idx, date in enumerate(dates[:-1]):
+            positive = (idx + 1) % 4 in (0, 1)
+            text = (
+                "Trump says Nasdaq and big tech are leading the market higher."
+                if positive
+                else "Trump trade pressure is weighing on energy and financials."
+            )
+            handle = "macroalpha" if positive else "policybeta"
+            row = ",".join(
+                [
+                    f"{date:%Y-%m-%d}T15:30:00-05:00",
+                    text,
+                    f"https://x.com/{handle}/status/{1000 + idx}",
+                    "false",
+                    handle,
+                    handle.title(),
+                    handle,
+                    "true",
+                    str(10 + idx % 5),
+                    str(20 + idx % 7),
+                    str(50 + idx % 11),
+                ],
+            )
+            rows.append(row)
+        return "\n".join(rows).encode("utf-8")
+
+    def test_build_live_monitor_state_generates_ranked_board_and_asset_specific_explanations(self) -> None:
+        adapter = XCsvAdapter(
+            settings=self.settings,
+            name="synthetic-x",
+            provenance="unit-test",
+            raw_bytes=self._build_x_csv(),
+        )
+        posts, _ = adapter.fetch_history()
+        tracked, _ = self.discovery.refresh_accounts(posts, pd.DataFrame(), as_of=posts["post_timestamp"].max(), auto_include_top_n=2)
+        spy_market = self._build_market()
+        asset_market = self._build_asset_market(["QQQ"])
+        asset_universe = pd.DataFrame(
+            [
+                {
+                    "symbol": "QQQ",
+                    "display_name": "Invesco QQQ Trust",
+                    "asset_type": "etf",
+                    "source": "core_etf",
+                },
+            ],
+        )
+        self.store.save_frame("asset_universe", asset_universe, metadata={"row_count": 1})
+        self.store.save_frame("asset_daily", asset_market, metadata={"row_count": int(len(asset_market))})
+
+        prepared_posts = self.features.prepare_session_posts(posts, spy_market, tracked, llm_enabled=True)
+        spy_dataset = self.features.build_session_dataset(
+            posts=posts,
+            spy_market=spy_market,
+            tracked_accounts=tracked,
+            feature_version="v1",
+            llm_enabled=True,
+            prepared_posts=prepared_posts,
+        )
+        spy_dataset["target_asset"] = "SPY"
+        asset_post_mappings = self.features.build_asset_post_mappings(prepared_posts, asset_universe, llm_enabled=True)
+        qqq_dataset = self.features.build_asset_session_dataset(
+            asset_post_mappings=asset_post_mappings,
+            asset_market=asset_market,
+            feature_version="asset-v1",
+            llm_enabled=True,
+            asset_universe=asset_universe,
+        )
+        qqq_dataset = qqq_dataset.loc[qqq_dataset["asset_symbol"] == "QQQ"].copy()
+        qqq_dataset["target_asset"] = "QQQ"
+
+        spy_config = ModelRunConfig(
+            run_name="spy-live-run",
+            target_asset="SPY",
+            llm_enabled=True,
+            train_window=60,
+            validation_window=20,
+            test_window=20,
+            step_size=20,
+            threshold_grid=(0.0, 0.001),
+            minimum_signal_grid=(1, 2),
+            account_weight_grid=(0.5, 1.0),
+        )
+        spy_run, spy_artifacts = self.backtests.run_walk_forward(spy_config, spy_dataset)
+        spy_saved_run = BacktestRun(
+            run_id=spy_run.run_id,
+            run_name=spy_run.run_name,
+            target_asset="SPY",
+            config_hash=spy_run.config_hash,
+            train_window=spy_run.train_window,
+            validation_window=spy_run.validation_window,
+            test_window=spy_run.test_window,
+            metrics=spy_run.metrics,
+            selected_params={"threshold": 0.50, "min_post_count": 999, "account_weight": 1.0},
+        )
+        self.experiments.save_run(
+            run=spy_saved_run,
+            config=spy_artifacts["config"],
+            trades=spy_artifacts["trades"],
+            predictions=spy_artifacts["predictions"],
+            windows=spy_artifacts["windows"],
+            importance=spy_artifacts["importance"],
+            model_artifact=spy_artifacts["model_artifact"],
+            feature_contributions=spy_artifacts["feature_contributions"],
+            post_attribution=build_post_attribution(prepared_posts),
+            account_attribution=build_account_attribution(build_post_attribution(prepared_posts)),
+            benchmarks=spy_artifacts["benchmarks"],
+            diagnostics=spy_artifacts["diagnostics"],
+            benchmark_curves=spy_artifacts["benchmark_curves"],
+            leakage_audit=spy_artifacts["leakage_audit"],
+        )
+
+        qqq_config = ModelRunConfig(
+            run_name="qqq-live-run",
+            target_asset="QQQ",
+            feature_version="asset-v1",
+            llm_enabled=True,
+            train_window=60,
+            validation_window=20,
+            test_window=20,
+            step_size=20,
+            threshold_grid=(0.0, 0.001),
+            minimum_signal_grid=(1, 2),
+            account_weight_grid=(0.5, 1.0),
+        )
+        qqq_run, qqq_artifacts = self.backtests.run_walk_forward(qqq_config, qqq_dataset)
+        qqq_saved_run = BacktestRun(
+            run_id=qqq_run.run_id,
+            run_name=qqq_run.run_name,
+            target_asset="QQQ",
+            config_hash=qqq_run.config_hash,
+            train_window=qqq_run.train_window,
+            validation_window=qqq_run.validation_window,
+            test_window=qqq_run.test_window,
+            metrics=qqq_run.metrics,
+            selected_params={"threshold": -1.0, "min_post_count": 0, "account_weight": 1.0},
+        )
+        qqq_post_attribution = build_post_attribution(asset_post_mappings.loc[asset_post_mappings["asset_symbol"] == "QQQ"].copy())
+        self.experiments.save_run(
+            run=qqq_saved_run,
+            config=qqq_artifacts["config"],
+            trades=qqq_artifacts["trades"],
+            predictions=qqq_artifacts["predictions"],
+            windows=qqq_artifacts["windows"],
+            importance=qqq_artifacts["importance"],
+            model_artifact=qqq_artifacts["model_artifact"],
+            feature_contributions=qqq_artifacts["feature_contributions"],
+            post_attribution=qqq_post_attribution,
+            account_attribution=build_account_attribution(qqq_post_attribution),
+            benchmarks=qqq_artifacts["benchmarks"],
+            diagnostics=qqq_artifacts["diagnostics"],
+            benchmark_curves=qqq_artifacts["benchmark_curves"],
+            leakage_audit=qqq_artifacts["leakage_audit"],
+        )
+
+        live_config = LiveMonitorConfig(
+            fallback_mode="SPY",
+            pinned_runs=[
+                LiveMonitorPinnedRun(asset_symbol="SPY", run_id=spy_saved_run.run_id, run_name=spy_saved_run.run_name),
+                LiveMonitorPinnedRun(asset_symbol="QQQ", run_id=qqq_saved_run.run_id, run_name=qqq_saved_run.run_name),
+            ],
+        )
+        board, decision, explanation_lookup, warnings = _build_live_monitor_state(
+            store=self.store,
+            feature_service=self.features,
+            model_service=self.model_service,
+            experiment_store=self.experiments,
+            posts=posts,
+            spy_market=spy_market,
+            tracked_accounts=tracked,
+            config=live_config,
+            generated_at=pd.Timestamp("2026-04-14 10:00:00"),
+        )
+
+        self.assertFalse(warnings)
+        self.assertSetEqual(set(board["asset_symbol"].astype(str)), {"SPY", "QQQ"})
+        self.assertEqual(decision.iloc[0]["winning_asset"], "QQQ")
+        self.assertEqual(decision.iloc[0]["decision_source"], "eligible")
+        self.assertFalse(bool(board.loc[board["asset_symbol"] == "SPY", "qualifies"].iloc[0]))
+        self.assertTrue(bool(board.loc[board["asset_symbol"] == "QQQ", "qualifies"].iloc[0]))
+        self.assertIn("QQQ", explanation_lookup)
+        self.assertEqual(str(explanation_lookup["QQQ"]["prediction_row"]["target_asset"]), "QQQ")
+        self.assertFalse(explanation_lookup["QQQ"]["post_attribution"].empty)
+
+        runner_frame = _build_live_runner_up_frame(board, decision.iloc[0])
+        self.assertEqual(len(runner_frame), 2)
+        self.assertIn("threshold_gap", runner_frame.columns.tolist())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trump_workbench/contracts.py
+++ b/trump_workbench/contracts.py
@@ -221,6 +221,45 @@ class BacktestRun:
 
 
 @dataclass(frozen=True)
+class LiveMonitorPinnedRun:
+    asset_symbol: str
+    run_id: str
+    run_name: str = ""
+    model_version: str = ""
+    pinned_at: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "LiveMonitorPinnedRun":
+        return cls(**payload)
+
+
+@dataclass(frozen=True)
+class LiveMonitorConfig:
+    fallback_mode: str = "SPY"
+    pinned_runs: list[LiveMonitorPinnedRun] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["pinned_runs"] = [item.to_dict() for item in self.pinned_runs]
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "LiveMonitorConfig":
+        pinned_runs = [
+            LiveMonitorPinnedRun.from_dict(item)
+            for item in payload.get("pinned_runs", [])
+            if isinstance(item, dict)
+        ]
+        return cls(
+            fallback_mode=str(payload.get("fallback_mode", "SPY") or "SPY").upper(),
+            pinned_runs=pinned_runs,
+        )
+
+
+@dataclass(frozen=True)
 class LinearModelArtifact:
     model_version: str
     feature_names: list[str]

--- a/trump_workbench/experiments.py
+++ b/trump_workbench/experiments.py
@@ -6,7 +6,8 @@ from typing import Any
 
 import pandas as pd
 
-from .contracts import BacktestRun, LinearModelArtifact, SavedRunArtifacts
+from .contracts import BacktestRun, LinearModelArtifact, LiveMonitorConfig, SavedRunArtifacts
+from .live_monitor import LIVE_MONITOR_CONFIG_PATH
 from .storage import DuckDBStore
 
 
@@ -151,6 +152,15 @@ class ExperimentStore:
             return artifact, row["selected_params_json"]
         return None
 
+    def save_live_monitor_config(self, config: LiveMonitorConfig) -> Path:
+        return self.store.save_json_artifact(LIVE_MONITOR_CONFIG_PATH, config.to_dict())
+
+    def load_live_monitor_config(self) -> LiveMonitorConfig | None:
+        payload = self.store.read_json_artifact(LIVE_MONITOR_CONFIG_PATH)
+        if payload is None:
+            return None
+        return LiveMonitorConfig.from_dict(payload)
+
     def save_prediction_snapshots(self, snapshots: pd.DataFrame) -> None:
         if snapshots.empty:
             return
@@ -162,6 +172,26 @@ class ExperimentStore:
             normalized,
             dedupe_on=["signal_session_date", "generated_at", "target_asset"],
             metadata={"dataset": "prediction_snapshots"},
+        )
+
+    def save_live_asset_snapshots(self, snapshots: pd.DataFrame) -> None:
+        if snapshots.empty:
+            return
+        self.store.append_frame(
+            "live_asset_snapshots",
+            snapshots.copy(),
+            dedupe_on=["generated_at", "asset_symbol", "run_id"],
+            metadata={"dataset": "live_asset_snapshots"},
+        )
+
+    def save_live_decision_snapshots(self, snapshots: pd.DataFrame) -> None:
+        if snapshots.empty:
+            return
+        self.store.append_frame(
+            "live_decision_snapshots",
+            snapshots.copy(),
+            dedupe_on=["generated_at", "winning_asset", "winning_run_id"],
+            metadata={"dataset": "live_decision_snapshots"},
         )
 
     @staticmethod

--- a/trump_workbench/live_monitor.py
+++ b/trump_workbench/live_monitor.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .contracts import LiveMonitorConfig, LiveMonitorPinnedRun
+
+LIVE_MONITOR_CONFIG_PATH = "live_monitor/config.json"
+LIVE_ASSET_SNAPSHOT_COLUMNS = [
+    "generated_at",
+    "signal_session_date",
+    "next_session_date",
+    "asset_symbol",
+    "run_id",
+    "run_name",
+    "feature_version",
+    "model_version",
+    "expected_return_score",
+    "confidence",
+    "threshold",
+    "min_post_count",
+    "post_count",
+    "qualifies",
+    "eligible_rank",
+    "is_winner",
+    "decision_source",
+    "stance",
+]
+LIVE_DECISION_SNAPSHOT_COLUMNS = [
+    "generated_at",
+    "signal_session_date",
+    "winning_asset",
+    "winning_run_id",
+    "decision_source",
+    "fallback_mode",
+    "stance",
+    "eligible_asset_count",
+    "runner_up_asset",
+    "winner_score",
+    "runner_up_score",
+]
+VALID_FALLBACK_MODES = {"SPY", "FLAT"}
+
+
+def seed_live_monitor_config(runs: pd.DataFrame) -> LiveMonitorConfig | None:
+    if runs.empty or "run_id" not in runs.columns:
+        return None
+    normalized = runs.copy()
+    if "target_asset" not in normalized.columns:
+        normalized["target_asset"] = "SPY"
+    normalized["target_asset"] = normalized["target_asset"].fillna("SPY").astype(str).str.upper()
+    if "created_at" in normalized.columns:
+        normalized = normalized.sort_values("created_at", ascending=False)
+
+    pinned_runs: list[LiveMonitorPinnedRun] = []
+    for asset_symbol, group in normalized.groupby("target_asset", sort=False):
+        row = group.iloc[0]
+        pinned_runs.append(
+            LiveMonitorPinnedRun(
+                asset_symbol=str(asset_symbol).upper(),
+                run_id=str(row.get("run_id", "") or ""),
+                run_name=str(row.get("run_name", "") or ""),
+            ),
+        )
+    pinned_runs = sorted(pinned_runs, key=lambda item: (item.asset_symbol != "SPY", item.asset_symbol))
+    return LiveMonitorConfig(fallback_mode="SPY", pinned_runs=pinned_runs)
+
+
+def validate_live_monitor_config(config: LiveMonitorConfig | None, runs: pd.DataFrame) -> list[str]:
+    if config is None:
+        return ["Save a pinned live model set before using the decision console."]
+
+    errors: list[str] = []
+    fallback_mode = str(config.fallback_mode or "SPY").upper()
+    if fallback_mode not in VALID_FALLBACK_MODES:
+        errors.append("Fallback mode must be `SPY` or `FLAT`.")
+
+    if not config.pinned_runs:
+        errors.append("At least one pinned run is required.")
+        return errors
+
+    run_lookup = runs.copy()
+    if not run_lookup.empty:
+        if "target_asset" not in run_lookup.columns:
+            run_lookup["target_asset"] = "SPY"
+        run_lookup["target_asset"] = run_lookup["target_asset"].fillna("SPY").astype(str).str.upper()
+        run_lookup = run_lookup.set_index("run_id", drop=False)
+
+    seen_assets: set[str] = set()
+    spy_count = 0
+    for pinned in config.pinned_runs:
+        asset_symbol = str(pinned.asset_symbol or "").upper()
+        if not asset_symbol:
+            errors.append("Pinned runs must include an asset symbol.")
+            continue
+        if asset_symbol in seen_assets:
+            errors.append(f"Only one pinned run is allowed for `{asset_symbol}`.")
+            continue
+        seen_assets.add(asset_symbol)
+        if asset_symbol == "SPY":
+            spy_count += 1
+
+        run_id = str(pinned.run_id or "")
+        if not run_id:
+            errors.append(f"`{asset_symbol}` must have a saved run selected.")
+            continue
+        if run_lookup.empty or run_id not in run_lookup.index:
+            errors.append(f"Pinned run `{run_id}` for `{asset_symbol}` is not available anymore.")
+            continue
+        row_asset = str(run_lookup.loc[run_id, "target_asset"] or "SPY").upper()
+        if row_asset != asset_symbol:
+            errors.append(f"Pinned run `{run_id}` targets `{row_asset}`, not `{asset_symbol}`.")
+
+    if spy_count != 1:
+        errors.append("Exactly one pinned `SPY` run is required.")
+    return errors
+
+
+def rank_live_asset_snapshots(snapshots: pd.DataFrame, fallback_mode: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    if snapshots.empty:
+        return (
+            pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS),
+            pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS),
+        )
+
+    board = snapshots.copy()
+    for column in LIVE_ASSET_SNAPSHOT_COLUMNS:
+        if column not in board.columns:
+            board[column] = pd.NA
+    board["asset_symbol"] = board["asset_symbol"].fillna("").astype(str).str.upper()
+    board["run_id"] = board["run_id"].fillna("").astype(str)
+    board["run_name"] = board["run_name"].fillna("").astype(str)
+    board["feature_version"] = board["feature_version"].fillna("").astype(str)
+    board["model_version"] = board["model_version"].fillna("").astype(str)
+    for column in ["expected_return_score", "confidence", "threshold", "post_count"]:
+        board[column] = pd.to_numeric(board[column], errors="coerce").fillna(0.0)
+    board["min_post_count"] = pd.to_numeric(board["min_post_count"], errors="coerce").fillna(1).astype(int)
+    board["generated_at"] = pd.to_datetime(board["generated_at"], errors="coerce")
+    board["signal_session_date"] = pd.to_datetime(board["signal_session_date"], errors="coerce")
+    board["next_session_date"] = pd.to_datetime(board["next_session_date"], errors="coerce")
+    board["qualifies"] = (board["expected_return_score"] > board["threshold"]) & (board["post_count"] >= board["min_post_count"])
+    board["eligible_rank"] = pd.Series([pd.NA] * len(board), dtype="Int64")
+
+    sort_columns = ["qualifies", "expected_return_score", "confidence", "asset_symbol", "run_id"]
+    sort_ascending = [False, False, False, True, True]
+    eligible = board.loc[board["qualifies"]].sort_values(sort_columns[1:], ascending=sort_ascending[1:]).reset_index(drop=True)
+    if not eligible.empty:
+        eligible["eligible_rank"] = pd.Series(range(1, len(eligible) + 1), dtype="Int64")
+        for _, row in eligible.iterrows():
+            mask = (board["asset_symbol"] == row["asset_symbol"]) & (board["run_id"] == row["run_id"])
+            board.loc[mask, "eligible_rank"] = row["eligible_rank"]
+
+    normalized_fallback = str(fallback_mode or "SPY").upper()
+    if normalized_fallback not in VALID_FALLBACK_MODES:
+        normalized_fallback = "SPY"
+
+    winning_asset = ""
+    winning_run_id = ""
+    decision_source = "eligible" if not eligible.empty else "fallback"
+    stance = "FLAT"
+    winner_score = 0.0
+
+    if not eligible.empty:
+        winner = eligible.iloc[0]
+        winning_asset = str(winner["asset_symbol"])
+        winning_run_id = str(winner["run_id"])
+        winner_score = float(winner["expected_return_score"])
+        stance = f"LONG {winning_asset} NEXT SESSION"
+    elif normalized_fallback == "SPY":
+        spy_rows = board.loc[board["asset_symbol"] == "SPY"].sort_values(sort_columns[1:], ascending=sort_ascending[1:])
+        if not spy_rows.empty:
+            winner = spy_rows.iloc[0]
+            winning_asset = "SPY"
+            winning_run_id = str(winner["run_id"])
+            winner_score = float(winner["expected_return_score"])
+            stance = "LONG SPY NEXT SESSION"
+
+    board["decision_source"] = decision_source
+    board["is_winner"] = (board["asset_symbol"] == winning_asset) & (board["run_id"] == winning_run_id)
+    board["stance"] = np.where(board["is_winner"], stance, "FLAT")
+    board = board.sort_values(sort_columns, ascending=sort_ascending).reset_index(drop=True)
+
+    runner_up_asset = ""
+    runner_up_score = np.nan
+    if winning_asset:
+        runner_candidates = board.loc[~board["is_winner"]].sort_values(
+            ["qualifies", "expected_return_score", "confidence", "asset_symbol"],
+            ascending=[False, False, False, True],
+        )
+        if not runner_candidates.empty:
+            runner = runner_candidates.iloc[0]
+            runner_up_asset = str(runner["asset_symbol"])
+            runner_up_score = float(runner["expected_return_score"])
+
+    signal_session_date = (
+        board.loc[board["is_winner"], "signal_session_date"].iloc[0]
+        if winning_asset and board["is_winner"].any()
+        else board["signal_session_date"].max()
+    )
+    generated_at = board["generated_at"].max()
+    decision = pd.DataFrame(
+        [
+            {
+                "generated_at": generated_at,
+                "signal_session_date": signal_session_date,
+                "winning_asset": winning_asset,
+                "winning_run_id": winning_run_id,
+                "decision_source": decision_source,
+                "fallback_mode": normalized_fallback,
+                "stance": stance,
+                "eligible_asset_count": int(board["qualifies"].sum()),
+                "runner_up_asset": runner_up_asset,
+                "winner_score": float(winner_score),
+                "runner_up_score": float(runner_up_score) if pd.notna(runner_up_score) else np.nan,
+            },
+        ],
+        columns=LIVE_DECISION_SNAPSHOT_COLUMNS,
+    )
+
+    return board[LIVE_ASSET_SNAPSHOT_COLUMNS].copy(), decision
+

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -12,7 +12,7 @@ import streamlit.components.v1 as components
 
 from .backtesting import BacktestService
 from .config import AppSettings, DEFAULT_ETF_SYMBOLS
-from .contracts import MANUAL_OVERRIDE_COLUMNS, ModelRunConfig, RANKING_HISTORY_COLUMNS
+from .contracts import LiveMonitorConfig, LiveMonitorPinnedRun, MANUAL_OVERRIDE_COLUMNS, ModelRunConfig, RANKING_HISTORY_COLUMNS
 from .discovery import DiscoveryService
 from .enrichment import LLMEnrichmentService
 from .explanations import build_account_attribution, build_post_attribution
@@ -21,6 +21,13 @@ from .features import FeatureService, latest_feature_preview, map_posts_to_trade
 from .ingestion import IngestionService, TruthSocialArchiveAdapter, XCsvAdapter
 from .market import MarketDataService, build_asset_universe, build_watchlist_frame, normalize_symbols
 from .modeling import ModelService, classify_feature_family
+from .live_monitor import (
+    LIVE_ASSET_SNAPSHOT_COLUMNS,
+    LIVE_DECISION_SNAPSHOT_COLUMNS,
+    seed_live_monitor_config,
+    rank_live_asset_snapshots,
+    validate_live_monitor_config,
+)
 from .research import (
     aggregate_research_sessions,
     build_asset_comparison_chart,
@@ -133,6 +140,162 @@ def _build_model_target_bundle(
     ].copy()
     attribution_posts["target_asset"] = normalized_target
     return feature_rows.reset_index(drop=True), attribution_posts.reset_index(drop=True)
+
+
+def _live_run_option_label(run_row: pd.Series) -> str:
+    created_at = pd.to_datetime(run_row.get("created_at"), errors="coerce")
+    created_label = f"{created_at:%Y-%m-%d %H:%M}" if pd.notna(created_at) else "unknown time"
+    run_name = str(run_row.get("run_name", run_row.get("run_id", "")) or run_row.get("run_id", ""))
+    robust_score = float((run_row.get("metrics_json") or {}).get("robust_score", 0.0) or 0.0)
+    return f"{run_name} | {created_label} | robust {robust_score:+.3f}"
+
+
+def _runs_by_asset(runs: pd.DataFrame) -> dict[str, pd.DataFrame]:
+    if runs.empty:
+        return {}
+    normalized = runs.copy()
+    if "target_asset" not in normalized.columns:
+        normalized["target_asset"] = "SPY"
+    normalized["target_asset"] = normalized["target_asset"].fillna("SPY").astype(str).str.upper()
+    return {
+        asset_symbol: group.reset_index(drop=True)
+        for asset_symbol, group in normalized.groupby("target_asset", sort=False)
+    }
+
+
+def _build_live_monitor_state(
+    store: DuckDBStore,
+    feature_service: FeatureService,
+    model_service: ModelService,
+    experiment_store: ExperimentStore,
+    posts: pd.DataFrame,
+    spy_market: pd.DataFrame,
+    tracked_accounts: pd.DataFrame,
+    config: LiveMonitorConfig,
+    generated_at: pd.Timestamp | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, dict[str, Any]], list[str]]:
+    snapshot_rows: list[dict[str, Any]] = []
+    explanation_lookup: dict[str, dict[str, Any]] = {}
+    warnings: list[str] = []
+    snapshot_time = pd.Timestamp.utcnow().floor("s") if generated_at is None else pd.Timestamp(generated_at)
+
+    for pinned in config.pinned_runs:
+        asset_symbol = str(pinned.asset_symbol or "").upper()
+        run_id = str(pinned.run_id or "")
+        if not asset_symbol or not run_id:
+            continue
+        run_bundle = experiment_store.load_run(run_id)
+        if run_bundle is None:
+            warnings.append(f"Pinned run `{run_id}` for `{asset_symbol}` could not be loaded.")
+            continue
+
+        run_config = _bundle_to_run_config(run_bundle)
+        try:
+            feature_rows, attribution_posts = _build_model_target_bundle(
+                store=store,
+                feature_service=feature_service,
+                posts=posts,
+                spy_market=spy_market,
+                tracked_accounts=tracked_accounts,
+                llm_enabled=run_config.llm_enabled,
+                target_asset=asset_symbol,
+                feature_version=run_config.feature_version,
+            )
+        except RuntimeError as exc:
+            warnings.append(f"`{asset_symbol}` live features could not be built: {exc}")
+            continue
+        if feature_rows.empty:
+            warnings.append(f"`{asset_symbol}` does not have any current live feature rows.")
+            continue
+
+        predictions = model_service.predict(run_bundle["model_artifact"], feature_rows)
+        feature_contributions = model_service.explain_predictions(run_bundle["model_artifact"], predictions)
+        post_attribution = build_post_attribution(attribution_posts)
+        account_attribution = build_account_attribution(post_attribution)
+        latest_prediction = predictions.sort_values("signal_session_date").iloc[-1].copy()
+        latest_prediction["prediction_confidence"] = float(latest_prediction.get("prediction_confidence", 0.0) or 0.0)
+        latest_prediction["target_asset"] = asset_symbol
+        latest_prediction["run_id"] = run_id
+        latest_prediction["run_name"] = str(run_bundle.get("run", {}).get("run_name", run_id) or run_id)
+        selected_params = run_bundle.get("selected_params", {}) or {}
+        threshold = selected_params.get("threshold", 0.0)
+        min_post_count = selected_params.get("min_post_count", 1)
+        snapshot_rows.append(
+            {
+                "generated_at": snapshot_time,
+                "signal_session_date": latest_prediction.get("signal_session_date"),
+                "next_session_date": latest_prediction.get("next_session_date"),
+                "asset_symbol": asset_symbol,
+                "run_id": run_id,
+                "run_name": latest_prediction["run_name"],
+                "feature_version": str(latest_prediction.get("feature_version", run_config.feature_version) or run_config.feature_version),
+                "model_version": str(latest_prediction.get("model_version", run_bundle["model_artifact"].model_version) or run_bundle["model_artifact"].model_version),
+                "expected_return_score": float(latest_prediction.get("expected_return_score", 0.0) or 0.0),
+                "confidence": float(latest_prediction.get("prediction_confidence", 0.0) or 0.0),
+                "threshold": float(threshold if threshold is not None else 0.0),
+                "min_post_count": int(min_post_count if min_post_count is not None else 1),
+                "post_count": int(latest_prediction.get("post_count", 0) or 0),
+            },
+        )
+        explanation_lookup[asset_symbol] = {
+            "prediction_row": latest_prediction,
+            "feature_contributions": feature_contributions,
+            "post_attribution": post_attribution,
+            "account_attribution": account_attribution,
+        }
+
+    snapshots = pd.DataFrame(snapshot_rows, columns=LIVE_ASSET_SNAPSHOT_COLUMNS)
+    if snapshots.empty:
+        return snapshots, pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, warnings
+
+    ranked_board, decision = rank_live_asset_snapshots(snapshots, config.fallback_mode)
+    for asset_symbol, payload in explanation_lookup.items():
+        board_match = ranked_board.loc[ranked_board["asset_symbol"] == asset_symbol]
+        if board_match.empty:
+            continue
+        payload["board_row"] = board_match.iloc[0]
+    return ranked_board, decision, explanation_lookup, warnings
+
+
+def _build_live_runner_up_frame(board: pd.DataFrame, decision_row: pd.Series) -> pd.DataFrame:
+    if board.empty:
+        return pd.DataFrame()
+    winner_asset = str(decision_row.get("winning_asset", "") or "")
+    ordered = board.sort_values(["qualifies", "expected_return_score", "confidence"], ascending=[False, False, False]).reset_index(drop=True)
+    rows: list[dict[str, Any]] = []
+    winner = ordered.loc[ordered["asset_symbol"] == winner_asset]
+    if not winner.empty:
+        winner_row = winner.iloc[0]
+        rows.append(
+            {
+                "asset_symbol": str(winner_row["asset_symbol"]),
+                "run_name": str(winner_row["run_name"]),
+                "score": float(winner_row["expected_return_score"]),
+                "confidence": float(winner_row["confidence"]),
+                "threshold_gap": float(winner_row["expected_return_score"] - winner_row["threshold"]),
+                "post_count": int(winner_row["post_count"]),
+                "qualifies": bool(winner_row["qualifies"]),
+                "winner": True,
+            },
+        )
+    runner_up_asset = str(decision_row.get("runner_up_asset", "") or "")
+    if runner_up_asset:
+        runner = ordered.loc[ordered["asset_symbol"] == runner_up_asset]
+        if not runner.empty:
+            runner_row = runner.iloc[0]
+            rows.append(
+                {
+                    "asset_symbol": str(runner_row["asset_symbol"]),
+                    "run_name": str(runner_row["run_name"]),
+                    "score": float(runner_row["expected_return_score"]),
+                    "confidence": float(runner_row["confidence"]),
+                    "threshold_gap": float(runner_row["expected_return_score"] - runner_row["threshold"]),
+                    "post_count": int(runner_row["post_count"]),
+                    "qualifies": bool(runner_row["qualifies"]),
+                    "winner": False,
+                },
+            )
+    return pd.DataFrame(rows)
 
 
 def _watchlist_symbols(store: DuckDBStore) -> list[str]:
@@ -1862,7 +2025,10 @@ def render_live_monitor(
     experiment_store: ExperimentStore,
 ) -> None:
     st.subheader("Live Monitor")
-    st.caption("Polling-style refresh for new posts plus the latest next-session SPY score from the newest saved model.")
+    st.caption(
+        "Multi-asset decision console for pinned saved runs. It ranks current live candidates, "
+        "applies the configured SPY/flat fallback, and keeps board history for debugging.",
+    )
     remote_url = st.text_input(
         "Remote X / mentions CSV URL for polling",
         key="live_remote_x_url",
@@ -1882,7 +2048,8 @@ def render_live_monitor(
             height=0,
         )
 
-    if st.button("Poll sources now", use_container_width=True):
+    refresh_requested = st.button("Poll sources now", use_container_width=True)
+    if refresh_requested:
         with st.spinner("Refreshing sources and market data..."):
             _refresh_datasets(
                 settings=settings,
@@ -1897,96 +2064,353 @@ def render_live_monitor(
             )
         st.success("Polling refresh complete.")
 
-    model_bundle = experiment_store.load_latest_model_artifact(target_asset="SPY")
-    if model_bundle is None:
-        st.info("Run a model in the Models & Backtests page to enable live predictions.")
+    runs = experiment_store.list_runs()
+    if runs.empty:
+        st.info("Save at least one run in Models & Backtests before using the live decision console.")
         return
 
-    artifact, deployment_params = model_bundle
+    run_groups = _runs_by_asset(runs)
+    if "SPY" not in run_groups:
+        st.info("Save at least one `SPY` model run first so the live monitor has a required fallback anchor.")
+        return
+
+    saved_config = experiment_store.load_live_monitor_config()
+    seeded_config = seed_live_monitor_config(runs)
+    editor_config = saved_config or seeded_config
+    if editor_config is None:
+        st.info("Save at least one model run before configuring the live decision console.")
+        return
+
+    st.markdown("**Pinned Model Set**")
+    if saved_config is None:
+        st.info("The selectors below are seeded from the newest saved run per asset. Save the pinned model set to enable monitoring.")
+
+    saved_config_errors = validate_live_monitor_config(saved_config, runs) if saved_config is not None else []
+    if saved_config_errors:
+        for message in saved_config_errors:
+            st.warning(message)
+        st.caption("Update and save the pinned model set below to restore live monitoring.")
+
+    available_non_spy_assets = sorted(asset_symbol for asset_symbol in run_groups if asset_symbol != "SPY")
+    fallback_default = str(editor_config.fallback_mode or "SPY").upper()
+    fallback_index = 0 if fallback_default == "SPY" else 1
+    asset_defaults = [
+        item.asset_symbol
+        for item in editor_config.pinned_runs
+        if item.asset_symbol != "SPY" and item.asset_symbol in available_non_spy_assets
+    ]
+    active_config = saved_config if not saved_config_errors else None
+
+    with st.form("live-monitor-config"):
+        fallback_mode = st.radio(
+            "Fallback mode",
+            options=["SPY", "FLAT"],
+            index=fallback_index,
+            horizontal=True,
+        )
+        selected_assets = st.multiselect(
+            "Pinned non-SPY assets",
+            options=available_non_spy_assets,
+            default=asset_defaults,
+        )
+        selected_asset_order = ["SPY"] + selected_assets
+        pinned_runs: list[LiveMonitorPinnedRun] = []
+        for asset_symbol in selected_asset_order:
+            asset_runs = run_groups.get(asset_symbol, pd.DataFrame())
+            if asset_runs.empty:
+                continue
+            run_options = asset_runs["run_id"].astype(str).tolist()
+            configured = next(
+                (
+                    item.run_id
+                    for item in editor_config.pinned_runs
+                    if item.asset_symbol == asset_symbol and item.run_id in run_options
+                ),
+                run_options[0],
+            )
+            selected_run_id = st.selectbox(
+                f"{asset_symbol} pinned run",
+                options=run_options,
+                index=run_options.index(configured) if configured in run_options else 0,
+                format_func=lambda run_id, asset_runs=asset_runs: _live_run_option_label(
+                    asset_runs.loc[asset_runs["run_id"].astype(str) == str(run_id)].iloc[0],
+                ),
+                key=f"live-pinned-run-{asset_symbol}",
+            )
+            selected_row = asset_runs.loc[asset_runs["run_id"].astype(str) == str(selected_run_id)].iloc[0]
+            pinned_runs.append(
+                LiveMonitorPinnedRun(
+                    asset_symbol=asset_symbol,
+                    run_id=str(selected_run_id),
+                    run_name=str(selected_row.get("run_name", selected_run_id) or selected_run_id),
+                    model_version="",
+                    pinned_at=pd.Timestamp.utcnow().floor("s").isoformat(),
+                ),
+            )
+        save_config = st.form_submit_button("Save pinned model set")
+
+    if save_config:
+        candidate_config = LiveMonitorConfig(
+            fallback_mode=str(fallback_mode).upper(),
+            pinned_runs=pinned_runs,
+        )
+        validation_errors = validate_live_monitor_config(candidate_config, runs)
+        if validation_errors:
+            for message in validation_errors:
+                st.error(message)
+        else:
+            enriched_pins: list[LiveMonitorPinnedRun] = []
+            for item in candidate_config.pinned_runs:
+                run_bundle = experiment_store.load_run(item.run_id)
+                model_version = ""
+                if run_bundle is not None:
+                    model_version = str(run_bundle["model_artifact"].model_version)
+                enriched_pins.append(
+                    LiveMonitorPinnedRun(
+                        asset_symbol=item.asset_symbol,
+                        run_id=item.run_id,
+                        run_name=item.run_name,
+                        model_version=model_version,
+                        pinned_at=item.pinned_at,
+                    ),
+                )
+            active_config = LiveMonitorConfig(
+                fallback_mode=candidate_config.fallback_mode,
+                pinned_runs=enriched_pins,
+            )
+            experiment_store.save_live_monitor_config(active_config)
+            st.success("Saved the pinned live model set.")
+
+    if active_config is None:
+        st.info("Save a valid pinned model set above to enable live monitoring.")
+        return
+
+    config_errors = validate_live_monitor_config(active_config, runs)
+    if config_errors:
+        for message in config_errors:
+            st.error(message)
+        return
+
     posts = store.read_frame("normalized_posts")
     spy = store.read_frame("spy_daily")
     tracked_accounts = store.read_frame("tracked_accounts")
-    prepared_posts = feature_service.prepare_session_posts(
-        posts=posts,
-        market_calendar=spy,
-        tracked_accounts=tracked_accounts,
-        llm_enabled=bool(artifact.metadata.get("llm_enabled", False)),
-    )
-    feature_rows = feature_service.build_session_dataset(
+    if posts.empty or spy.empty:
+        st.info("Refresh datasets first so the live decision console has normalized posts and SPY market data.")
+        return
+    board_generated_at = pd.Timestamp.utcnow().floor("s")
+    board, decision_history_row, explanation_lookup, live_warnings = _build_live_monitor_state(
+        store=store,
+        feature_service=feature_service,
+        model_service=model_service,
+        experiment_store=experiment_store,
         posts=posts,
         spy_market=spy,
         tracked_accounts=tracked_accounts,
-        feature_version="v1",
-        llm_enabled=bool(artifact.metadata.get("llm_enabled", False)),
-        prepared_posts=prepared_posts,
+        config=active_config,
+        generated_at=board_generated_at,
     )
-    feature_rows["target_asset"] = "SPY"
-    predictions = model_service.predict(artifact, feature_rows)
-    feature_contributions = model_service.explain_predictions(artifact, predictions)
-    post_attribution = build_post_attribution(prepared_posts)
-    account_attribution = build_account_attribution(post_attribution)
-    latest = predictions.sort_values("signal_session_date").iloc[-1]
-    threshold = float(deployment_params.get("threshold", 0.0))
-    min_post_count = int(deployment_params.get("min_post_count", 1))
-    stance = "LONG SPY NEXT SESSION" if latest["expected_return_score"] > threshold and latest["post_count"] >= min_post_count else "FLAT"
-    snapshot = pd.DataFrame(
-        [
-            {
-                "signal_session_date": latest["signal_session_date"],
-                "next_session_date": latest["next_session_date"],
-                "target_asset": "SPY",
-                "expected_return_score": latest["expected_return_score"],
-                "feature_version": latest["feature_version"],
-                "model_version": latest["model_version"],
-                "confidence": latest["prediction_confidence"],
-                "generated_at": pd.Timestamp.utcnow(),
-                "stance": stance,
-            },
-        ],
-    )
-    experiment_store.save_prediction_snapshots(snapshot)
+    for message in live_warnings:
+        st.warning(message)
+    if board.empty or decision_history_row.empty:
+        st.info("No live candidate rows could be built from the pinned model set.")
+        return
 
-    cols = st.columns(4)
-    cols[0].metric("Signal session", f"{pd.Timestamp(latest['signal_session_date']):%Y-%m-%d}")
-    cols[1].metric("Expected next-session return", f"{latest['expected_return_score']:+.3%}")
-    cols[2].metric("Confidence", f"{latest['prediction_confidence']:.2f}")
-    cols[3].metric("Suggested stance", stance)
+    should_persist_snapshots = bool(refresh_requested)
+    if poll_enabled:
+        last_persisted = pd.to_datetime(st.session_state.get("live_monitor_last_persisted_at"), errors="coerce")
+        if pd.isna(last_persisted) or (board_generated_at - last_persisted).total_seconds() >= max(int(poll_seconds * 0.8), 5):
+            should_persist_snapshots = True
+    if should_persist_snapshots:
+        experiment_store.save_live_asset_snapshots(board)
+        experiment_store.save_live_decision_snapshots(decision_history_row)
+        st.session_state["live_monitor_last_persisted_at"] = board_generated_at.isoformat()
 
-    st.json(
-        {
-            "threshold": threshold,
-            "minimum_post_count": min_post_count,
-            "latest_feature_preview": latest_feature_preview(feature_rows),
-        },
-    )
+    decision_row = decision_history_row.iloc[0]
+    winner_asset = str(decision_row.get("winning_asset", "") or "")
+    winner_rows = board.loc[board["is_winner"]].copy()
+    winner_row = winner_rows.iloc[0] if not winner_rows.empty else None
+    winner_confidence = float(winner_row["confidence"]) if winner_row is not None else 0.0
+    display_asset = winner_asset or "FLAT"
+    tabs = st.tabs(["Current Decision", "Why This Asset Won", "History"])
 
-    history = store.read_frame("prediction_snapshots")
-    if not history.empty:
-        if "target_asset" not in history.columns:
-            history["target_asset"] = "SPY"
-        history = history.loc[history["target_asset"].astype(str).str.upper() == "SPY"].copy()
-    if not history.empty:
-        history = history.sort_values("generated_at")
-        fig = go.Figure()
-        fig.add_trace(
-            go.Scatter(
-                x=history["generated_at"],
-                y=history["expected_return_score"],
-                mode="lines+markers",
-                name="Expected return score",
-            ),
+    with tabs[0]:
+        metric_cols = st.columns(6)
+        metric_cols[0].metric("Winning asset", display_asset)
+        metric_cols[1].metric(
+            "Signal session",
+            f"{pd.Timestamp(decision_row['signal_session_date']):%Y-%m-%d}" if pd.notna(decision_row["signal_session_date"]) else "n/a",
         )
-        fig.update_layout(title="Prediction snapshot history", xaxis_title="Generated at", yaxis_title="Expected next-session return")
-        st.plotly_chart(fig, use_container_width=True)
-        st.dataframe(history.tail(25), use_container_width=True, hide_index=True)
+        metric_cols[2].metric("Decision source", str(decision_row["decision_source"]).upper())
+        metric_cols[3].metric("Stance", str(decision_row["stance"]))
+        metric_cols[4].metric("Winner score", f"{float(decision_row['winner_score']):+.3%}")
+        metric_cols[5].metric("Winner confidence", f"{winner_confidence:.2f}")
 
-    _render_signal_explanation_panel(
-        prediction_row=latest,
-        feature_contributions=feature_contributions,
-        post_attribution=post_attribution,
-        account_attribution=account_attribution,
-        heading="Why This Live Signal?",
-    )
+        st.json(
+            {
+                "fallback_mode": str(decision_row["fallback_mode"]),
+                "eligible_asset_count": int(decision_row["eligible_asset_count"]),
+                "runner_up_asset": str(decision_row.get("runner_up_asset", "") or ""),
+                "generated_at": str(pd.Timestamp(decision_row["generated_at"])),
+            },
+        )
+        board_view = board.rename(
+            columns={
+                "asset_symbol": "Asset",
+                "run_name": "Run",
+                "expected_return_score": "Score",
+                "confidence": "Confidence",
+                "threshold": "Threshold",
+                "min_post_count": "Min posts",
+                "post_count": "Posts",
+                "qualifies": "Qualifies",
+                "eligible_rank": "Eligible rank",
+                "is_winner": "Winner",
+                "decision_source": "Decision source",
+                "stance": "Stance",
+            },
+        )
+        st.markdown("**Live ranked board**")
+        st.dataframe(
+            board_view[
+                [
+                    "Asset",
+                    "Run",
+                    "Score",
+                    "Confidence",
+                    "Threshold",
+                    "Min posts",
+                    "Posts",
+                    "Qualifies",
+                    "Eligible rank",
+                    "Winner",
+                    "Decision source",
+                    "Stance",
+                ]
+            ],
+            use_container_width=True,
+            hide_index=True,
+        )
+
+    with tabs[1]:
+        explain_options = board["asset_symbol"].astype(str).tolist()
+        default_explain_asset = winner_asset or (explain_options[0] if explain_options else "")
+        selected_asset = st.selectbox(
+            "Explain asset",
+            options=explain_options,
+            index=explain_options.index(default_explain_asset) if default_explain_asset in explain_options else 0,
+            key="live-monitor-explain-asset",
+        )
+        runner_frame = _build_live_runner_up_frame(board, decision_row)
+        if not runner_frame.empty:
+            st.markdown("**Winner vs runner-up**")
+            st.dataframe(
+                runner_frame.rename(
+                    columns={
+                        "asset_symbol": "Asset",
+                        "run_name": "Run",
+                        "score": "Score",
+                        "confidence": "Confidence",
+                        "threshold_gap": "Threshold gap",
+                        "post_count": "Posts",
+                        "qualifies": "Qualifies",
+                        "winner": "Winner",
+                    },
+                ),
+                use_container_width=True,
+                hide_index=True,
+            )
+        selected_payload = explanation_lookup.get(selected_asset, {})
+        prediction_row = selected_payload.get("prediction_row", pd.Series(dtype=object)).copy()
+        if not prediction_row.empty:
+            board_row = selected_payload.get("board_row")
+            if board_row is not None:
+                prediction_row["expected_return_score"] = board_row["expected_return_score"]
+                prediction_row["prediction_confidence"] = board_row["confidence"]
+            heading = "Why This Asset Won?" if selected_asset == winner_asset else f"Why {selected_asset}?"
+            _render_signal_explanation_panel(
+                prediction_row=prediction_row,
+                feature_contributions=selected_payload.get("feature_contributions", pd.DataFrame()),
+                post_attribution=selected_payload.get("post_attribution", pd.DataFrame()),
+                account_attribution=selected_payload.get("account_attribution", pd.DataFrame()),
+                heading=heading,
+            )
+
+    with tabs[2]:
+        asset_history = store.read_frame("live_asset_snapshots")
+        decision_history = store.read_frame("live_decision_snapshots")
+        monitored_assets = {item.asset_symbol for item in active_config.pinned_runs}
+        if not asset_history.empty and "asset_symbol" in asset_history.columns:
+            asset_history["asset_symbol"] = asset_history["asset_symbol"].astype(str).str.upper()
+            asset_history = asset_history.loc[asset_history["asset_symbol"].isin(monitored_assets)].copy()
+        if not decision_history.empty:
+            decision_history = decision_history.sort_values("generated_at").reset_index(drop=True)
+
+        if asset_history.empty:
+            st.info("No persisted live board history yet. Use polling or the manual refresh button to build it up.")
+        else:
+            asset_history = asset_history.sort_values("generated_at").reset_index(drop=True)
+            history_fig = go.Figure()
+            for asset_symbol, group in asset_history.groupby("asset_symbol", sort=False):
+                history_fig.add_trace(
+                    go.Scatter(
+                        x=group["generated_at"],
+                        y=group["expected_return_score"],
+                        mode="lines+markers",
+                        name=str(asset_symbol),
+                    ),
+                )
+            history_fig.update_layout(
+                title="Live asset score history",
+                xaxis_title="Generated at",
+                yaxis_title="Expected next-session return",
+            )
+            st.plotly_chart(history_fig, use_container_width=True)
+
+        st.markdown("**Recent live decisions**")
+        if decision_history.empty:
+            st.info("No persisted live decision history yet.")
+        else:
+            st.dataframe(decision_history.tail(25), use_container_width=True, hide_index=True)
+
+        mapped_post_asset = st.selectbox(
+            "Mapped-post view asset",
+            options=board["asset_symbol"].astype(str).tolist(),
+            index=board["asset_symbol"].astype(str).tolist().index(default_explain_asset) if default_explain_asset in board["asset_symbol"].astype(str).tolist() else 0,
+            key="live-monitor-post-asset",
+        )
+        post_payload = explanation_lookup.get(mapped_post_asset, {})
+        post_prediction = post_payload.get("prediction_row", pd.Series(dtype=object))
+        mapped_posts = _filter_for_session(
+            post_payload.get("post_attribution", pd.DataFrame()),
+            _normalize_session_date(post_prediction.get("signal_session_date")),
+        )
+        st.markdown(f"**Latest mapped posts for {mapped_post_asset}**")
+        if mapped_posts.empty:
+            st.info(f"No mapped live posts are available for `{mapped_post_asset}`.")
+        else:
+            st.dataframe(
+                mapped_posts[
+                    [
+                        "post_timestamp",
+                        "author_handle",
+                        "sentiment_score",
+                        "engagement_score",
+                        "post_signal_score",
+                        "post_preview",
+                    ]
+                ].rename(
+                    columns={
+                        "post_timestamp": "Timestamp",
+                        "author_handle": "Handle",
+                        "sentiment_score": "Sentiment",
+                        "engagement_score": "Engagement",
+                        "post_signal_score": "Signal score",
+                        "post_preview": "Post",
+                    },
+                ),
+                use_container_width=True,
+                hide_index=True,
+            )
 
 
 def render_historical_replay_view(


### PR DESCRIPTION
## Summary
- replace the old SPY-only Live Monitor with a multi-asset decision console driven by pinned saved runs
- add persisted live monitor config plus per-asset and per-decision snapshot history for debugging and score evolution
- surface current winner selection, fallback handling, runner-up comparison, and live explanation data in the UI

## Why
Closes #9.

The app already had watchlists, asset-aware research views, and asset-specific models, but the live surface was still effectively SPY-only. This change makes the monitor operate the way the product now works: one pinned model per asset, asset-by-asset eligibility checks, a clear winner or fallback decision, and persisted history so we can understand how the board evolved over time.

## What changed
- added `LiveMonitorConfig` / `LiveMonitorPinnedRun` contracts and persistence in the experiment store
- introduced `trump_workbench/live_monitor.py` for config seeding, validation, board ranking, and decision selection
- rebuilt `Live Monitor` in the Streamlit UI around four sections: pinned model set, current decision, why this asset won, and history
- persisted `live_asset_snapshots` and `live_decision_snapshots` while leaving legacy `prediction_snapshots` intact for compatibility
- added unit and integration coverage for config validation, winner selection, fallback behavior, snapshot persistence, and live explanation routing

## Validation
- `./.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python -m coverage run -m unittest discover -s tests`
- `./.venv/bin/python -m coverage report -m`
- `./.venv/bin/streamlit run app.py --server.headless true --server.port 8510`
