### PR TITLE
Add GitHub Actions and repo hygiene baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @keithwegner

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a defect or regression in the workbench
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the defect clearly.
+
+## Steps To Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What should have happened?
+
+## Actual Behavior
+
+What happened instead?
+
+## Environment
+
+- Branch / commit:
+- Python version:
+- Relevant data inputs:
+
+## Validation / Evidence
+
+- Logs, screenshots, stack traces, or failing command output:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Propose a product, research, or engineering improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+What should be added or changed?
+
+## Problem
+
+What limitation or pain point does this address?
+
+## Proposed Outcome
+
+Describe the expected behavior, workflow, or result.
+
+## Constraints
+
+- In scope:
+- Out of scope:
+- Dependencies / blockers:
+
+## Acceptance Signals
+
+How will we know this is done?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "14:00"
+      timezone: UTC
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "14:00"
+      timezone: UTC
+    groups:
+      github-actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+- What changed?
+- Why was it needed?
+
+## Validation
+
+- [ ] `bash scripts/ci.sh`
+- [ ] Additional manual checks, if any, are described below
+
+## Linked Work
+
+- Issue / PR / note:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Run shared CI entrypoint
+        run: bash scripts/ci.sh
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: error

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -1,0 +1,46 @@
+name: weekly-health
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Run shared CI entrypoint
+        run: bash scripts/ci.sh
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-health-coverage-xml
+          path: coverage.xml
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache/
 .coverage
 .coverage.*
+coverage.xml
 htmlcov/
 .pytest_cache/
 .venv/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![UI: Streamlit](https://img.shields.io/badge/ui-Streamlit-FF4B4B?logo=streamlit&logoColor=white)](https://streamlit.io/)
 [![Storage: DuckDB + Parquet](https://img.shields.io/badge/storage-DuckDB%20%2B%20Parquet-FFF000?logo=duckdb&logoColor=black)](https://duckdb.org/)
+[![CI](https://github.com/keithwegner/allcaps/actions/workflows/ci.yml/badge.svg)](https://github.com/keithwegner/allcaps/actions/workflows/ci.yml)
 [![Status: Experimental](https://img.shields.io/badge/status-experimental-orange)](https://github.com/keithwegner/allcaps)
 
 This is a local Streamlit workbench for researching whether President Donald Trump's social posts, plus posts from influential X accounts that mention him, help predict the **next trading session's SPY return**.
@@ -44,6 +45,19 @@ source .venv/bin/activate
 pip install -r requirements.txt
 streamlit run app.py
 ```
+
+## Contributor Workflow
+
+Use Python `3.11` for local development and CI parity.
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+bash scripts/ci.sh
+```
+
+`main` is intended to stay behind pull requests with a green `ci` check, so `bash scripts/ci.sh` is the local pre-push baseline.
 
 On the first launch, the app may take a little longer because it can bootstrap local working datasets automatically.
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -x "$ROOT_DIR/.venv/bin/python" ]]; then
+  PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python)"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3)"
+else
+  echo "No Python interpreter found on PATH." >&2
+  exit 1
+fi
+
+PORT="${STREAMLIT_SMOKE_PORT:-8513}"
+STARTUP_TIMEOUT_SECONDS="${STREAMLIT_SMOKE_TIMEOUT_SECONDS:-45}"
+LOG_FILE="${STREAMLIT_SMOKE_LOG_FILE:-${TMPDIR:-/tmp}/allcaps-streamlit-smoke.log}"
+
+echo "==> Compile check"
+"$PYTHON_BIN" -m py_compile app.py trump_workbench/*.py tests/*.py
+
+echo "==> Test suite with coverage"
+"$PYTHON_BIN" -m coverage erase
+"$PYTHON_BIN" -m coverage run -m unittest discover -s tests -v
+
+echo "==> Coverage gate"
+"$PYTHON_BIN" -m coverage report --fail-under=90 -m
+"$PYTHON_BIN" -m coverage xml
+
+echo "==> Streamlit smoke test"
+rm -f "$LOG_FILE"
+"$PYTHON_BIN" -m streamlit run app.py --server.headless true --server.port "$PORT" >"$LOG_FILE" 2>&1 &
+app_pid=$!
+
+cleanup() {
+  if kill -0 "$app_pid" >/dev/null 2>&1; then
+    kill "$app_pid" >/dev/null 2>&1 || true
+    wait "$app_pid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+"$PYTHON_BIN" - "$PORT" "$STARTUP_TIMEOUT_SECONDS" "$LOG_FILE" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+import time
+import urllib.request
+
+port = int(sys.argv[1])
+timeout_seconds = int(sys.argv[2])
+log_path = pathlib.Path(sys.argv[3])
+url = f"http://127.0.0.1:{port}"
+deadline = time.time() + timeout_seconds
+last_error = ""
+
+while time.time() < deadline:
+    try:
+        with urllib.request.urlopen(url, timeout=2) as response:
+            if response.status < 500:
+                print(f"Streamlit smoke check passed on {url}")
+                sys.exit(0)
+    except Exception as exc:  # noqa: BLE001
+        last_error = str(exc)
+    time.sleep(1)
+
+log_excerpt = ""
+if log_path.exists():
+    log_excerpt = log_path.read_text(encoding="utf-8", errors="ignore")[-4000:]
+
+sys.stderr.write(
+    f"Streamlit failed to start on {url} within {timeout_seconds} seconds. "
+    f"Last error: {last_error}\n",
+)
+if log_excerpt:
+    sys.stderr.write("\n--- Streamlit log tail ---\n")
+    sys.stderr.write(log_excerpt)
+    sys.stderr.write("\n")
+sys.exit(1)
+PY

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,11 @@ from trump_workbench.utils import (
 
 
 class UtilsTests(unittest.TestCase):
+    def assert_timezone_name(self, ts: pd.Timestamp, expected: str) -> None:
+        tz = ts.tz
+        name = getattr(tz, "zone", None) or getattr(tz, "key", None) or str(tz)
+        self.assertEqual(name, expected)
+
     def test_clean_text_strips_html_and_mojibake(self) -> None:
         raw = "Hello<br>world &amp; team ‚Äî test"
         self.assertEqual(clean_text(raw), "Hello world & team — test")
@@ -35,7 +40,7 @@ class UtilsTests(unittest.TestCase):
 
     def test_parse_timestamp_to_eastern_normalizes_timezone(self) -> None:
         ts = parse_timestamp_to_eastern("2025-02-01T15:00:00Z")
-        self.assertEqual(ts.tz.zone, "America/New_York")
+        self.assert_timezone_name(ts, "America/New_York")
 
     def test_infer_mentions_trump(self) -> None:
         self.assertTrue(infer_mentions_trump("Markets are reacting to Trump again"))
@@ -52,7 +57,7 @@ class UtilsTests(unittest.TestCase):
 
         localized = parse_timestamp_to_eastern("2025-02-01 15:00:00")
         self.assertFalse(pd.isna(localized))
-        self.assertEqual(localized.tz.zone, EASTERN)
+        self.assert_timezone_name(localized, EASTERN)
 
     def test_normalize_boolean_handles_empty_boolean_and_string_inputs(self) -> None:
         empty = normalize_boolean(pd.Series(dtype=object))

--- a/trump_workbench/utils.py
+++ b/trump_workbench/utils.py
@@ -86,18 +86,20 @@ def normalize_boolean(series: pd.Series, default: bool = False) -> pd.Series:
     if series.dtype == bool:
         return series.fillna(default)
 
-    lowered = series.astype(str).str.strip().str.lower()
     truthy = {"1", "true", "yes", "y", "t"}
-    falsy = {"0", "false", "no", "n", "f", "nan", "none", ""}
+    falsy = {"0", "false", "no", "n", "f", "nan", "none", "", "<na>", "null"}
 
-    def parse(value: str) -> bool:
-        if value in truthy:
+    def parse(value: object) -> bool:
+        if pd.isna(value):
+            return False
+        lowered = str(value).strip().lower()
+        if lowered in truthy:
             return True
-        if value in falsy:
+        if lowered in falsy:
             return False
         return default
 
-    return lowered.map(parse)
+    return series.map(parse)
 
 
 def read_csv_bytes(raw: bytes) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- track the local .github scaffolding in the repo
- standardize CI and weekly health on a shared scripts/ci.sh entrypoint
- add repo hygiene templates and contributor workflow docs

## Validation
- bash scripts/ci.sh

## Notes
- applying branch protection on main is still blocked by the current token available in this environment
