### PR TITLE
Add local Docker packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.venv
+.cache
+.workbench
+__pycache__
+*.pyc
+.coverage
+.coverage.*
+coverage.xml
+htmlcov
+.pytest_cache
+.env
+.env.local
+docker-state

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,5 @@
+# Copy to `.env` if you want Docker Compose to inject these automatically.
+# Leave blank if you do not need them.
+
+ALPHA_VANTAGE_API_KEY=
+ALLCAPS_REMOTE_X_CSV_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,11 @@
 .coverage.*
 coverage.xml
 htmlcov/
+.env
+.env.local
 .pytest_cache/
 .venv/
 .workbench/
+docker-state/
 __pycache__/
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8501 \
+    ALLCAPS_STATE_DIR=/var/data
+
+RUN groupadd --system allcaps \
+    && useradd --system --create-home --gid allcaps --shell /bin/bash allcaps
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+
+RUN pip install --upgrade pip \
+    && pip install -r /app/requirements.txt
+
+COPY . /app
+
+RUN chmod +x /app/scripts/start_app.sh /app/scripts/start_render.sh \
+    && mkdir -p /var/data \
+    && chown -R allcaps:allcaps /app /var/data
+
+USER allcaps
+
+EXPOSE 8501
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=5 CMD python -c "import sys, urllib.request; urllib.request.urlopen('http://127.0.0.1:8501', timeout=3); sys.exit(0)"
+
+CMD ["bash", "scripts/start_app.sh"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ In plain English, the app helps you:
 - [What You Need Before You Start](#what-you-need-before-you-start)
 - [Quick Start](#quick-start)
 - [Contributor Workflow](#contributor-workflow)
+- [Run With Docker](#run-with-docker)
 - [Hosting On Render](#hosting-on-render)
 - [Hosted Environment Variables](#hosted-environment-variables)
 - [Recommended First Run](#recommended-first-run)
@@ -88,6 +89,69 @@ The app opens as a multi-page Streamlit workbench with these sections:
 - `Discovery`
 - `Models & Backtests`
 - `Live Monitor`
+
+## Run With Docker
+
+The repo includes local Docker packaging for a single-user browser workflow.
+
+Default behavior:
+
+- runs the app on [http://127.0.0.1:8501](http://127.0.0.1:8501)
+- keeps the app private and writable by default
+- stores runtime state in a named Docker volume mounted at `/var/data`
+- leaves the scheduler off by default
+
+Start it:
+
+```bash
+docker compose up --build
+```
+
+Open:
+
+- [http://127.0.0.1:8501](http://127.0.0.1:8501)
+
+Stop it:
+
+```bash
+docker compose down
+```
+
+Remove the container and the named state volume:
+
+```bash
+docker compose down -v
+```
+
+Optional env vars:
+
+1. Copy `.env.docker.example` to `.env`
+2. Set any values you want, such as:
+   - `ALPHA_VANTAGE_API_KEY`
+   - `ALLCAPS_REMOTE_X_CSV_URL`
+
+Optional local CSV mount:
+
+If you want the container to read local CSV files from `./data`, start with the extra Compose file:
+
+```bash
+docker compose -f compose.yaml -f compose.data.yaml up --build
+```
+
+That mounts:
+
+- `./data` -> `/app/data` (read-only)
+
+Optional host bind mount for persistent state:
+
+The default setup uses a named Docker volume. If you prefer to keep state in a visible host folder, replace the volume mapping in `compose.yaml` with:
+
+```yaml
+volumes:
+  - ./docker-state:/var/data
+```
+
+That will store DuckDB, parquet data, cache files, and run artifacts in `./docker-state`.
 
 ## Hosting On Render
 

--- a/compose.data.yaml
+++ b/compose.data.yaml
@@ -1,0 +1,4 @@
+services:
+  allcaps:
+    volumes:
+      - ./data:/app/data:ro

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,20 @@
+services:
+  allcaps:
+    build:
+      context: .
+    container_name: allcaps
+    ports:
+      - "127.0.0.1:8501:8501"
+    environment:
+      PORT: "8501"
+      ALLCAPS_STATE_DIR: /var/data
+      ALLCAPS_PUBLIC_MODE: "false"
+      ALLCAPS_AUTO_BOOTSTRAP_ON_START: "true"
+      ALLCAPS_SCHEDULER_ENABLED: "false"
+      ALLCAPS_REMOTE_X_CSV_URL: ${ALLCAPS_REMOTE_X_CSV_URL:-}
+      ALPHA_VANTAGE_API_KEY: ${ALPHA_VANTAGE_API_KEY:-}
+    volumes:
+      - allcaps_state:/var/data
+
+volumes:
+  allcaps_state:

--- a/scripts/start_app.sh
+++ b/scripts/start_app.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export ALLCAPS_STATE_DIR="${ALLCAPS_STATE_DIR:-/var/data}"
+mkdir -p "${ALLCAPS_STATE_DIR}"
+
+SCHEDULER_PID=""
+cleanup() {
+  if [[ -n "${SCHEDULER_PID}" ]]; then
+    kill "${SCHEDULER_PID}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+case "${ALLCAPS_SCHEDULER_ENABLED:-false}" in
+  1|true|TRUE|yes|YES|on|ON)
+    python -m trump_workbench.scheduler &
+    SCHEDULER_PID="$!"
+    ;;
+esac
+
+exec streamlit run app.py \
+  --server.address 0.0.0.0 \
+  --server.port "${PORT:-8501}" \
+  --server.headless true \
+  --browser.gatherUsageStats false

--- a/scripts/start_render.sh
+++ b/scripts/start_render.sh
@@ -1,26 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
 export ALLCAPS_STATE_DIR="${ALLCAPS_STATE_DIR:-/var/data}"
-mkdir -p "${ALLCAPS_STATE_DIR}"
+export ALLCAPS_PUBLIC_MODE="${ALLCAPS_PUBLIC_MODE:-true}"
+export ALLCAPS_AUTO_BOOTSTRAP_ON_START="${ALLCAPS_AUTO_BOOTSTRAP_ON_START:-false}"
+export ALLCAPS_SCHEDULER_ENABLED="${ALLCAPS_SCHEDULER_ENABLED:-true}"
 
-SCHEDULER_PID=""
-cleanup() {
-  if [[ -n "${SCHEDULER_PID}" ]]; then
-    kill "${SCHEDULER_PID}" >/dev/null 2>&1 || true
-  fi
-}
-trap cleanup EXIT INT TERM
-
-case "${ALLCAPS_SCHEDULER_ENABLED:-true}" in
-  1|true|TRUE|yes|YES|on|ON)
-    python -m trump_workbench.scheduler &
-    SCHEDULER_PID="$!"
-    ;;
-esac
-
-exec streamlit run app.py \
-  --server.address 0.0.0.0 \
-  --server.port "${PORT:-8501}" \
-  --server.headless true \
-  --browser.gatherUsageStats false
+exec bash "$ROOT_DIR/scripts/start_app.sh"


### PR DESCRIPTION
## Summary
- add local Docker packaging so the Streamlit app can run in a container and still be used from a local browser
- add a Compose-first workflow with state persisted in a Docker volume and browser exposure limited to `127.0.0.1:8501`
- standardize startup so Docker and Render both reuse the same app launch path
- document optional local CSV mounting and host bind-mount persistence

## What changed
- added `Dockerfile`
- added `.dockerignore`
- added `compose.yaml` for the default local workflow
- added `compose.data.yaml` for optional `./data` CSV mounting
- added `.env.docker.example` for optional local Docker env vars
- added `scripts/start_app.sh` as the generic runtime entrypoint
- refactored `scripts/start_render.sh` to delegate to `scripts/start_app.sh`
- updated `README.md` with Docker usage, persistence, and CSV-mount guidance
- updated `.gitignore` for `.env` and `docker-state/`

## Default Docker behavior
- private single-user mode
- writable app by default
- state stored at `/var/data`
- named Docker volume used by default
- scheduler disabled by default
- app exposed on `127.0.0.1:8501`

## Validation
- `bash scripts/ci.sh`
- `docker build -t allcaps-local:test .`
- `docker compose -f compose.yaml -f compose.data.yaml config`
- `docker compose up -d --build`
- verified `http://127.0.0.1:8501` returned `200`
- verified named-volume persistence across restart
- verified host bind-mount persistence with `docker run -v "$PWD/docker-state:/var/data" ...`

## Notes
- branch: `codex/docker-local-browser`
- commit: `09f4fea`