### PR TITLE
Add data health dashboard

### DIFF
--- a/tests/test_data_health_ui.py
+++ b/tests/test_data_health_ui.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from trump_workbench.config import AppSettings, EASTERN
+from trump_workbench.contracts import MANUAL_OVERRIDE_COLUMNS, RANKING_HISTORY_COLUMNS, TRACKED_ACCOUNT_COLUMNS
+from trump_workbench.health import DataHealthService, HEALTH_CHECK_COLUMNS, REFRESH_HISTORY_COLUMNS
+from trump_workbench.storage import DuckDBStore
+from trump_workbench.ui import (
+    _append_refresh_history,
+    _filter_health_rows,
+    _load_data_health_view_state,
+    _refresh_datasets,
+)
+
+
+class _FakeIngestionService:
+    def __init__(self, full_posts: pd.DataFrame, incremental_posts: pd.DataFrame, source_manifest: pd.DataFrame) -> None:
+        self.full_posts = full_posts
+        self.incremental_posts = incremental_posts
+        self.source_manifest = source_manifest
+
+    def run_refresh(self, adapters):  # noqa: ANN001
+        return self.full_posts.copy(), self.source_manifest.copy()
+
+    def run_incremental_refresh(self, adapters, last_cursor):  # noqa: ANN001, ARG002
+        return self.incremental_posts.copy(), self.source_manifest.copy()
+
+
+class _FakeMarketService:
+    def __init__(self, sp500: pd.DataFrame, spy: pd.DataFrame, asset_daily: pd.DataFrame, asset_intraday: pd.DataFrame, asset_market_manifest: pd.DataFrame) -> None:
+        self.sp500 = sp500
+        self.spy = spy
+        self.asset_daily = asset_daily
+        self.asset_intraday = asset_intraday
+        self.asset_market_manifest = asset_market_manifest
+
+    def load_sp500_daily(self, start: str, end: str) -> pd.DataFrame:  # noqa: ARG002
+        return self.sp500.copy()
+
+    def load_spy_daily(self, start: str, end: str) -> pd.DataFrame:  # noqa: ARG002
+        return self.spy.copy()
+
+    def load_assets_daily(self, symbols, start: str, end: str):  # noqa: ANN001, ARG002
+        manifest = self.asset_market_manifest.loc[self.asset_market_manifest["dataset_kind"] == "daily"].reset_index(drop=True)
+        return self.asset_daily.copy(), manifest
+
+    def load_assets_intraday(self, symbols, interval: str = "5m", lookback_days: int = 30):  # noqa: ANN001, ARG002
+        manifest = self.asset_market_manifest.loc[self.asset_market_manifest["dataset_kind"] == f"intraday_{interval}"].reset_index(drop=True)
+        return self.asset_intraday.copy(), manifest
+
+
+class _FakeDiscoveryService:
+    def __init__(self, tracked_accounts: pd.DataFrame, ranking_history: pd.DataFrame) -> None:
+        self.tracked_accounts = tracked_accounts
+        self.ranking_history = ranking_history
+
+    def normalize_manual_overrides(self, overrides: pd.DataFrame | None) -> pd.DataFrame:
+        if overrides is None or overrides.empty:
+            return pd.DataFrame(columns=MANUAL_OVERRIDE_COLUMNS)
+        return overrides.copy()
+
+    def refresh_accounts(self, posts: pd.DataFrame, existing_accounts: pd.DataFrame, as_of: pd.Timestamp, manual_overrides: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:  # noqa: ARG002
+        return self.tracked_accounts.copy(), self.ranking_history.copy()
+
+
+class _FakeFeatureService:
+    def __init__(self, prepared_posts: pd.DataFrame, asset_post_mappings: pd.DataFrame, asset_session_features: pd.DataFrame) -> None:
+        self.prepared_posts = prepared_posts
+        self.asset_post_mappings = asset_post_mappings
+        self.asset_session_features = asset_session_features
+
+    def prepare_session_posts(self, posts: pd.DataFrame, market_calendar: pd.DataFrame, tracked_accounts: pd.DataFrame, llm_enabled: bool) -> pd.DataFrame:  # noqa: ARG002
+        return self.prepared_posts.copy()
+
+    def build_asset_post_mappings(self, prepared_posts: pd.DataFrame, asset_universe: pd.DataFrame, llm_enabled: bool) -> pd.DataFrame:  # noqa: ARG002
+        return self.asset_post_mappings.copy()
+
+    def build_asset_session_dataset(self, asset_post_mappings: pd.DataFrame, asset_market: pd.DataFrame, feature_version: str, llm_enabled: bool, asset_universe: pd.DataFrame) -> pd.DataFrame:  # noqa: ARG002
+        return self.asset_session_features.copy()
+
+
+class DataHealthUiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.settings = AppSettings(base_dir=Path(self.temp_dir.name))
+        self.store = DuckDBStore(self.settings)
+        self.health_service = DataHealthService()
+        post_ts = pd.Timestamp("2026-04-15 10:00:00", tz=EASTERN)
+        self.posts = pd.DataFrame(
+            [
+                {
+                    "source_platform": "X",
+                    "source_type": "x_csv",
+                    "author_account_id": "acct-a",
+                    "author_handle": "macroa",
+                    "author_display_name": "Macro A",
+                    "author_is_trump": False,
+                    "post_id": "post-1",
+                    "post_url": "https://x.com/macroa/status/1",
+                    "post_timestamp": post_ts,
+                    "raw_text": "Trump growth",
+                    "cleaned_text": "Trump growth",
+                    "is_reshare": False,
+                    "has_media": False,
+                    "replies_count": 1,
+                    "reblogs_count": 2,
+                    "favourites_count": 3,
+                    "mentions_trump": True,
+                    "source_provenance": "unit-test",
+                    "engagement_score": 6.0,
+                    "sentiment_score": 0.3,
+                    "sentiment_label": "positive",
+                },
+            ],
+        )
+        self.source_manifest = pd.DataFrame(
+            [
+                {
+                    "source": "Truth Social archive",
+                    "provenance": "unit-test",
+                    "post_count": 1,
+                    "coverage_start": post_ts,
+                    "coverage_end": post_ts,
+                    "status": "ok",
+                    "detail": "",
+                },
+            ],
+        )
+        self.sp500 = pd.DataFrame([{"trade_date": pd.Timestamp("2026-04-15"), "close": 6100.0}])
+        self.spy = pd.DataFrame(
+            [{"trade_date": pd.Timestamp("2026-04-15"), "open": 600.0, "high": 605.0, "low": 598.0, "close": 603.0, "volume": 1_000_000}],
+        )
+        self.asset_daily = pd.DataFrame(
+            [
+                {"symbol": "SPY", "trade_date": pd.Timestamp("2026-04-15"), "open": 600.0, "high": 605.0, "low": 598.0, "close": 603.0, "volume": 1_000_000},
+                {"symbol": "QQQ", "trade_date": pd.Timestamp("2026-04-15"), "open": 500.0, "high": 505.0, "low": 498.0, "close": 504.0, "volume": 900_000},
+                {"symbol": "XLK", "trade_date": pd.Timestamp("2026-04-15"), "open": 200.0, "high": 201.0, "low": 198.0, "close": 200.5, "volume": 700_000},
+                {"symbol": "XLF", "trade_date": pd.Timestamp("2026-04-15"), "open": 40.0, "high": 41.0, "low": 39.5, "close": 40.5, "volume": 500_000},
+                {"symbol": "XLE", "trade_date": pd.Timestamp("2026-04-15"), "open": 80.0, "high": 81.0, "low": 79.0, "close": 80.5, "volume": 400_000},
+                {"symbol": "SMH", "trade_date": pd.Timestamp("2026-04-15"), "open": 250.0, "high": 252.0, "low": 248.0, "close": 251.0, "volume": 300_000},
+            ],
+        )
+        self.asset_intraday = pd.DataFrame(
+            [
+                {"symbol": "SPY", "timestamp": post_ts, "open": 600.0, "high": 601.0, "low": 599.0, "close": 600.5, "volume": 1000, "interval": "5m"},
+                {"symbol": "QQQ", "timestamp": post_ts, "open": 500.0, "high": 501.0, "low": 499.0, "close": 500.5, "volume": 900, "interval": "5m"},
+                {"symbol": "XLK", "timestamp": post_ts, "open": 200.0, "high": 201.0, "low": 199.0, "close": 200.5, "volume": 800, "interval": "5m"},
+                {"symbol": "XLF", "timestamp": post_ts, "open": 40.0, "high": 40.5, "low": 39.5, "close": 40.2, "volume": 700, "interval": "5m"},
+                {"symbol": "XLE", "timestamp": post_ts, "open": 80.0, "high": 81.0, "low": 79.0, "close": 80.4, "volume": 600, "interval": "5m"},
+                {"symbol": "SMH", "timestamp": post_ts, "open": 250.0, "high": 251.0, "low": 249.0, "close": 250.5, "volume": 500, "interval": "5m"},
+            ],
+        )
+        self.asset_market_manifest = pd.DataFrame(
+            [
+                {"symbol": "SPY", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "SPY", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": post_ts, "end_at": post_ts, "detail": ""},
+                {"symbol": "QQQ", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "QQQ", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": post_ts, "end_at": post_ts, "detail": ""},
+                {"symbol": "XLK", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "XLK", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": post_ts, "end_at": post_ts, "detail": ""},
+                {"symbol": "XLF", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "XLF", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": post_ts, "end_at": post_ts, "detail": ""},
+                {"symbol": "XLE", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "XLE", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": post_ts, "end_at": post_ts, "detail": ""},
+                {"symbol": "SMH", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "SMH", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": post_ts, "end_at": post_ts, "detail": ""},
+            ],
+        )
+        self.tracked_accounts = pd.DataFrame(
+            [
+                {
+                    "version_id": "v1",
+                    "account_id": "acct-a",
+                    "handle": "macroa",
+                    "display_name": "Macro A",
+                    "source_platform": "X",
+                    "discovery_score": 1.0,
+                    "status": "active",
+                    "first_seen_at": pd.Timestamp("2026-04-10"),
+                    "last_seen_at": pd.Timestamp("2026-04-15"),
+                    "effective_from": pd.Timestamp("2026-04-15"),
+                    "effective_to": pd.NaT,
+                    "auto_included": True,
+                    "provenance": "unit-test",
+                    "mention_count": 1,
+                    "engagement_mean": 10.0,
+                    "active_days": 1,
+                },
+            ],
+            columns=TRACKED_ACCOUNT_COLUMNS,
+        )
+        self.ranking_history = pd.DataFrame(columns=RANKING_HISTORY_COLUMNS)
+        self.asset_post_mappings = pd.DataFrame(
+            [
+                {
+                    "asset_symbol": "QQQ",
+                    "session_date": pd.Timestamp("2026-04-15"),
+                    "post_id": "post-1",
+                    "reaction_anchor_ts": post_ts,
+                    "mapping_reason": "same-session",
+                    "author_handle": "macroa",
+                    "author_display_name": "Macro A",
+                    "author_account_id": "acct-a",
+                    "author_is_trump": False,
+                    "source_platform": "X",
+                    "cleaned_text": "Trump growth",
+                    "mentions_trump": True,
+                    "engagement_score": 6.0,
+                    "sentiment_score": 0.3,
+                    "sentiment_label": "positive",
+                    "semantic_topic": "markets",
+                    "semantic_policy_bucket": "economy",
+                    "semantic_stance": "supportive",
+                    "semantic_market_relevance": 0.8,
+                    "semantic_urgency": 0.2,
+                    "semantic_primary_asset": "QQQ",
+                    "semantic_asset_targets": "QQQ",
+                    "semantic_confidence": 0.7,
+                    "semantic_summary": "Market-related post",
+                    "semantic_schema_version": "v1",
+                    "semantic_provider": "heuristic",
+                    "is_active_tracked_account": True,
+                    "tracked_discovery_score": 1.0,
+                    "tracked_account_status": "active",
+                    "rule_match_score": 0.4,
+                    "semantic_match_score": 0.3,
+                    "asset_relevance_score": 0.7,
+                    "match_reasons": "ticker",
+                    "match_rank": 1,
+                    "is_primary_asset": True,
+                    "asset_display_name": "QQQ",
+                    "asset_type": "etf",
+                    "asset_source": "core_etf",
+                },
+            ],
+        )
+        self.asset_session_features = pd.DataFrame(
+            [
+                {
+                    "asset_symbol": "QQQ",
+                    "signal_session_date": pd.Timestamp("2026-04-15"),
+                    "next_session_date": pd.Timestamp("2026-04-16"),
+                    "post_count": 1,
+                    "target_next_session_return": 0.01,
+                    "target_available": True,
+                },
+            ],
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _save_required_frames(self) -> None:
+        self.store.save_frame("normalized_posts", self.posts, metadata={"row_count": len(self.posts)})
+        self.store.save_frame("source_manifests", self.source_manifest, metadata={"row_count": len(self.source_manifest)})
+        self.store.save_frame("sp500_daily", self.sp500, metadata={"row_count": len(self.sp500)})
+        self.store.save_frame("spy_daily", self.spy, metadata={"row_count": len(self.spy)})
+        self.store.save_frame(
+            "asset_universe",
+            pd.DataFrame(
+                [
+                    {"symbol": "SPY", "display_name": "SPY", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                    {"symbol": "QQQ", "display_name": "QQQ", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                    {"symbol": "XLK", "display_name": "XLK", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                    {"symbol": "XLF", "display_name": "XLF", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                    {"symbol": "XLE", "display_name": "XLE", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                    {"symbol": "SMH", "display_name": "SMH", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                ],
+            ),
+            metadata={"row_count": 6},
+        )
+        self.store.save_frame("asset_daily", self.asset_daily, metadata={"row_count": len(self.asset_daily)})
+        self.store.save_frame("asset_intraday", self.asset_intraday, metadata={"row_count": len(self.asset_intraday)})
+        self.store.save_frame("asset_market_manifest", self.asset_market_manifest, metadata={"row_count": len(self.asset_market_manifest)})
+        self.store.save_frame("tracked_accounts", self.tracked_accounts, metadata={"row_count": len(self.tracked_accounts)})
+        self.store.save_frame("asset_post_mappings", self.asset_post_mappings, metadata={"row_count": len(self.asset_post_mappings)})
+        self.store.save_frame("asset_session_features", self.asset_session_features, metadata={"row_count": len(self.asset_session_features)})
+
+    def test_append_refresh_history_records_success_and_failure_rows(self) -> None:
+        first = _append_refresh_history(
+            self.store,
+            refresh_id="refresh-1",
+            refresh_mode="full",
+            status="success",
+            started_at=pd.Timestamp("2026-04-15 12:00:00", tz="UTC"),
+            completed_at=pd.Timestamp("2026-04-15 12:01:00", tz="UTC"),
+        )
+        second = _append_refresh_history(
+            self.store,
+            refresh_id="refresh-2",
+            refresh_mode="incremental",
+            status="error",
+            started_at=pd.Timestamp("2026-04-15 12:05:00", tz="UTC"),
+            completed_at=pd.Timestamp("2026-04-15 12:06:00", tz="UTC"),
+            error_message="network timeout",
+        )
+
+        history = self.store.read_frame("refresh_history")
+        self.assertEqual(len(first), 1)
+        self.assertEqual(len(second), 2)
+        self.assertEqual(list(history["status"]), ["success", "error"])
+        self.assertEqual(list(history["refresh_mode"]), ["full", "incremental"])
+
+    def test_load_data_health_view_state_computes_in_memory_snapshot_without_history(self) -> None:
+        self._save_required_frames()
+
+        state = _load_data_health_view_state(self.store, self.health_service)
+
+        self.assertFalse(state["latest"].empty)
+        self.assertTrue(state["history"].empty)
+        self.assertEqual(state["refresh_history"].columns.tolist(), REFRESH_HISTORY_COLUMNS)
+        self.assertIn("overall_severity", state["summary"])
+        self.assertFalse(state["trend"].empty)
+
+    def test_filter_health_rows_filters_severity_and_scope_kind(self) -> None:
+        rows = pd.DataFrame(
+            [
+                {"snapshot_id": "a", "generated_at": pd.Timestamp("2026-04-15", tz="UTC"), "refresh_id": "r1", "scope_kind": "dataset", "scope_key": "normalized_posts", "check_name": "row_count_anomaly", "severity": "warn", "observed_value": 120.0, "baseline_value": 100.0, "detail": ""},
+                {"snapshot_id": "a", "generated_at": pd.Timestamp("2026-04-15", tz="UTC"), "refresh_id": "r1", "scope_kind": "asset_intraday", "scope_key": "QQQ", "check_name": "intraday_lag_minutes", "severity": "severe", "observed_value": 130.0, "baseline_value": 30.0, "detail": ""},
+                {"snapshot_id": "a", "generated_at": pd.Timestamp("2026-04-15", tz="UTC"), "refresh_id": "r1", "scope_kind": "dataset", "scope_key": "spy_daily", "check_name": "duplicate_rate", "severity": "ok", "observed_value": 0.0, "baseline_value": 0.005, "detail": ""},
+            ],
+            columns=HEALTH_CHECK_COLUMNS,
+        )
+
+        filtered = _filter_health_rows(rows, ["warn", "severe"], "dataset")
+
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered.iloc[0]["scope_key"], "normalized_posts")
+
+    def test_refresh_datasets_persists_health_snapshots_for_full_and_incremental_runs(self) -> None:
+        ingestion_service = _FakeIngestionService(self.posts, self.posts, self.source_manifest)
+        market_service = _FakeMarketService(self.sp500, self.spy, self.asset_daily, self.asset_intraday, self.asset_market_manifest)
+        discovery_service = _FakeDiscoveryService(self.tracked_accounts, self.ranking_history)
+        feature_service = _FakeFeatureService(self.posts, self.asset_post_mappings, self.asset_session_features)
+
+        first = _refresh_datasets(
+            settings=self.settings,
+            store=self.store,
+            ingestion_service=ingestion_service,
+            market_service=market_service,
+            discovery_service=discovery_service,
+            feature_service=feature_service,
+            health_service=self.health_service,
+            remote_url="",
+            uploaded_files=[],
+            incremental=False,
+            refresh_mode="full",
+        )
+        second = _refresh_datasets(
+            settings=self.settings,
+            store=self.store,
+            ingestion_service=ingestion_service,
+            market_service=market_service,
+            discovery_service=discovery_service,
+            feature_service=feature_service,
+            health_service=self.health_service,
+            remote_url="",
+            uploaded_files=[],
+            incremental=True,
+            refresh_mode="incremental",
+        )
+
+        latest = self.store.read_frame("data_health_latest")
+        history = self.store.read_frame("data_health_history")
+        refresh_history = self.store.read_frame("refresh_history")
+
+        self.assertFalse(first["data_health_latest"].empty)
+        self.assertFalse(second["data_health_latest"].empty)
+        self.assertFalse(latest.empty)
+        self.assertGreaterEqual(history["snapshot_id"].nunique(), 2)
+        self.assertEqual(len(refresh_history), 2)
+        self.assertEqual(list(refresh_history["status"]), ["success", "success"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from trump_workbench.config import AppSettings, EASTERN
+from trump_workbench.health import (
+    HEALTH_CHECK_COLUMNS,
+    DataHealthService,
+    create_refresh_id,
+)
+from trump_workbench.storage import DuckDBStore
+
+
+class DataHealthServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.settings = AppSettings(base_dir=Path(self.temp_dir.name))
+        self.store = DuckDBStore(self.settings)
+        self.service = DataHealthService()
+        self.generated_at = pd.Timestamp("2026-04-15 15:00:00", tz="UTC")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _complete_datasets(self) -> dict[str, pd.DataFrame]:
+        base_ts = pd.Timestamp("2026-04-15 10:00:00", tz=EASTERN)
+        return {
+            "normalized_posts": pd.DataFrame(
+                [
+                    {
+                        "source_platform": "X",
+                        "source_type": "x_csv",
+                        "author_account_id": "acct-a",
+                        "author_handle": "macroa",
+                        "author_display_name": "Macro A",
+                        "author_is_trump": False,
+                        "post_id": "post-1",
+                        "post_url": "https://x.com/macroa/status/1",
+                        "post_timestamp": base_ts,
+                        "raw_text": "Trump growth",
+                        "cleaned_text": "Trump growth",
+                        "is_reshare": False,
+                        "has_media": False,
+                        "replies_count": 1,
+                        "reblogs_count": 2,
+                        "favourites_count": 3,
+                        "mentions_trump": True,
+                        "source_provenance": "unit-test",
+                        "engagement_score": 6.0,
+                        "sentiment_score": 0.2,
+                        "sentiment_label": "positive",
+                    },
+                ],
+            ),
+            "source_manifests": pd.DataFrame(
+                [
+                    {
+                        "source": "Truth Social archive",
+                        "provenance": "unit-test",
+                        "post_count": 1,
+                        "coverage_start": base_ts,
+                        "coverage_end": base_ts,
+                        "status": "ok",
+                        "detail": "",
+                    },
+                ],
+            ),
+            "sp500_daily": pd.DataFrame([{"trade_date": pd.Timestamp("2026-04-15"), "close": 6100.0}]),
+            "spy_daily": pd.DataFrame(
+                [
+                    {
+                        "trade_date": pd.Timestamp("2026-04-15"),
+                        "open": 600.0,
+                        "high": 605.0,
+                        "low": 598.0,
+                        "close": 603.0,
+                        "volume": 1_000_000,
+                    },
+                ],
+            ),
+            "asset_universe": pd.DataFrame(
+                [
+                    {"symbol": "SPY", "display_name": "SPY", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                    {"symbol": "QQQ", "display_name": "QQQ", "asset_type": "etf", "source": "core_etf", "is_default": True, "is_watchlist": False},
+                ],
+            ),
+            "asset_daily": pd.DataFrame(
+                [
+                    {"symbol": "SPY", "trade_date": pd.Timestamp("2026-04-15"), "open": 600.0, "high": 605.0, "low": 598.0, "close": 603.0, "volume": 1_000_000},
+                    {"symbol": "QQQ", "trade_date": pd.Timestamp("2026-04-15"), "open": 500.0, "high": 506.0, "low": 498.0, "close": 504.0, "volume": 500_000},
+                ],
+            ),
+            "asset_intraday": pd.DataFrame(
+                [
+                    {"symbol": "SPY", "timestamp": base_ts, "open": 600.0, "high": 601.0, "low": 599.0, "close": 600.5, "volume": 1000, "interval": "5m"},
+                    {"symbol": "QQQ", "timestamp": base_ts, "open": 500.0, "high": 501.0, "low": 499.0, "close": 500.5, "volume": 900, "interval": "5m"},
+                ],
+            ),
+            "asset_market_manifest": pd.DataFrame(
+                [
+                    {"symbol": "SPY", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                    {"symbol": "SPY", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": base_ts, "end_at": base_ts, "detail": ""},
+                    {"symbol": "QQQ", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                    {"symbol": "QQQ", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": base_ts, "end_at": base_ts, "detail": ""},
+                ],
+            ),
+            "tracked_accounts": pd.DataFrame(
+                [
+                    {
+                        "version_id": "v1",
+                        "account_id": "acct-a",
+                        "handle": "macroa",
+                        "display_name": "Macro A",
+                        "source_platform": "X",
+                        "discovery_score": 1.0,
+                        "status": "active",
+                        "first_seen_at": pd.Timestamp("2026-04-10"),
+                        "last_seen_at": pd.Timestamp("2026-04-15"),
+                        "effective_from": pd.Timestamp("2026-04-15"),
+                        "effective_to": pd.NaT,
+                        "auto_included": True,
+                        "provenance": "unit-test",
+                        "mention_count": 1,
+                        "engagement_mean": 10.0,
+                        "active_days": 1,
+                    },
+                ],
+            ),
+            "asset_post_mappings": pd.DataFrame(
+                [
+                    {
+                        "asset_symbol": "QQQ",
+                        "post_id": "post-1",
+                        "session_date": pd.Timestamp("2026-04-15"),
+                        "asset_relevance_score": 0.6,
+                        "mapping_reason": "same-session",
+                    },
+                ],
+            ),
+            "asset_session_features": pd.DataFrame(
+                [
+                    {
+                        "asset_symbol": "QQQ",
+                        "signal_session_date": pd.Timestamp("2026-04-15"),
+                        "post_count": 1,
+                        "target_next_session_return": 0.01,
+                        "target_available": True,
+                    },
+                ],
+            ),
+        }
+
+    def _dataset_registry(self, datasets: dict[str, pd.DataFrame]) -> pd.DataFrame:
+        rows = []
+        for dataset_name, frame in datasets.items():
+            rows.append(
+                {
+                    "dataset_name": dataset_name,
+                    "parquet_path": f"/tmp/{dataset_name}.parquet",
+                    "row_count": int(len(frame)),
+                    "updated_at": self.generated_at - pd.Timedelta(hours=1),
+                    "metadata_json": "{}",
+                },
+            )
+        return pd.DataFrame(rows)
+
+    def _history_rows(self, scope_kind: str, scope_key: str, check_name: str, observed_values: list[float]) -> pd.DataFrame:
+        rows = []
+        for idx, value in enumerate(observed_values):
+            ts = self.generated_at - pd.Timedelta(days=idx + 1)
+            rows.append(
+                {
+                    "snapshot_id": f"snap-{idx}",
+                    "generated_at": ts,
+                    "refresh_id": f"refresh-{idx}",
+                    "scope_kind": scope_kind,
+                    "scope_key": scope_key,
+                    "check_name": check_name,
+                    "severity": "ok",
+                    "observed_value": float(value),
+                    "baseline_value": pd.NA,
+                    "detail": "",
+                },
+            )
+        return pd.DataFrame(rows, columns=HEALTH_CHECK_COLUMNS)
+
+    def test_missing_required_dataset_is_severe(self) -> None:
+        datasets = self._complete_datasets()
+        datasets["normalized_posts"] = pd.DataFrame()
+
+        health = self.service.evaluate(
+            datasets=datasets,
+            dataset_registry=self._dataset_registry(datasets),
+            history=pd.DataFrame(columns=HEALTH_CHECK_COLUMNS),
+            refresh_id="refresh-1",
+            generated_at=self.generated_at,
+        )
+
+        row = health.loc[
+            (health["scope_key"] == "normalized_posts")
+            & (health["check_name"] == "dataset_presence")
+        ].iloc[0]
+        self.assertEqual(row["severity"], "severe")
+
+    def test_missing_required_columns_is_severe(self) -> None:
+        datasets = self._complete_datasets()
+        datasets["asset_daily"] = pd.DataFrame(
+            [{"symbol": "SPY", "trade_date": pd.Timestamp("2026-04-15"), "close": 603.0}],
+        )
+
+        health = self.service.evaluate(
+            datasets=datasets,
+            dataset_registry=self._dataset_registry(datasets),
+            history=pd.DataFrame(columns=HEALTH_CHECK_COLUMNS),
+            refresh_id="refresh-2",
+            generated_at=self.generated_at,
+        )
+
+        row = health.loc[
+            (health["scope_key"] == "asset_daily")
+            & (health["check_name"] == "required_columns")
+        ].iloc[0]
+        self.assertEqual(row["severity"], "severe")
+        self.assertIn("open", str(row["detail"]))
+
+    def test_manifest_errors_are_severe(self) -> None:
+        datasets = self._complete_datasets()
+        datasets["source_manifests"].loc[0, "status"] = "error"
+        datasets["source_manifests"].loc[0, "detail"] = "remote CSV timeout"
+        datasets["asset_market_manifest"].loc[1, "status"] = "error"
+        datasets["asset_market_manifest"].loc[1, "detail"] = "intraday download failed"
+
+        health = self.service.evaluate(
+            datasets=datasets,
+            dataset_registry=self._dataset_registry(datasets),
+            history=pd.DataFrame(columns=HEALTH_CHECK_COLUMNS),
+            refresh_id="refresh-3",
+            generated_at=self.generated_at,
+        )
+
+        source_row = health.loc[
+            (health["scope_kind"] == "source_manifest")
+            & (health["check_name"] == "manifest_status")
+        ].iloc[0]
+        market_row = health.loc[
+            (health["scope_key"] == "SPY:intraday_5m")
+            & (health["check_name"] == "manifest_status")
+        ].iloc[0]
+        self.assertEqual(source_row["severity"], "severe")
+        self.assertEqual(market_row["severity"], "severe")
+
+    def test_duplicate_rate_warn_and_severe_thresholds(self) -> None:
+        datasets = self._complete_datasets()
+        normalized_rows = []
+        for idx in range(100):
+            normalized_rows.append(
+                {
+                    **datasets["normalized_posts"].iloc[0].to_dict(),
+                    "post_id": f"post-{idx}",
+                    "post_url": f"https://x.com/macroa/status/{idx}",
+                },
+            )
+        normalized_rows.append({**normalized_rows[0]})
+        datasets["normalized_posts"] = pd.DataFrame(normalized_rows)
+
+        daily_rows = []
+        for idx in range(100):
+            daily_rows.append(
+                {
+                    "symbol": "SPY",
+                    "trade_date": pd.Timestamp("2026-01-01") + pd.Timedelta(days=idx),
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": 100.5,
+                    "volume": 1_000,
+                },
+            )
+        daily_rows.extend([daily_rows[0], daily_rows[1], daily_rows[2]])
+        datasets["asset_daily"] = pd.DataFrame(daily_rows)
+
+        health = self.service.evaluate(
+            datasets=datasets,
+            dataset_registry=self._dataset_registry(datasets),
+            history=pd.DataFrame(columns=HEALTH_CHECK_COLUMNS),
+            refresh_id="refresh-4",
+            generated_at=self.generated_at,
+        )
+
+        post_row = health.loc[
+            (health["scope_key"] == "normalized_posts")
+            & (health["check_name"] == "duplicate_rate")
+        ].iloc[0]
+        daily_row = health.loc[
+            (health["scope_key"] == "asset_daily")
+            & (health["check_name"] == "duplicate_rate")
+        ].iloc[0]
+        self.assertEqual(post_row["severity"], "warn")
+        self.assertEqual(daily_row["severity"], "severe")
+
+    def test_row_count_anomaly_thresholds_and_intraday_lag(self) -> None:
+        datasets = self._complete_datasets()
+        datasets["normalized_posts"] = pd.concat(
+            [datasets["normalized_posts"]] * 160,
+            ignore_index=True,
+        ).assign(post_id=lambda df: [f"post-{idx}" for idx in range(len(df))])
+        datasets["asset_intraday"] = pd.DataFrame(
+            [
+                {"symbol": "SPY", "timestamp": pd.Timestamp("2026-04-15 10:00:00", tz=EASTERN), "open": 600.0, "high": 601.0, "low": 599.0, "close": 600.5, "volume": 1000, "interval": "5m"},
+                {"symbol": "QQQ", "timestamp": pd.Timestamp("2026-04-15 09:20:00", tz=EASTERN), "open": 500.0, "high": 501.0, "low": 499.0, "close": 500.5, "volume": 900, "interval": "5m"},
+                {"symbol": "XLK", "timestamp": pd.Timestamp("2026-04-15 07:50:00", tz=EASTERN), "open": 200.0, "high": 201.0, "low": 199.0, "close": 200.5, "volume": 700, "interval": "5m"},
+            ],
+        )
+        datasets["asset_market_manifest"] = pd.DataFrame(
+            [
+                {"symbol": "SPY", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "SPY", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15 10:00:00", tz=EASTERN), "end_at": pd.Timestamp("2026-04-15 10:00:00", tz=EASTERN), "detail": ""},
+                {"symbol": "QQQ", "dataset_kind": "daily", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15"), "end_at": pd.Timestamp("2026-04-15"), "detail": ""},
+                {"symbol": "QQQ", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15 09:20:00", tz=EASTERN), "end_at": pd.Timestamp("2026-04-15 09:20:00", tz=EASTERN), "detail": ""},
+                {"symbol": "XLK", "dataset_kind": "intraday_5m", "row_count": 1, "status": "ok", "start_at": pd.Timestamp("2026-04-15 07:50:00", tz=EASTERN), "end_at": pd.Timestamp("2026-04-15 07:50:00", tz=EASTERN), "detail": ""},
+            ],
+        )
+        history = self._history_rows("dataset", "normalized_posts", "row_count_anomaly", [100.0] * 10)
+
+        health = self.service.evaluate(
+            datasets=datasets,
+            dataset_registry=self._dataset_registry(datasets),
+            history=history,
+            refresh_id="refresh-5",
+            generated_at=self.generated_at,
+        )
+
+        anomaly_row = health.loc[
+            (health["scope_key"] == "normalized_posts")
+            & (health["check_name"] == "row_count_anomaly")
+        ].iloc[0]
+        qqq_lag = health.loc[
+            (health["scope_key"] == "QQQ")
+            & (health["check_name"] == "intraday_lag_minutes")
+        ].iloc[0]
+        xlk_lag = health.loc[
+            (health["scope_key"] == "XLK")
+            & (health["check_name"] == "intraday_lag_minutes")
+        ].iloc[0]
+        self.assertEqual(anomaly_row["severity"], "warn")
+        self.assertEqual(qqq_lag["severity"], "warn")
+        self.assertEqual(xlk_lag["severity"], "severe")
+
+    def test_persist_snapshot_round_trips_latest_and_history(self) -> None:
+        datasets = self._complete_datasets()
+        for dataset_name, frame in datasets.items():
+            self.store.save_frame(dataset_name, frame, metadata={"row_count": int(len(frame))})
+
+        first_refresh_id = create_refresh_id("full", self.generated_at)
+        first_latest = self.service.persist_snapshot(self.store, refresh_id=first_refresh_id, generated_at=self.generated_at)
+        second_refresh_id = create_refresh_id("incremental", self.generated_at + pd.Timedelta(minutes=5))
+        second_latest = self.service.persist_snapshot(
+            self.store,
+            refresh_id=second_refresh_id,
+            generated_at=self.generated_at + pd.Timedelta(minutes=5),
+        )
+
+        latest = self.store.read_frame("data_health_latest")
+        history = self.store.read_frame("data_health_history")
+
+        self.assertFalse(first_latest.empty)
+        self.assertFalse(second_latest.empty)
+        self.assertEqual(str(latest.iloc[0]["refresh_id"]), second_refresh_id)
+        self.assertGreaterEqual(history["snapshot_id"].nunique(), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trump_workbench/health.py
+++ b/trump_workbench/health.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .config import EASTERN
+from .contracts import NORMALIZED_POST_COLUMNS, TRACKED_ACCOUNT_COLUMNS
+from .features import ASSET_POST_MAPPING_COLUMNS
+from .market import ASSET_DAILY_COLUMNS, ASSET_INTRADAY_COLUMNS, ASSET_UNIVERSE_COLUMNS, MARKET_MANIFEST_COLUMNS
+from .storage import DuckDBStore
+from .utils import stable_text_id
+
+HEALTH_CHECK_COLUMNS = [
+    "snapshot_id",
+    "generated_at",
+    "refresh_id",
+    "scope_kind",
+    "scope_key",
+    "check_name",
+    "severity",
+    "observed_value",
+    "baseline_value",
+    "detail",
+]
+
+REFRESH_HISTORY_COLUMNS = [
+    "refresh_id",
+    "started_at",
+    "completed_at",
+    "refresh_mode",
+    "status",
+    "error_message",
+]
+
+SEVERITY_ORDER = {"ok": 0, "warn": 1, "severe": 2}
+REQUIRED_DATASET_COLUMNS: dict[str, list[str]] = {
+    "normalized_posts": NORMALIZED_POST_COLUMNS,
+    "source_manifests": ["source", "post_count"],
+    "sp500_daily": ["trade_date", "close"],
+    "spy_daily": ["trade_date", "open", "close"],
+    "asset_universe": ASSET_UNIVERSE_COLUMNS,
+    "asset_daily": ASSET_DAILY_COLUMNS,
+    "asset_intraday": ASSET_INTRADAY_COLUMNS,
+    "asset_market_manifest": MARKET_MANIFEST_COLUMNS,
+    "tracked_accounts": TRACKED_ACCOUNT_COLUMNS,
+    "asset_post_mappings": [
+        "asset_symbol",
+        "post_id",
+        "session_date",
+        "asset_relevance_score",
+        "mapping_reason",
+    ],
+    "asset_session_features": [
+        "asset_symbol",
+        "signal_session_date",
+        "post_count",
+        "target_next_session_return",
+        "target_available",
+    ],
+}
+REQUIRED_DATASETS = tuple(REQUIRED_DATASET_COLUMNS.keys())
+FRESHNESS_THRESHOLDS_HOURS = {
+    "asset_intraday": (6.0, 24.0),
+    "asset_market_manifest": (6.0, 24.0),
+}
+DEFAULT_FRESHNESS_THRESHOLDS = (24.0, 72.0)
+DUPLICATE_KEY_COLUMNS = {
+    "normalized_posts": ["post_id"],
+    "asset_daily": ["symbol", "trade_date"],
+    "asset_intraday": ["symbol", "timestamp", "interval"],
+}
+
+
+def _empty_health_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=HEALTH_CHECK_COLUMNS)
+
+
+def _empty_refresh_history_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=REFRESH_HISTORY_COLUMNS)
+
+
+def _coerce_utc_timestamp(value: object) -> pd.Timestamp | pd.NaT:
+    ts = pd.to_datetime(value, errors="coerce")
+    if pd.isna(ts):
+        return pd.NaT
+    if ts.tzinfo is None:
+        return ts.tz_localize("UTC")
+    return ts.tz_convert("UTC")
+
+
+def _ensure_health_frame(frame: pd.DataFrame | None) -> pd.DataFrame:
+    if frame is None or frame.empty:
+        return _empty_health_frame()
+    out = frame.copy()
+    for column in HEALTH_CHECK_COLUMNS:
+        if column not in out.columns:
+            out[column] = pd.NA
+    out["generated_at"] = pd.to_datetime(out["generated_at"], errors="coerce", utc=True)
+    out["observed_value"] = pd.to_numeric(out["observed_value"], errors="coerce")
+    out["baseline_value"] = pd.to_numeric(out["baseline_value"], errors="coerce")
+    out["severity"] = out["severity"].fillna("ok").astype(str).str.lower()
+    return out[HEALTH_CHECK_COLUMNS].copy()
+
+
+def ensure_refresh_history_frame(frame: pd.DataFrame | None) -> pd.DataFrame:
+    if frame is None or frame.empty:
+        return _empty_refresh_history_frame()
+    out = frame.copy()
+    for column in REFRESH_HISTORY_COLUMNS:
+        if column not in out.columns:
+            out[column] = pd.NA
+    out["started_at"] = pd.to_datetime(out["started_at"], errors="coerce", utc=True)
+    out["completed_at"] = pd.to_datetime(out["completed_at"], errors="coerce", utc=True)
+    out["refresh_mode"] = out["refresh_mode"].fillna("").astype(str)
+    out["status"] = out["status"].fillna("").astype(str)
+    out["error_message"] = out["error_message"].fillna("").astype(str)
+    return out[REFRESH_HISTORY_COLUMNS].copy()
+
+
+def create_refresh_id(refresh_mode: str, started_at: pd.Timestamp) -> str:
+    return stable_text_id(refresh_mode, _coerce_utc_timestamp(started_at).isoformat())
+
+
+def make_refresh_history_frame(
+    refresh_id: str,
+    refresh_mode: str,
+    status: str,
+    started_at: pd.Timestamp,
+    completed_at: pd.Timestamp,
+    error_message: str = "",
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "refresh_id": str(refresh_id),
+                "started_at": _coerce_utc_timestamp(started_at),
+                "completed_at": _coerce_utc_timestamp(completed_at),
+                "refresh_mode": str(refresh_mode),
+                "status": str(status),
+                "error_message": str(error_message or ""),
+            },
+        ],
+        columns=REFRESH_HISTORY_COLUMNS,
+    )
+
+
+def build_health_summary(latest: pd.DataFrame, refresh_history: pd.DataFrame) -> dict[str, Any]:
+    checks = _ensure_health_frame(latest)
+    history = ensure_refresh_history_frame(refresh_history)
+    if checks.empty:
+        overall_severity = "ok"
+        severe_count = 0
+        warn_count = 0
+        anomaly_count = 0
+    else:
+        severity_scores = checks["severity"].map(SEVERITY_ORDER).fillna(0)
+        overall_score = int(severity_scores.max()) if not severity_scores.empty else 0
+        overall_severity = next(
+            severity
+            for severity, score in SEVERITY_ORDER.items()
+            if score == overall_score
+        )
+        severe_count = int((checks["severity"] == "severe").sum())
+        warn_count = int((checks["severity"] == "warn").sum())
+        anomaly_count = int(
+            checks.loc[
+                checks["check_name"].astype(str).str.contains("anomaly", case=False, na=False)
+                & (checks["severity"] != "ok")
+            ].shape[0],
+        )
+
+    last_refresh_status = "n/a"
+    last_refresh_at = pd.NaT
+    last_refresh_mode = ""
+    if not history.empty:
+        order_col = "completed_at" if history["completed_at"].notna().any() else "started_at"
+        last_row = history.sort_values(order_col).iloc[-1]
+        last_refresh_status = str(last_row.get("status", "n/a") or "n/a")
+        last_refresh_at = last_row.get(order_col, pd.NaT)
+        last_refresh_mode = str(last_row.get("refresh_mode", "") or "")
+
+    return {
+        "overall_severity": overall_severity,
+        "severe_count": severe_count,
+        "warn_count": warn_count,
+        "anomaly_count": anomaly_count,
+        "last_refresh_status": last_refresh_status,
+        "last_refresh_at": last_refresh_at,
+        "last_refresh_mode": last_refresh_mode,
+    }
+
+
+def build_health_trend_frame(history: pd.DataFrame) -> pd.DataFrame:
+    checks = _ensure_health_frame(history)
+    if checks.empty:
+        return pd.DataFrame(columns=["snapshot_id", "generated_at", "ok_count", "warn_count", "severe_count", "overall_severity"])
+    grouped = (
+        checks.groupby(["snapshot_id", "generated_at", "severity"])
+        .size()
+        .unstack(fill_value=0)
+        .reset_index()
+    )
+    for column in ["ok", "warn", "severe"]:
+        if column not in grouped.columns:
+            grouped[column] = 0
+    grouped = grouped.rename(columns={"ok": "ok_count", "warn": "warn_count", "severe": "severe_count"})
+
+    def resolve_overall(row: pd.Series) -> str:
+        if int(row.get("severe_count", 0)) > 0:
+            return "severe"
+        if int(row.get("warn_count", 0)) > 0:
+            return "warn"
+        return "ok"
+
+    grouped["overall_severity"] = grouped.apply(resolve_overall, axis=1)
+    return grouped.sort_values("generated_at").reset_index(drop=True)
+
+
+class DataHealthService:
+    def __init__(self, history_window: int = 10) -> None:
+        self.history_window = history_window
+
+    def evaluate_store(
+        self,
+        store: DuckDBStore,
+        refresh_id: str = "",
+        generated_at: pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        datasets = {
+            dataset_name: store.read_frame(dataset_name)
+            for dataset_name in REQUIRED_DATASETS
+        }
+        return self.evaluate(
+            datasets=datasets,
+            dataset_registry=store.dataset_registry(),
+            history=store.read_frame("data_health_history"),
+            refresh_id=refresh_id,
+            generated_at=generated_at,
+        )
+
+    def persist_snapshot(
+        self,
+        store: DuckDBStore,
+        refresh_id: str,
+        generated_at: pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        latest = self.evaluate_store(store, refresh_id=refresh_id, generated_at=generated_at)
+        snapshot_id = str(latest.iloc[0]["snapshot_id"]) if not latest.empty else ""
+        store.save_frame(
+            "data_health_latest",
+            latest,
+            metadata={"row_count": int(len(latest)), "snapshot_id": snapshot_id},
+        )
+        store.append_frame(
+            "data_health_history",
+            latest,
+            dedupe_on=["snapshot_id", "scope_kind", "scope_key", "check_name"],
+            metadata={"snapshot_id": snapshot_id},
+        )
+        return latest
+
+    def evaluate(
+        self,
+        datasets: dict[str, pd.DataFrame],
+        dataset_registry: pd.DataFrame,
+        history: pd.DataFrame | None = None,
+        refresh_id: str = "",
+        generated_at: pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        generated_ts = _coerce_utc_timestamp(generated_at)
+        if pd.isna(generated_ts):
+            generated_ts = pd.Timestamp.now(tz="UTC")
+        snapshot_id = stable_text_id(refresh_id or "ad-hoc", generated_ts.isoformat())
+        checks_history = _ensure_health_frame(history)
+        registry = dataset_registry.copy() if dataset_registry is not None else pd.DataFrame()
+        if not registry.empty:
+            if "dataset_name" not in registry.columns:
+                registry["dataset_name"] = ""
+            registry["dataset_name"] = registry["dataset_name"].astype(str)
+            registry["updated_at"] = registry["updated_at"].map(_coerce_utc_timestamp)
+
+        rows: list[dict[str, Any]] = []
+
+        def add_row(
+            scope_kind: str,
+            scope_key: str,
+            check_name: str,
+            severity: str,
+            observed_value: float | int | None,
+            baseline_value: float | int | None = None,
+            detail: str = "",
+        ) -> None:
+            rows.append(
+                {
+                    "snapshot_id": snapshot_id,
+                    "generated_at": generated_ts,
+                    "refresh_id": str(refresh_id),
+                    "scope_kind": str(scope_kind),
+                    "scope_key": str(scope_key),
+                    "check_name": str(check_name),
+                    "severity": str(severity),
+                    "observed_value": float(observed_value) if observed_value is not None and pd.notna(observed_value) else np.nan,
+                    "baseline_value": float(baseline_value) if baseline_value is not None and pd.notna(baseline_value) else np.nan,
+                    "detail": str(detail or ""),
+                },
+            )
+
+        for dataset_name, required_columns in REQUIRED_DATASET_COLUMNS.items():
+            frame = datasets.get(dataset_name, pd.DataFrame())
+            row_count = int(len(frame))
+            add_row(
+                "dataset",
+                dataset_name,
+                "dataset_presence",
+                "severe" if row_count == 0 else "ok",
+                row_count,
+                detail="Dataset missing or empty." if row_count == 0 else "",
+            )
+            if row_count == 0:
+                continue
+            missing_columns = [column for column in required_columns if column not in frame.columns]
+            add_row(
+                "dataset",
+                dataset_name,
+                "required_columns",
+                "severe" if missing_columns else "ok",
+                len(missing_columns),
+                detail=", ".join(missing_columns),
+            )
+
+        source_manifests = datasets.get("source_manifests", pd.DataFrame())
+        if not source_manifests.empty and "status" in source_manifests.columns:
+            for idx, row in source_manifests.iterrows():
+                scope_key = str(row.get("source") or row.get("provenance") or f"source_{idx}")
+                status = str(row.get("status", "ok") or "ok").lower()
+                add_row(
+                    "source_manifest",
+                    scope_key,
+                    "manifest_status",
+                    "severe" if status == "error" else "ok",
+                    row.get("post_count", 0),
+                    detail=str(row.get("detail", "") or row.get("provenance", "") or ""),
+                )
+
+        asset_market_manifest = datasets.get("asset_market_manifest", pd.DataFrame())
+        if not asset_market_manifest.empty and {"symbol", "dataset_kind", "status"}.issubset(asset_market_manifest.columns):
+            for _, row in asset_market_manifest.iterrows():
+                scope_key = f"{str(row.get('symbol', '')).upper()}:{row.get('dataset_kind', '')}"
+                status = str(row.get("status", "ok") or "ok").lower()
+                add_row(
+                    "asset_market",
+                    scope_key,
+                    "manifest_status",
+                    "severe" if status == "error" else "ok",
+                    row.get("row_count", 0),
+                    detail=str(row.get("detail", "") or ""),
+                )
+
+        for dataset_name in REQUIRED_DATASETS:
+            frame = datasets.get(dataset_name, pd.DataFrame())
+            if frame.empty:
+                continue
+            warn_hours, severe_hours = FRESHNESS_THRESHOLDS_HOURS.get(dataset_name, DEFAULT_FRESHNESS_THRESHOLDS)
+            registry_row = registry.loc[registry["dataset_name"] == dataset_name].tail(1) if not registry.empty else pd.DataFrame()
+            if registry_row.empty or pd.isna(registry_row.iloc[0].get("updated_at", pd.NaT)):
+                add_row(
+                    "dataset",
+                    dataset_name,
+                    "freshness_hours",
+                    "severe",
+                    np.nan,
+                    severe_hours,
+                    detail="Dataset registry entry or updated_at timestamp is missing.",
+                )
+                continue
+            updated_at = registry_row.iloc[0]["updated_at"]
+            age_hours = float((generated_ts - updated_at).total_seconds() / 3600.0)
+            severity = "ok"
+            if age_hours > severe_hours:
+                severity = "severe"
+            elif age_hours > warn_hours:
+                severity = "warn"
+            add_row(
+                "dataset",
+                dataset_name,
+                "freshness_hours",
+                severity,
+                age_hours,
+                warn_hours,
+                detail=f"Last updated at {updated_at.tz_convert(EASTERN).isoformat()}",
+            )
+
+        for dataset_name, subset in DUPLICATE_KEY_COLUMNS.items():
+            frame = datasets.get(dataset_name, pd.DataFrame())
+            if frame.empty or not set(subset).issubset(frame.columns):
+                continue
+            duplicate_rate = float(frame.duplicated(subset=subset, keep="last").mean())
+            severity = "ok"
+            if duplicate_rate > 0.02:
+                severity = "severe"
+            elif duplicate_rate > 0.005:
+                severity = "warn"
+            add_row(
+                "dataset",
+                dataset_name,
+                "duplicate_rate",
+                severity,
+                duplicate_rate,
+                0.005,
+                detail=f"Duplicate keys checked on {', '.join(subset)}",
+            )
+
+        asset_universe = datasets.get("asset_universe", pd.DataFrame())
+        asset_daily = datasets.get("asset_daily", pd.DataFrame())
+        if not asset_universe.empty and "symbol" in asset_universe.columns:
+            daily_counts = (
+                asset_daily.groupby("symbol").size().astype(int).to_dict()
+                if not asset_daily.empty and "symbol" in asset_daily.columns
+                else {}
+            )
+            for symbol in asset_universe["symbol"].astype(str).str.upper().tolist():
+                count = int(daily_counts.get(symbol, 0))
+                add_row(
+                    "asset_daily",
+                    symbol,
+                    "daily_coverage",
+                    "severe" if count == 0 else "ok",
+                    count,
+                    1.0,
+                    detail="No daily OHLCV rows were stored for this symbol." if count == 0 else "",
+                )
+
+        asset_intraday = datasets.get("asset_intraday", pd.DataFrame())
+        if not asset_intraday.empty and {"symbol", "timestamp"}.issubset(asset_intraday.columns):
+            intraday = asset_intraday.copy()
+            intraday["timestamp"] = pd.to_datetime(intraday["timestamp"], errors="coerce", utc=True)
+            intraday = intraday.dropna(subset=["timestamp"]).copy()
+            if not intraday.empty:
+                global_latest = intraday["timestamp"].max()
+                for symbol, group in intraday.groupby(intraday["symbol"].astype(str).str.upper()):
+                    symbol_latest = group["timestamp"].max()
+                    lag_minutes = float((global_latest - symbol_latest).total_seconds() / 60.0)
+                    severity = "ok"
+                    if lag_minutes > 120.0:
+                        severity = "severe"
+                    elif lag_minutes > 30.0:
+                        severity = "warn"
+                    add_row(
+                        "asset_intraday",
+                        str(symbol),
+                        "intraday_lag_minutes",
+                        severity,
+                        lag_minutes,
+                        30.0,
+                        detail=f"Latest intraday row at {symbol_latest.tz_convert(EASTERN).isoformat()}",
+                    )
+
+        for dataset_name in REQUIRED_DATASETS:
+            frame = datasets.get(dataset_name, pd.DataFrame())
+            row_count = int(len(frame))
+            baseline = self._history_median(checks_history, "dataset", dataset_name, "row_count_anomaly")
+            severity, detail = self._ratio_severity(row_count, baseline)
+            add_row("dataset", dataset_name, "row_count_anomaly", severity, row_count, baseline, detail)
+
+        if not asset_market_manifest.empty and {"symbol", "dataset_kind", "row_count"}.issubset(asset_market_manifest.columns):
+            for _, row in asset_market_manifest.iterrows():
+                scope_key = f"{str(row.get('symbol', '')).upper()}:{row.get('dataset_kind', '')}"
+                row_count = float(row.get("row_count", 0) or 0)
+                baseline = self._history_median(checks_history, "asset_market", scope_key, "market_coverage_anomaly")
+                severity, detail = self._ratio_severity(row_count, baseline)
+                add_row("asset_market", scope_key, "market_coverage_anomaly", severity, row_count, baseline, detail)
+
+        health = pd.DataFrame(rows, columns=HEALTH_CHECK_COLUMNS)
+        if health.empty:
+            return _empty_health_frame()
+        health["severity_rank"] = health["severity"].map(SEVERITY_ORDER).fillna(0)
+        health = health.sort_values(
+            ["severity_rank", "scope_kind", "scope_key", "check_name"],
+            ascending=[False, True, True, True],
+        ).drop(columns=["severity_rank"])
+        return health.reset_index(drop=True)
+
+    def _history_median(
+        self,
+        history: pd.DataFrame,
+        scope_kind: str,
+        scope_key: str,
+        check_name: str,
+    ) -> float | None:
+        if history.empty:
+            return None
+        relevant = history.loc[
+            (history["scope_kind"].astype(str) == str(scope_kind))
+            & (history["scope_key"].astype(str) == str(scope_key))
+            & (history["check_name"].astype(str) == str(check_name))
+        ].copy()
+        if relevant.empty:
+            return None
+        relevant = relevant.sort_values("generated_at", ascending=False).head(self.history_window)
+        values = pd.to_numeric(relevant["observed_value"], errors="coerce").dropna()
+        if values.empty:
+            return None
+        return float(values.median())
+
+    @staticmethod
+    def _ratio_severity(current_value: float | int, baseline_value: float | None) -> tuple[str, str]:
+        if baseline_value is None or pd.isna(baseline_value) or float(baseline_value) <= 0.0:
+            return "ok", ""
+        ratio = float(current_value) / float(baseline_value)
+        if ratio < 0.5 or ratio > 2.0:
+            return "severe", f"Current value is {ratio:.2f}x the recent median baseline."
+        if ratio < 0.75 or ratio > 1.5:
+            return "warn", f"Current value is {ratio:.2f}x the recent median baseline."
+        return "ok", f"Current value is {ratio:.2f}x the recent median baseline."

--- a/trump_workbench/ingestion.py
+++ b/trump_workbench/ingestion.py
@@ -350,6 +350,9 @@ class IngestionService:
         for adapter in adapters:
             posts, meta = adapter.fetch_history()
             frames.append(posts)
+            meta = dict(meta)
+            meta.setdefault("status", "ok")
+            meta.setdefault("detail", "")
             manifest_rows.append(meta)
         combined = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(columns=NORMALIZED_POST_COLUMNS)
         combined = _ensure_normalized_schema(combined) if not combined.empty else pd.DataFrame(columns=NORMALIZED_POST_COLUMNS)
@@ -366,6 +369,9 @@ class IngestionService:
         for adapter in adapters:
             posts, meta = adapter.fetch_since(last_cursor)
             frames.append(posts)
+            meta = dict(meta)
+            meta.setdefault("status", "ok")
+            meta.setdefault("detail", "")
             manifest_rows.append(meta)
         combined = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(columns=NORMALIZED_POST_COLUMNS)
         combined = _ensure_normalized_schema(combined) if not combined.empty else pd.DataFrame(columns=NORMALIZED_POST_COLUMNS)

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -11,7 +11,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 
 from .backtesting import BacktestService
-from .config import AppSettings, DEFAULT_ETF_SYMBOLS
+from .config import AppSettings, DEFAULT_ETF_SYMBOLS, EASTERN
 from .contracts import (
     LiveMonitorConfig,
     LiveMonitorPinnedRun,
@@ -26,6 +26,16 @@ from .enrichment import LLMEnrichmentService
 from .explanations import build_account_attribution, build_post_attribution
 from .experiments import ExperimentStore
 from .features import FeatureService, latest_feature_preview, map_posts_to_trade_sessions
+from .health import (
+    HEALTH_CHECK_COLUMNS,
+    REFRESH_HISTORY_COLUMNS,
+    DataHealthService,
+    build_health_summary,
+    build_health_trend_frame,
+    create_refresh_id,
+    ensure_refresh_history_frame,
+    make_refresh_history_frame,
+)
 from .ingestion import IngestionService, TruthSocialArchiveAdapter, XCsvAdapter
 from .market import MarketDataService, build_asset_universe, build_watchlist_frame, normalize_symbols
 from .modeling import (
@@ -625,87 +635,118 @@ def _refresh_datasets(
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
     feature_service: FeatureService,
+    health_service: DataHealthService,
     remote_url: str,
     uploaded_files: list[Any],
     incremental: bool = False,
+    refresh_mode: str = "full",
 ) -> dict[str, Any]:
-    adapters = _build_adapters(settings, remote_url, uploaded_files)
-    existing_posts = store.read_frame("normalized_posts")
-    last_cursor = pd.to_datetime(existing_posts["post_timestamp"], errors="coerce").max() if not existing_posts.empty else None
-    if incremental and last_cursor is not None:
-        new_posts, source_manifest = ingestion_service.run_incremental_refresh(adapters, last_cursor=last_cursor)
-        posts = pd.concat([existing_posts, new_posts], ignore_index=True) if not existing_posts.empty else new_posts
-        posts = posts.drop_duplicates(subset=["post_id"], keep="last").sort_values("post_timestamp").reset_index(drop=True)
-    else:
-        posts, source_manifest = ingestion_service.run_refresh(adapters)
-    store.save_frame("normalized_posts", posts, metadata={"row_count": int(len(posts))})
-    store.save_frame("source_manifests", source_manifest, metadata={"row_count": int(len(source_manifest))})
+    started_at = pd.Timestamp.now(tz="UTC")
+    resolved_mode = str(refresh_mode or ("incremental" if incremental else "full"))
+    refresh_id = create_refresh_id(resolved_mode, started_at)
 
-    start = settings.term_start.strftime("%Y-%m-%d")
-    end = pd.Timestamp.now(tz=settings.timezone).strftime("%Y-%m-%d")
-    sp500 = market_service.load_sp500_daily(start, end)
-    spy = market_service.load_spy_daily(start, end)
-    store.save_frame("sp500_daily", sp500, metadata={"row_count": int(len(sp500))})
-    store.save_frame("spy_daily", spy, metadata={"row_count": int(len(spy))})
+    try:
+        adapters = _build_adapters(settings, remote_url, uploaded_files)
+        existing_posts = store.read_frame("normalized_posts")
+        last_cursor = pd.to_datetime(existing_posts["post_timestamp"], errors="coerce").max() if not existing_posts.empty else None
+        if incremental and last_cursor is not None:
+            new_posts, source_manifest = ingestion_service.run_incremental_refresh(adapters, last_cursor=last_cursor)
+            posts = pd.concat([existing_posts, new_posts], ignore_index=True) if not existing_posts.empty else new_posts
+            posts = posts.drop_duplicates(subset=["post_id"], keep="last").sort_values("post_timestamp").reset_index(drop=True)
+        else:
+            posts, source_manifest = ingestion_service.run_refresh(adapters)
+        store.save_frame("normalized_posts", posts, metadata={"row_count": int(len(posts))})
+        store.save_frame("source_manifests", source_manifest, metadata={"row_count": int(len(source_manifest))})
 
-    watchlist_symbols = _watchlist_symbols(store)
-    watchlist, asset_universe = _save_watchlist(store, watchlist_symbols)
-    asset_symbols = asset_universe["symbol"].astype(str).tolist() if not asset_universe.empty else list(DEFAULT_ETF_SYMBOLS)
-    asset_daily, daily_manifest = market_service.load_assets_daily(asset_symbols, start, end)
-    asset_intraday, intraday_manifest = market_service.load_assets_intraday(asset_symbols, interval="5m", lookback_days=30)
-    asset_market_manifest = pd.concat([daily_manifest, intraday_manifest], ignore_index=True)
-    store.save_frame("asset_daily", asset_daily, metadata={"row_count": int(len(asset_daily)), "symbols": asset_symbols})
-    store.save_frame(
-        "asset_intraday",
-        asset_intraday,
-        metadata={"row_count": int(len(asset_intraday)), "symbols": asset_symbols, "interval": "5m", "lookback_days": 30},
-    )
-    store.save_frame("asset_market_manifest", asset_market_manifest, metadata={"row_count": int(len(asset_market_manifest))})
+        start = settings.term_start.strftime("%Y-%m-%d")
+        end = pd.Timestamp.now(tz=settings.timezone).strftime("%Y-%m-%d")
+        sp500 = market_service.load_sp500_daily(start, end)
+        spy = market_service.load_spy_daily(start, end)
+        store.save_frame("sp500_daily", sp500, metadata={"row_count": int(len(sp500))})
+        store.save_frame("spy_daily", spy, metadata={"row_count": int(len(spy))})
 
-    as_of = posts["post_timestamp"].max() if not posts.empty else pd.Timestamp.now(tz=settings.timezone)
-    tracked_accounts, ranking_history = _rebuild_discovery_state(store, discovery_service, posts, as_of)
-    prepared_posts = feature_service.prepare_session_posts(
-        posts=posts,
-        market_calendar=spy,
-        tracked_accounts=tracked_accounts,
-        llm_enabled=True,
-    )
-    asset_post_mappings = feature_service.build_asset_post_mappings(
-        prepared_posts=prepared_posts,
-        asset_universe=asset_universe,
-        llm_enabled=True,
-    )
-    asset_session_features = feature_service.build_asset_session_dataset(
-        asset_post_mappings=asset_post_mappings,
-        asset_market=asset_daily,
-        feature_version="asset-v1",
-        llm_enabled=True,
-        asset_universe=asset_universe,
-    )
-    store.save_frame(
-        "asset_post_mappings",
-        asset_post_mappings,
-        metadata={"row_count": int(len(asset_post_mappings)), "match_mode": "rules_plus_semantic"},
-    )
-    store.save_frame(
-        "asset_session_features",
-        asset_session_features,
-        metadata={"row_count": int(len(asset_session_features)), "feature_version": "asset-v1"},
-    )
-    return {
-        "posts": posts,
-        "source_manifest": source_manifest,
-        "sp500": sp500,
-        "spy": spy,
-        "asset_watchlist": watchlist,
-        "asset_universe": asset_universe,
-        "asset_daily": asset_daily,
-        "asset_intraday": asset_intraday,
-        "asset_market_manifest": asset_market_manifest,
-        "asset_post_mappings": asset_post_mappings,
-        "asset_session_features": asset_session_features,
-        "tracked_accounts": tracked_accounts,
-    }
+        watchlist_symbols = _watchlist_symbols(store)
+        watchlist, asset_universe = _save_watchlist(store, watchlist_symbols)
+        asset_symbols = asset_universe["symbol"].astype(str).tolist() if not asset_universe.empty else list(DEFAULT_ETF_SYMBOLS)
+        asset_daily, daily_manifest = market_service.load_assets_daily(asset_symbols, start, end)
+        asset_intraday, intraday_manifest = market_service.load_assets_intraday(asset_symbols, interval="5m", lookback_days=30)
+        asset_market_manifest = pd.concat([daily_manifest, intraday_manifest], ignore_index=True)
+        store.save_frame("asset_daily", asset_daily, metadata={"row_count": int(len(asset_daily)), "symbols": asset_symbols})
+        store.save_frame(
+            "asset_intraday",
+            asset_intraday,
+            metadata={"row_count": int(len(asset_intraday)), "symbols": asset_symbols, "interval": "5m", "lookback_days": 30},
+        )
+        store.save_frame("asset_market_manifest", asset_market_manifest, metadata={"row_count": int(len(asset_market_manifest))})
+
+        as_of = posts["post_timestamp"].max() if not posts.empty else pd.Timestamp.now(tz=settings.timezone)
+        tracked_accounts, ranking_history = _rebuild_discovery_state(store, discovery_service, posts, as_of)
+        prepared_posts = feature_service.prepare_session_posts(
+            posts=posts,
+            market_calendar=spy,
+            tracked_accounts=tracked_accounts,
+            llm_enabled=True,
+        )
+        asset_post_mappings = feature_service.build_asset_post_mappings(
+            prepared_posts=prepared_posts,
+            asset_universe=asset_universe,
+            llm_enabled=True,
+        )
+        asset_session_features = feature_service.build_asset_session_dataset(
+            asset_post_mappings=asset_post_mappings,
+            asset_market=asset_daily,
+            feature_version="asset-v1",
+            llm_enabled=True,
+            asset_universe=asset_universe,
+        )
+        store.save_frame(
+            "asset_post_mappings",
+            asset_post_mappings,
+            metadata={"row_count": int(len(asset_post_mappings)), "match_mode": "rules_plus_semantic"},
+        )
+        store.save_frame(
+            "asset_session_features",
+            asset_session_features,
+            metadata={"row_count": int(len(asset_session_features)), "feature_version": "asset-v1"},
+        )
+        completed_at = pd.Timestamp.now(tz="UTC")
+        health_latest = health_service.persist_snapshot(store, refresh_id=refresh_id, generated_at=completed_at)
+        refresh_history = _append_refresh_history(
+            store=store,
+            refresh_id=refresh_id,
+            refresh_mode=resolved_mode,
+            status="success",
+            started_at=started_at,
+            completed_at=completed_at,
+        )
+        return {
+            "posts": posts,
+            "source_manifest": source_manifest,
+            "sp500": sp500,
+            "spy": spy,
+            "asset_watchlist": watchlist,
+            "asset_universe": asset_universe,
+            "asset_daily": asset_daily,
+            "asset_intraday": asset_intraday,
+            "asset_market_manifest": asset_market_manifest,
+            "asset_post_mappings": asset_post_mappings,
+            "asset_session_features": asset_session_features,
+            "tracked_accounts": tracked_accounts,
+            "data_health_latest": health_latest,
+            "refresh_history": refresh_history,
+            "refresh_id": refresh_id,
+        }
+    except Exception as exc:
+        _append_refresh_history(
+            store=store,
+            refresh_id=refresh_id,
+            refresh_mode=resolved_mode,
+            status="error",
+            started_at=started_at,
+            completed_at=pd.Timestamp.now(tz="UTC"),
+            error_message=str(exc),
+        )
+        raise
 
 
 def _ensure_bootstrap(
@@ -715,6 +756,7 @@ def _ensure_bootstrap(
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
     feature_service: FeatureService,
+    health_service: DataHealthService,
 ) -> None:
     if store.read_frame("asset_watchlist").empty and store.read_frame("asset_universe").empty:
         _save_watchlist(store, [])
@@ -734,9 +776,11 @@ def _ensure_bootstrap(
             market_service=market_service,
             discovery_service=discovery_service,
             feature_service=feature_service,
+            health_service=health_service,
             remote_url=st.session_state.get("remote_x_url", ""),
             uploaded_files=[],
             incremental=False,
+            refresh_mode="bootstrap",
         )
 
 
@@ -827,6 +871,66 @@ def _render_equity_curve_comparison(curves_by_run: dict[str, pd.DataFrame], titl
     st.plotly_chart(fig, use_container_width=True)
 
 
+def _append_refresh_history(
+    store: DuckDBStore,
+    refresh_id: str,
+    refresh_mode: str,
+    status: str,
+    started_at: pd.Timestamp,
+    completed_at: pd.Timestamp,
+    error_message: str = "",
+) -> pd.DataFrame:
+    refresh_row = make_refresh_history_frame(
+        refresh_id=refresh_id,
+        refresh_mode=refresh_mode,
+        status=status,
+        started_at=started_at,
+        completed_at=completed_at,
+        error_message=error_message,
+    )
+    store.append_frame(
+        "refresh_history",
+        refresh_row,
+        dedupe_on=["refresh_id"],
+        metadata={"latest_status": status, "latest_refresh_mode": refresh_mode},
+    )
+    return ensure_refresh_history_frame(store.read_frame("refresh_history"))
+
+
+def _load_data_health_view_state(
+    store: DuckDBStore,
+    health_service: DataHealthService,
+) -> dict[str, pd.DataFrame | dict[str, Any]]:
+    latest = store.read_frame("data_health_latest")
+    if latest.empty:
+        latest = health_service.evaluate_store(store)
+    history = store.read_frame("data_health_history")
+    refresh_history = ensure_refresh_history_frame(store.read_frame("refresh_history"))
+    trend_source = history if not history.empty else latest
+    return {
+        "latest": latest if not latest.empty else pd.DataFrame(columns=HEALTH_CHECK_COLUMNS),
+        "history": history if not history.empty else pd.DataFrame(columns=HEALTH_CHECK_COLUMNS),
+        "refresh_history": refresh_history,
+        "summary": build_health_summary(latest, refresh_history),
+        "trend": build_health_trend_frame(trend_source),
+    }
+
+
+def _filter_health_rows(
+    health_rows: pd.DataFrame,
+    severities: list[str] | tuple[str, ...],
+    scope_kind: str,
+) -> pd.DataFrame:
+    if health_rows.empty:
+        return pd.DataFrame(columns=HEALTH_CHECK_COLUMNS)
+    filtered = health_rows.copy()
+    if severities:
+        filtered = filtered.loc[filtered["severity"].astype(str).isin([str(item).lower() for item in severities])].copy()
+    if scope_kind and scope_kind != "All":
+        filtered = filtered.loc[filtered["scope_kind"].astype(str) == str(scope_kind)].copy()
+    return filtered.reset_index(drop=True)
+
+
 def render_datasets_view(
     settings: AppSettings,
     store: DuckDBStore,
@@ -834,6 +938,7 @@ def render_datasets_view(
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
     feature_service: FeatureService,
+    health_service: DataHealthService,
 ) -> None:
     st.subheader("Datasets")
     st.caption("Refresh historical sources, store normalized datasets, and inspect the local DuckDB + Parquet catalog.")
@@ -880,8 +985,10 @@ def render_datasets_view(
                 market_service=market_service,
                 discovery_service=discovery_service,
                 feature_service=feature_service,
+                health_service=health_service,
                 remote_url=remote_url,
                 uploaded_files=uploaded_files or [],
+                refresh_mode="full",
             )
         st.success(
             f"Refreshed {len(summary['posts']):,} normalized posts, {len(summary['asset_daily']):,} daily market rows, "
@@ -896,13 +1003,118 @@ def render_datasets_view(
                 market_service=market_service,
                 discovery_service=discovery_service,
                 feature_service=feature_service,
+                health_service=health_service,
                 remote_url=remote_url,
                 uploaded_files=uploaded_files or [],
                 incremental=True,
+                refresh_mode="incremental",
             )
         st.success(
             f"Incremental refresh complete. Total posts stored: {len(summary['posts']):,}. "
             f"Asset intraday rows stored: {len(summary['asset_intraday']):,}.",
+        )
+
+    health_state = _load_data_health_view_state(store, health_service)
+    latest_health = health_state["latest"]
+    refresh_history = health_state["refresh_history"]
+    trend = health_state["trend"]
+    summary = health_state["summary"]
+
+    st.markdown("**Data Health**")
+    st.caption("Warn-only checks for freshness, completeness, manifest errors, duplicates, and anomaly drift across refresh history.")
+    overall_severity = str(summary.get("overall_severity", "ok"))
+    if overall_severity == "severe":
+        st.error("Severe data health issues are present. Workflows remain available, but the stored datasets need inspection.")
+    elif overall_severity == "warn":
+        st.warning("Dataset health warnings are present. Workflows remain available, but review the checks below.")
+    else:
+        st.success("No current warning or severe data health checks are active.")
+
+    last_refresh_at = summary.get("last_refresh_at", pd.NaT)
+    if pd.notna(last_refresh_at):
+        last_refresh_label = pd.Timestamp(last_refresh_at).tz_convert(EASTERN).strftime("%Y-%m-%d %H:%M")
+    else:
+        last_refresh_label = "n/a"
+    metric_cols = st.columns(6)
+    metric_cols[0].metric("Overall", str(summary.get("overall_severity", "ok")).upper())
+    metric_cols[1].metric("Severe", f"{int(summary.get('severe_count', 0))}")
+    metric_cols[2].metric("Warn", f"{int(summary.get('warn_count', 0))}")
+    metric_cols[3].metric("Anomalies", f"{int(summary.get('anomaly_count', 0))}")
+    metric_cols[4].metric("Last refresh", last_refresh_label)
+    metric_cols[5].metric(
+        "Refresh status",
+        str(summary.get("last_refresh_status", "n/a")).upper(),
+        str(summary.get("last_refresh_mode", "")).upper(),
+    )
+
+    latest_health = latest_health.copy() if isinstance(latest_health, pd.DataFrame) else pd.DataFrame(columns=HEALTH_CHECK_COLUMNS)
+    if not latest_health.empty:
+        latest_health["generated_at"] = pd.to_datetime(latest_health["generated_at"], errors="coerce", utc=True)
+        latest_health["observed_value"] = pd.to_numeric(latest_health["observed_value"], errors="coerce")
+        latest_health["baseline_value"] = pd.to_numeric(latest_health["baseline_value"], errors="coerce")
+        latest_health["severity"] = latest_health["severity"].astype(str)
+        latest_health["generated_at"] = latest_health["generated_at"].dt.tz_convert(EASTERN)
+
+    filter_cols = st.columns([2, 2, 3])
+    default_severities = [severity for severity in ["warn", "severe"] if latest_health.empty or severity in latest_health["severity"].astype(str).unique()]
+    selected_severities = filter_cols[0].multiselect(
+        "Health severities",
+        options=["warn", "severe", "ok"],
+        default=default_severities or ["warn", "severe"],
+        key="datasets_health_severities",
+    )
+    scope_options = ["All"]
+    if not latest_health.empty and "scope_kind" in latest_health.columns:
+        scope_options.extend(sorted(latest_health["scope_kind"].dropna().astype(str).unique().tolist()))
+    selected_scope = filter_cols[1].selectbox("Scope kind", options=scope_options, index=0, key="datasets_health_scope")
+    filter_cols[2].caption("The table defaults to current warnings and severe checks. Add `ok` to inspect the full snapshot.")
+    filtered_health = _filter_health_rows(latest_health, selected_severities, selected_scope)
+    if filtered_health.empty:
+        st.info("No health rows match the current filters.")
+    else:
+        st.dataframe(filtered_health, use_container_width=True, hide_index=True)
+
+    st.markdown("**Health history**")
+    trend_frame = trend.copy() if isinstance(trend, pd.DataFrame) else pd.DataFrame()
+    if not trend_frame.empty:
+        trend_frame["generated_at"] = pd.to_datetime(trend_frame["generated_at"], errors="coerce", utc=True)
+        trend_frame["generated_at"] = trend_frame["generated_at"].dt.tz_convert(EASTERN)
+        trend_fig = go.Figure()
+        trend_fig.add_trace(
+            go.Scatter(
+                x=trend_frame["generated_at"],
+                y=trend_frame["warn_count"],
+                mode="lines+markers",
+                name="Warn checks",
+            ),
+        )
+        trend_fig.add_trace(
+            go.Scatter(
+                x=trend_frame["generated_at"],
+                y=trend_frame["severe_count"],
+                mode="lines+markers",
+                name="Severe checks",
+            ),
+        )
+        trend_fig.update_layout(
+            title="Health severity counts by snapshot",
+            xaxis_title="Snapshot time",
+            yaxis_title="Check count",
+            margin={"l": 20, "r": 20, "t": 60, "b": 20},
+        )
+        st.plotly_chart(trend_fig, use_container_width=True)
+    else:
+        st.info("Health trend history will appear after at least one persisted refresh snapshot is available.")
+
+    if not refresh_history.empty:
+        refresh_history = refresh_history.copy()
+        for column in ["started_at", "completed_at"]:
+            refresh_history[column] = pd.to_datetime(refresh_history[column], errors="coerce", utc=True).dt.tz_convert(EASTERN)
+        st.markdown("**Refresh history**")
+        st.dataframe(
+            refresh_history.sort_values("completed_at", ascending=False),
+            use_container_width=True,
+            hide_index=True,
         )
 
     registry = store.dataset_registry()
@@ -2923,6 +3135,7 @@ def render_live_monitor(
     market_service: MarketDataService,
     discovery_service: DiscoveryService,
     feature_service: FeatureService,
+    health_service: DataHealthService,
     model_service: ModelService,
     experiment_store: ExperimentStore,
 ) -> None:
@@ -2960,9 +3173,11 @@ def render_live_monitor(
                 market_service=market_service,
                 discovery_service=discovery_service,
                 feature_service=feature_service,
+                health_service=health_service,
                 remote_url=remote_url,
                 uploaded_files=[],
                 incremental=True,
+                refresh_mode="incremental",
             )
         st.success("Polling refresh complete.")
 
@@ -3432,13 +3647,14 @@ def main() -> None:
     ingestion_service = IngestionService()
     market_service = MarketDataService()
     discovery_service = DiscoveryService()
+    health_service = DataHealthService()
     enrichment_service = LLMEnrichmentService(store)
     feature_service = FeatureService(enrichment_service)
     model_service = ModelService()
     backtest_service = BacktestService(model_service)
     experiment_store = ExperimentStore(store)
 
-    _ensure_bootstrap(settings, store, ingestion_service, market_service, discovery_service, feature_service)
+    _ensure_bootstrap(settings, store, ingestion_service, market_service, discovery_service, feature_service, health_service)
 
     page = st.sidebar.radio(
         "Workbench",
@@ -3451,7 +3667,7 @@ def main() -> None:
     if page == "Research View":
         render_research_view(settings, store, market_service, feature_service)
     elif page == "Datasets":
-        render_datasets_view(settings, store, ingestion_service, market_service, discovery_service, feature_service)
+        render_datasets_view(settings, store, ingestion_service, market_service, discovery_service, feature_service, health_service)
     elif page == "Discovery":
         render_discovery_view(settings, store, discovery_service)
     elif page == "Models & Backtests":
@@ -3466,6 +3682,7 @@ def main() -> None:
             market_service,
             discovery_service,
             feature_service,
+            health_service,
             model_service,
             experiment_store,
         )


### PR DESCRIPTION
## Summary
- add a warn-only data health dashboard to the Datasets page
- persist health snapshots and refresh history across bootstrap, full, and incremental refreshes
- add structural, freshness, duplicate, coverage, and anomaly checks backed by history

## Validation
- bash scripts/ci.sh

Closes #25
