### PR TITLE
Add live paper portfolio audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ In plain English, the app helps you:
 - collect Trump-related social data
 - decide which X accounts matter enough to track
 - turn that data into trading features
-- backtest a simple **long / flat SPY** strategy
-- compare saved runs and inspect why a run did or did not work
+- backtest **long / flat** strategies for `SPY` and tracked assets
+- compare saved runs, portfolio variants, and inspect why a run did or did not work
+- monitor live portfolio decisions and a paper-trading audit trail
 
 ## Table of Contents
 
@@ -202,7 +203,8 @@ If you are new to the app, follow this order:
 4. Open `Discovery` and review the tracked-account universe.
 5. Open `Research View` to inspect mapped posts and market context.
 6. Open `Models & Backtests` and run a baseline walk-forward backtest.
-7. Open `Live Monitor` only after you have at least one saved model run.
+7. Save a joint portfolio run in `Models & Backtests`.
+8. Open `Live Monitor` to pin that run, inspect the live board, and optionally enable paper trading.
 
 ## How To Work With Each Page
 
@@ -283,18 +285,20 @@ Inputs you can tune here include:
 
 ## `Live Monitor`
 
-This page gives you a lightweight, polling-style live view after you already have a saved model.
+This page gives you a live decision console after you already have a saved joint portfolio run.
 
 Use it to:
 
 - poll sources for new rows
-- see the latest signal session and expected next-session return
-- inspect the current suggested stance
-- review prediction snapshot history over time
+- pin a saved joint portfolio run for live monitoring
+- inspect the ranked live asset board and current suggested stance
+- review explanation details for the winner and runner-up
+- review persisted live board and decision history over time
+- enable paper trading, inspect the paper decision journal, and track realized equity vs `SPY`
 
 Important note:
 
-- This page will not do much until you have already created at least one saved run in `Models & Backtests`
+- This page will not do much until you have already created at least one saved joint portfolio run in `Models & Backtests`
 
 ## Data Inputs
 
@@ -362,7 +366,8 @@ Here is the most common way to use the app from start to finish:
 4. Explore `Research View` to sanity-check whether the mapped posts look reasonable.
 5. Run a default experiment in `Models & Backtests`.
 6. Compare the strategy against the built-in baselines.
-7. If one run looks promising, use `Live Monitor` to watch the latest score from the most recent saved model.
+7. Save a joint portfolio run if you want live portfolio monitoring.
+8. Use `Live Monitor` to watch the latest board, pin a deployment run, and optionally track paper PnL.
 
 ## Troubleshooting
 
@@ -381,7 +386,13 @@ If `Models & Backtests` says there is no data:
 
 If `Live Monitor` says there is no saved model:
 
-- create and save a run in `Models & Backtests` first
+- create and save a joint portfolio run in `Models & Backtests` first
+
+If `Live Monitor` shows no paper portfolio history:
+
+- save and pin a joint portfolio run first
+- enable paper trading from the `Paper Portfolio` tab
+- use polling or let the scheduler persist live decisions before the next session opens
 
 If the intraday drill-down fails:
 
@@ -389,11 +400,12 @@ If the intraday drill-down fails:
 
 ## Current Limits
 
-- `SPY` is the only traded instrument in v1
-- the strategy is `long / flat` only in v1
+- the strategy is `long / flat` only
+- the portfolio allocator holds at most one asset per session
+- paper trading is simulated only; there is no broker integration or order routing
 - semantic enrichment is optional and heuristic-backed by default
-- the app is single-user and local-first
-- the current research layer is exploratory, not production trading infrastructure
+- hosted mode is still single-instance and admin-gated rather than full multi-user auth
+- the research and live layers are decision-support tools, not production trading infrastructure
 
 ## Architecture
 

--- a/tests/test_paper_trading.py
+++ b/tests/test_paper_trading.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from trump_workbench.config import AppSettings
+from trump_workbench.contracts import LiveMonitorConfig
+from trump_workbench.paper_trading import PaperTradingService, ensure_paper_benchmark_curve_frame, ensure_paper_decision_journal_frame, ensure_paper_equity_curve_frame, ensure_paper_portfolio_registry_frame, ensure_paper_trade_ledger_frame
+from trump_workbench.storage import DuckDBStore
+
+
+class PaperTradingServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.settings = AppSettings(base_dir=Path(self.temp_dir.name))
+        self.store = DuckDBStore(self.settings)
+        self.paper_service = PaperTradingService(self.store)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def _live_config(run_id: str = "portfolio-1", variant: str = "pooled", fallback_mode: str = "SPY") -> LiveMonitorConfig:
+        return LiveMonitorConfig(
+            mode="portfolio_run",
+            fallback_mode=fallback_mode,
+            portfolio_run_id=run_id,
+            portfolio_run_name=f"Run {run_id}",
+            deployment_variant=variant,
+        )
+
+    @staticmethod
+    def _snapshot_rows(
+        generated_at: pd.Timestamp,
+        signal_session_date: str = "2026-04-15",
+        next_session_date: str = "2026-04-16",
+        next_session_open_ts: str = "2026-04-16 13:30:00+00:00",
+        spy_score: float = 0.005,
+        qqq_score: float = 0.010,
+        spy_threshold: float = 0.001,
+        qqq_threshold: float = 0.001,
+        spy_posts: int = 5,
+        qqq_posts: int = 5,
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {
+                    "generated_at": generated_at,
+                    "variant_name": "pooled",
+                    "signal_session_date": pd.Timestamp(signal_session_date, tz="UTC"),
+                    "next_session_date": pd.Timestamp(next_session_date, tz="UTC"),
+                    "asset_symbol": "SPY",
+                    "run_id": "portfolio-1",
+                    "run_name": "Joint run",
+                    "feature_version": "asset-v1",
+                    "model_version": "portfolio-model",
+                    "expected_return_score": spy_score,
+                    "confidence": 0.6,
+                    "threshold": spy_threshold,
+                    "min_post_count": 1,
+                    "post_count": spy_posts,
+                    "target_available": False,
+                    "tradeable": True,
+                    "next_session_open": 500.0,
+                    "next_session_close": 510.0,
+                    "next_session_open_ts": pd.Timestamp(next_session_open_ts),
+                },
+                {
+                    "generated_at": generated_at,
+                    "variant_name": "pooled",
+                    "signal_session_date": pd.Timestamp(signal_session_date, tz="UTC"),
+                    "next_session_date": pd.Timestamp(next_session_date, tz="UTC"),
+                    "asset_symbol": "QQQ",
+                    "run_id": "portfolio-1",
+                    "run_name": "Joint run",
+                    "feature_version": "asset-v1",
+                    "model_version": "portfolio-model",
+                    "expected_return_score": qqq_score,
+                    "confidence": 0.7,
+                    "threshold": qqq_threshold,
+                    "min_post_count": 1,
+                    "post_count": qqq_posts,
+                    "target_available": False,
+                    "tradeable": True,
+                    "next_session_open": 400.0,
+                    "next_session_close": 420.0,
+                    "next_session_open_ts": pd.Timestamp(next_session_open_ts),
+                },
+            ],
+        )
+
+    def test_capture_uses_latest_snapshot_before_open_cutoff(self) -> None:
+        config = self.paper_service.build_config(
+            live_config=self._live_config(),
+            portfolio_run_name="Joint run",
+            transaction_cost_bps=2.0,
+            enabled=True,
+            now=pd.Timestamp("2026-04-15 20:00:00+00:00"),
+        )
+        pre_open_early = self._snapshot_rows(
+            generated_at=pd.Timestamp("2026-04-16 11:00:00+00:00"),
+            spy_score=0.006,
+            qqq_score=0.009,
+        )
+        pre_open_late = self._snapshot_rows(
+            generated_at=pd.Timestamp("2026-04-16 13:00:00+00:00"),
+            spy_score=0.008,
+            qqq_score=0.012,
+        )
+        post_open = self._snapshot_rows(
+            generated_at=pd.Timestamp("2026-04-16 14:00:00+00:00"),
+            spy_score=0.020,
+            qqq_score=0.003,
+        )
+        self.store.save_frame(
+            "live_asset_snapshots",
+            pd.concat([pre_open_early, pre_open_late, post_open], ignore_index=True),
+            metadata={"row_count": 6},
+        )
+
+        journal = self.paper_service.capture_authoritative_decisions(
+            config,
+            as_of=pd.Timestamp("2026-04-16 15:00:00+00:00"),
+        )
+
+        portfolio_rows = journal.loc[journal["paper_portfolio_id"].astype(str) == config.paper_portfolio_id].copy()
+        self.assertEqual(len(portfolio_rows), 1)
+        self.assertEqual(str(portfolio_rows.iloc[0]["winning_asset"]), "QQQ")
+        self.assertEqual(pd.Timestamp(portfolio_rows.iloc[0]["generated_at"]), pd.Timestamp("2026-04-16 13:00:00+00:00"))
+
+    def test_flat_decision_creates_no_trade_but_builds_curves(self) -> None:
+        config = self.paper_service.build_config(
+            live_config=self._live_config(fallback_mode="FLAT"),
+            portfolio_run_name="Joint run",
+            transaction_cost_bps=2.0,
+            enabled=True,
+            now=pd.Timestamp("2026-04-15 20:00:00+00:00"),
+        )
+        flat_rows = self._snapshot_rows(
+            generated_at=pd.Timestamp("2026-04-16 12:00:00+00:00"),
+            spy_score=0.0001,
+            qqq_score=0.0002,
+            spy_threshold=0.005,
+            qqq_threshold=0.005,
+            spy_posts=1,
+            qqq_posts=1,
+        )
+        self.store.save_frame("live_asset_snapshots", flat_rows, metadata={"row_count": 2})
+        self.store.save_frame(
+            "spy_daily",
+            pd.DataFrame([{"trade_date": pd.Timestamp("2026-04-16"), "open": 500.0, "close": 510.0}]),
+            metadata={"row_count": 1},
+        )
+
+        self.paper_service.process_live_history(config, as_of=pd.Timestamp("2026-04-16 16:00:00+00:00"))
+
+        journal = ensure_paper_decision_journal_frame(self.store.read_frame("paper_decision_journal"))
+        trades = ensure_paper_trade_ledger_frame(self.store.read_frame("paper_trade_ledger"))
+        equity = ensure_paper_equity_curve_frame(self.store.read_frame("paper_equity_curve"))
+        benchmark = ensure_paper_benchmark_curve_frame(self.store.read_frame("paper_benchmark_curve"))
+
+        portfolio_journal = journal.loc[journal["paper_portfolio_id"].astype(str) == config.paper_portfolio_id]
+        self.assertEqual(len(portfolio_journal), 1)
+        self.assertEqual(str(portfolio_journal.iloc[0]["settlement_status"]), "flat")
+        self.assertTrue(trades.empty)
+        self.assertEqual(len(equity), 1)
+        self.assertAlmostEqual(float(equity.iloc[0]["equity"]), 100000.0)
+        self.assertEqual(len(benchmark), 1)
+        self.assertGreater(float(benchmark.iloc[0]["equity"]), 100000.0)
+
+    def test_long_trade_settlement_uses_open_close_and_transaction_costs(self) -> None:
+        config = self.paper_service.build_config(
+            live_config=self._live_config(),
+            portfolio_run_name="Joint run",
+            transaction_cost_bps=10.0,
+            enabled=True,
+            now=pd.Timestamp("2026-04-15 20:00:00+00:00"),
+        )
+        rows = self._snapshot_rows(
+            generated_at=pd.Timestamp("2026-04-16 12:00:00+00:00"),
+            spy_score=0.002,
+            qqq_score=0.015,
+        )
+        self.store.save_frame("live_asset_snapshots", rows, metadata={"row_count": 2})
+        self.store.save_frame(
+            "asset_daily",
+            pd.DataFrame(
+                [
+                    {"symbol": "QQQ", "trade_date": pd.Timestamp("2026-04-16"), "open": 400.0, "close": 420.0},
+                    {"symbol": "SPY", "trade_date": pd.Timestamp("2026-04-16"), "open": 500.0, "close": 510.0},
+                ],
+            ),
+            metadata={"row_count": 2},
+        )
+
+        self.paper_service.process_live_history(config, as_of=pd.Timestamp("2026-04-16 16:00:00+00:00"))
+
+        trades = ensure_paper_trade_ledger_frame(self.store.read_frame("paper_trade_ledger"))
+        self.assertEqual(len(trades), 1)
+        trade = trades.iloc[0]
+        self.assertEqual(str(trade["asset_symbol"]), "QQQ")
+        self.assertAlmostEqual(float(trade["gross_return"]), 0.05)
+        self.assertAlmostEqual(float(trade["net_return"]), 0.048)
+        self.assertAlmostEqual(float(trade["ending_equity"]), 104800.0)
+
+    def test_switching_live_config_archives_previous_paper_portfolio(self) -> None:
+        first = self.paper_service.upsert_current_for_live_config(
+            live_config=self._live_config(run_id="portfolio-1", variant="pooled"),
+            portfolio_run_name="Run 1",
+            transaction_cost_bps=2.0,
+            starting_cash=100000.0,
+            enabled=True,
+            now=pd.Timestamp("2026-04-15 20:00:00+00:00"),
+        )
+        second = self.paper_service.upsert_current_for_live_config(
+            live_config=self._live_config(run_id="portfolio-2", variant="per_asset"),
+            portfolio_run_name="Run 2",
+            transaction_cost_bps=5.0,
+            starting_cash=125000.0,
+            enabled=True,
+            now=pd.Timestamp("2026-04-16 20:00:00+00:00"),
+        )
+
+        registry = ensure_paper_portfolio_registry_frame(self.store.read_frame("paper_portfolio_registry"))
+
+        self.assertEqual(len(registry), 2)
+        first_row = registry.loc[registry["paper_portfolio_id"].astype(str) == first.paper_portfolio_id].iloc[0]
+        second_row = registry.loc[registry["paper_portfolio_id"].astype(str) == second.paper_portfolio_id].iloc[0]
+        self.assertTrue(pd.notna(first_row["archived_at"]))
+        self.assertTrue(pd.isna(second_row["archived_at"]))
+        self.assertEqual(float(second_row["starting_cash"]), 125000.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trump_workbench/contracts.py
+++ b/trump_workbench/contracts.py
@@ -243,6 +243,7 @@ class PortfolioCandidatePrediction:
     post_count: int
     tradeable: bool = False
     target_available: bool = False
+    next_session_open_ts: Optional[pd.Timestamp] = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -353,6 +354,104 @@ class LiveMonitorConfig:
             deployment_variant=str(payload.get("deployment_variant", "") or ""),
             pinned_runs=pinned_runs,
         )
+
+
+@dataclass(frozen=True)
+class PaperPortfolioConfig:
+    paper_portfolio_id: str
+    portfolio_run_id: str
+    portfolio_run_name: str = ""
+    deployment_variant: str = ""
+    fallback_mode: str = "SPY"
+    transaction_cost_bps: float = 0.0
+    starting_cash: float = 100000.0
+    enabled: bool = False
+    created_at: str = ""
+    archived_at: str = ""
+
+    @property
+    def is_archived(self) -> bool:
+        return bool(self.archived_at)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PaperPortfolioConfig":
+        return cls(
+            paper_portfolio_id=str(payload.get("paper_portfolio_id", "") or ""),
+            portfolio_run_id=str(payload.get("portfolio_run_id", "") or ""),
+            portfolio_run_name=str(payload.get("portfolio_run_name", "") or ""),
+            deployment_variant=str(payload.get("deployment_variant", "") or ""),
+            fallback_mode=str(payload.get("fallback_mode", "SPY") or "SPY").upper(),
+            transaction_cost_bps=float(payload.get("transaction_cost_bps", 0.0) or 0.0),
+            starting_cash=float(payload.get("starting_cash", 100000.0) or 100000.0),
+            enabled=bool(payload.get("enabled", False)),
+            created_at=str(payload.get("created_at", "") or ""),
+            archived_at=str(payload.get("archived_at", "") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class PaperDecisionRecord:
+    paper_portfolio_id: str
+    generated_at: pd.Timestamp
+    signal_session_date: pd.Timestamp
+    next_session_date: Optional[pd.Timestamp]
+    decision_cutoff_ts: Optional[pd.Timestamp]
+    portfolio_run_id: str
+    portfolio_run_name: str
+    deployment_variant: str
+    winning_asset: str
+    winning_run_id: str
+    decision_source: str
+    fallback_mode: str
+    stance: str
+    winner_score: float
+    runner_up_asset: str = ""
+    runner_up_score: float = 0.0
+    eligible_asset_count: int = 0
+    settlement_status: str = "pending"
+    settled_at: Optional[pd.Timestamp] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PaperTradeRecord:
+    paper_portfolio_id: str
+    signal_session_date: pd.Timestamp
+    next_session_date: Optional[pd.Timestamp]
+    asset_symbol: str
+    run_id: str
+    decision_source: str
+    stance: str
+    next_session_open: float
+    next_session_close: float
+    gross_return: float
+    net_return: float
+    benchmark_return: float
+    transaction_cost_bps: float
+    starting_equity: float
+    ending_equity: float
+    settled_at: pd.Timestamp
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PaperEquityPoint:
+    paper_portfolio_id: str
+    signal_session_date: pd.Timestamp
+    next_session_date: Optional[pd.Timestamp]
+    equity: float
+    return_pct: float
+    settled_at: pd.Timestamp
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 @dataclass(frozen=True)

--- a/trump_workbench/live_monitor.py
+++ b/trump_workbench/live_monitor.py
@@ -5,6 +5,8 @@ from typing import Any
 import pandas as pd
 
 from .contracts import LiveMonitorConfig, LiveMonitorPinnedRun
+from .explanations import build_account_attribution, build_post_attribution
+from .modeling import LinearModelArtifact, ModelService, add_asset_indicator_columns
 from .portfolio import PORTFOLIO_CANDIDATE_COLUMNS, PORTFOLIO_DECISION_COLUMNS, VALID_FALLBACK_MODES, rank_portfolio_candidates
 
 LIVE_MONITOR_CONFIG_PATH = "live_monitor/config.json"
@@ -159,3 +161,196 @@ def rank_live_asset_snapshots(snapshots: pd.DataFrame, fallback_mode: str) -> tu
         if column not in decision.columns:
             decision[column] = pd.NA
     return ranked_board[LIVE_ASSET_SNAPSHOT_COLUMNS].copy(), decision[LIVE_DECISION_SNAPSHOT_COLUMNS].copy()
+
+
+def _normalize_session_date(value: Any) -> pd.Timestamp | None:
+    session_date = pd.to_datetime(value, errors="coerce")
+    if pd.isna(session_date):
+        return None
+    return pd.Timestamp(session_date).normalize()
+
+
+def _apply_live_account_weight(feature_rows: pd.DataFrame, account_weight: float) -> pd.DataFrame:
+    adjusted = feature_rows.copy()
+    for column in ["tracked_weighted_mentions", "tracked_weighted_engagement", "tracked_account_post_count"]:
+        if column in adjusted.columns:
+            adjusted[column] = adjusted[column] * float(account_weight)
+    return adjusted
+
+
+def _portfolio_live_model_artifact(payload: dict[str, Any]) -> LinearModelArtifact:
+    return LinearModelArtifact.from_dict(payload)
+
+
+def _predict_portfolio_live_variant(
+    model_service: ModelService,
+    feature_rows: pd.DataFrame,
+    variant_payload: dict[str, Any],
+    selected_symbols: list[str],
+) -> tuple[pd.DataFrame, dict[str, dict[str, Any]]]:
+    topology = str(variant_payload.get("topology", "per_asset") or "per_asset")
+    models_payload = variant_payload.get("models", {}) or {}
+    predictions: list[pd.DataFrame] = []
+    explanations: dict[str, dict[str, Any]] = {}
+    if topology == "pooled":
+        pooled_model = models_payload.get("pooled")
+        if not isinstance(pooled_model, dict):
+            return pd.DataFrame(), {}
+        artifact = _portfolio_live_model_artifact(pooled_model)
+        pooled_rows = add_asset_indicator_columns(feature_rows, selected_symbols)
+        scored = model_service.predict(artifact, pooled_rows)
+        predictions.append(scored)
+        for asset_symbol in selected_symbols:
+            asset_rows = scored.loc[scored["asset_symbol"].astype(str).str.upper() == asset_symbol].copy()
+            if asset_rows.empty:
+                continue
+            explanations[asset_symbol] = {
+                "artifact": artifact,
+                "prediction_frame": asset_rows,
+                "feature_contributions": model_service.explain_predictions(artifact, asset_rows),
+            }
+    else:
+        for asset_symbol in selected_symbols:
+            model_payload = models_payload.get(asset_symbol)
+            if not isinstance(model_payload, dict):
+                continue
+            artifact = _portfolio_live_model_artifact(model_payload)
+            asset_rows = feature_rows.loc[feature_rows["asset_symbol"].astype(str).str.upper() == asset_symbol].copy()
+            if asset_rows.empty:
+                continue
+            scored = model_service.predict(artifact, asset_rows)
+            predictions.append(scored)
+            explanations[asset_symbol] = {
+                "artifact": artifact,
+                "prediction_frame": scored,
+                "feature_contributions": model_service.explain_predictions(artifact, scored),
+            }
+    if not predictions:
+        return pd.DataFrame(), {}
+    combined = pd.concat(predictions, ignore_index=True).sort_values(["signal_session_date", "asset_symbol"]).reset_index(drop=True)
+    return combined, explanations
+
+
+def build_live_portfolio_run_state(
+    store: Any,
+    model_service: ModelService,
+    experiment_store: Any,
+    config: LiveMonitorConfig,
+    generated_at: pd.Timestamp | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, dict[str, Any]], list[str]]:
+    warnings: list[str] = []
+    explanation_lookup: dict[str, dict[str, Any]] = {}
+    snapshot_time = pd.Timestamp.utcnow().floor("s") if generated_at is None else pd.Timestamp(generated_at)
+    run_id = str(config.portfolio_run_id or "")
+    if not run_id:
+        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["Select and save a joint portfolio run first."]
+
+    run_bundle = experiment_store.load_run(run_id)
+    if run_bundle is None:
+        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, [f"Saved portfolio run `{run_id}` could not be loaded."]
+
+    portfolio_bundle = run_bundle.get("portfolio_model_bundle", {}) or {}
+    deployment_variant = str(config.deployment_variant or portfolio_bundle.get("deployment_variant") or "")
+    variant_payload = (portfolio_bundle.get("variants", {}) or {}).get(deployment_variant, {})
+    if not variant_payload:
+        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, [f"Deployment variant `{deployment_variant}` is not available in the pinned portfolio run."]
+
+    selected_symbols = [str(symbol).upper() for symbol in (variant_payload.get("selected_symbols") or portfolio_bundle.get("selected_symbols") or [])]
+    asset_session_features = store.read_frame("asset_session_features")
+    asset_post_mappings = store.read_frame("asset_post_mappings")
+    if asset_session_features.empty:
+        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["Refresh datasets first so `asset_session_features` is available."]
+    live_rows = asset_session_features.copy()
+    live_rows["asset_symbol"] = live_rows["asset_symbol"].astype(str).str.upper()
+    if selected_symbols:
+        live_rows = live_rows.loc[live_rows["asset_symbol"].isin(selected_symbols)].copy()
+    feature_version = str(variant_payload.get("feature_version") or portfolio_bundle.get("feature_version") or "")
+    if feature_version and "feature_version" in live_rows.columns:
+        matching = live_rows.loc[live_rows["feature_version"].astype(str) == feature_version].copy()
+        if not matching.empty:
+            live_rows = matching
+    llm_enabled = bool(variant_payload.get("llm_enabled", portfolio_bundle.get("llm_enabled", False)))
+    if "llm_enabled" in live_rows.columns:
+        matching = live_rows.loc[live_rows["llm_enabled"].fillna(False).astype(bool) == llm_enabled].copy()
+        if not matching.empty:
+            live_rows = matching
+    if live_rows.empty:
+        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["No live asset-session rows matched the pinned portfolio run."]
+
+    latest_rows = (
+        live_rows.sort_values(["asset_symbol", "signal_session_date"])
+        .groupby("asset_symbol", as_index=False, sort=False)
+        .tail(1)
+        .reset_index(drop=True)
+    )
+    weighted_rows = _apply_live_account_weight(latest_rows, float(variant_payload.get("account_weight", 1.0) or 1.0))
+    scored_rows, explanation_models = _predict_portfolio_live_variant(
+        model_service=model_service,
+        feature_rows=weighted_rows,
+        variant_payload=variant_payload,
+        selected_symbols=selected_symbols,
+    )
+    if scored_rows.empty:
+        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["The pinned portfolio models could not score any live rows."]
+
+    threshold = float(variant_payload.get("threshold", 0.0) or 0.0)
+    min_post_count = int(variant_payload.get("min_post_count", 1) or 1)
+    run_name = str(config.portfolio_run_name or run_bundle.get("run", {}).get("run_name", run_id) or run_id)
+    snapshot_rows: list[dict[str, Any]] = []
+    for _, row in scored_rows.sort_values("signal_session_date").iterrows():
+        asset_symbol = str(row.get("asset_symbol", "") or "").upper()
+        snapshot_rows.append(
+            {
+                "generated_at": snapshot_time,
+                "variant_name": deployment_variant,
+                "signal_session_date": row.get("signal_session_date"),
+                "next_session_date": row.get("next_session_date"),
+                "asset_symbol": asset_symbol,
+                "run_id": run_id,
+                "run_name": run_name,
+                "feature_version": str(row.get("feature_version", feature_version) or feature_version),
+                "model_version": str(row.get("model_version", "") or ""),
+                "expected_return_score": float(row.get("expected_return_score", 0.0) or 0.0),
+                "confidence": float(row.get("prediction_confidence", 0.0) or 0.0),
+                "threshold": threshold,
+                "min_post_count": min_post_count,
+                "post_count": int(row.get("post_count", 0) or 0),
+                "target_available": bool(row.get("target_available", False)),
+                "tradeable": bool(row.get("tradeable", row.get("target_available", False))),
+                "next_session_open": row.get("next_session_open"),
+                "next_session_close": row.get("next_session_close"),
+                "next_session_open_ts": row.get("next_session_open_ts"),
+            },
+        )
+        session_date = _normalize_session_date(row.get("signal_session_date"))
+        if asset_post_mappings.empty or session_date is None:
+            post_attribution = pd.DataFrame()
+        else:
+            post_rows = asset_post_mappings.copy()
+            post_rows["asset_symbol"] = post_rows["asset_symbol"].astype(str).str.upper()
+            session_mask = pd.to_datetime(post_rows["session_date"], errors="coerce").dt.normalize() == session_date
+            post_rows = post_rows.loc[(post_rows["asset_symbol"] == asset_symbol) & session_mask].copy()
+            post_attribution = build_post_attribution(post_rows)
+        account_attribution = build_account_attribution(post_attribution)
+        explanation_payload = explanation_models.get(asset_symbol, {})
+        explanation_lookup[asset_symbol] = {
+            "prediction_row": row,
+            "feature_contributions": explanation_payload.get("feature_contributions", pd.DataFrame()),
+            "post_attribution": post_attribution,
+            "account_attribution": account_attribution,
+            "variant_name": deployment_variant,
+        }
+
+    snapshots = pd.DataFrame(snapshot_rows)
+    if snapshots.empty:
+        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["No live portfolio snapshots were produced."]
+
+    ranked_board, decision = rank_live_asset_snapshots(snapshots, config.fallback_mode)
+    decision["deployment_variant"] = deployment_variant
+    decision["portfolio_run_id"] = run_id
+    decision["portfolio_run_name"] = run_name
+    for asset_symbol, payload in explanation_lookup.items():
+        board_match = ranked_board.loc[ranked_board["asset_symbol"].astype(str) == asset_symbol]
+        if not board_match.empty:
+            payload["board_row"] = board_match.iloc[0]
+    return ranked_board, decision, explanation_lookup, warnings

--- a/trump_workbench/paper_trading.py
+++ b/trump_workbench/paper_trading.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from uuid import uuid4
+
+import pandas as pd
+
+from .config import EASTERN
+from .contracts import LiveMonitorConfig, PaperDecisionRecord, PaperEquityPoint, PaperPortfolioConfig, PaperTradeRecord
+from .portfolio import rank_portfolio_candidates
+
+PAPER_PORTFOLIO_CONFIG_PATH = "live_monitor/paper_portfolio.json"
+PAPER_PORTFOLIO_REGISTRY_COLUMNS = [
+    "paper_portfolio_id",
+    "portfolio_run_id",
+    "portfolio_run_name",
+    "deployment_variant",
+    "fallback_mode",
+    "transaction_cost_bps",
+    "starting_cash",
+    "enabled",
+    "created_at",
+    "archived_at",
+]
+PAPER_DECISION_JOURNAL_COLUMNS = [
+    "paper_portfolio_id",
+    "generated_at",
+    "signal_session_date",
+    "next_session_date",
+    "decision_cutoff_ts",
+    "portfolio_run_id",
+    "portfolio_run_name",
+    "deployment_variant",
+    "winning_asset",
+    "winning_run_id",
+    "decision_source",
+    "fallback_mode",
+    "stance",
+    "winner_score",
+    "runner_up_asset",
+    "runner_up_score",
+    "eligible_asset_count",
+    "settlement_status",
+    "settled_at",
+]
+PAPER_TRADE_LEDGER_COLUMNS = [
+    "paper_portfolio_id",
+    "signal_session_date",
+    "next_session_date",
+    "asset_symbol",
+    "run_id",
+    "decision_source",
+    "stance",
+    "next_session_open",
+    "next_session_close",
+    "gross_return",
+    "net_return",
+    "benchmark_return",
+    "transaction_cost_bps",
+    "starting_equity",
+    "ending_equity",
+    "settled_at",
+]
+PAPER_EQUITY_CURVE_COLUMNS = [
+    "paper_portfolio_id",
+    "signal_session_date",
+    "next_session_date",
+    "equity",
+    "return_pct",
+    "settled_at",
+]
+PAPER_BENCHMARK_CURVE_COLUMNS = [
+    "paper_portfolio_id",
+    "benchmark_name",
+    "signal_session_date",
+    "next_session_date",
+    "equity",
+    "return_pct",
+    "settled_at",
+]
+
+
+def ensure_paper_portfolio_registry_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    registry = frame.copy()
+    for column in PAPER_PORTFOLIO_REGISTRY_COLUMNS:
+        if column not in registry.columns:
+            registry[column] = pd.NA
+    for column in ["created_at", "archived_at"]:
+        registry[column] = pd.to_datetime(registry[column], errors="coerce", utc=True)
+    registry["enabled"] = pd.Series(registry["enabled"], dtype="boolean").fillna(False).astype(bool)
+    registry["transaction_cost_bps"] = pd.to_numeric(registry["transaction_cost_bps"], errors="coerce").fillna(0.0)
+    registry["starting_cash"] = pd.to_numeric(registry["starting_cash"], errors="coerce").fillna(100000.0)
+    return registry[PAPER_PORTFOLIO_REGISTRY_COLUMNS].copy()
+
+
+def ensure_paper_decision_journal_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    journal = frame.copy()
+    for column in PAPER_DECISION_JOURNAL_COLUMNS:
+        if column not in journal.columns:
+            journal[column] = pd.NA
+    for column in ["generated_at", "signal_session_date", "next_session_date", "decision_cutoff_ts", "settled_at"]:
+        journal[column] = pd.to_datetime(journal[column], errors="coerce", utc=True)
+    for column in ["winner_score", "runner_up_score"]:
+        journal[column] = pd.to_numeric(journal[column], errors="coerce").fillna(0.0)
+    journal["eligible_asset_count"] = pd.to_numeric(journal["eligible_asset_count"], errors="coerce").fillna(0).astype(int)
+    journal["settlement_status"] = journal["settlement_status"].fillna("pending").astype(str)
+    return journal[PAPER_DECISION_JOURNAL_COLUMNS].copy()
+
+
+def ensure_paper_trade_ledger_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    ledger = frame.copy()
+    for column in PAPER_TRADE_LEDGER_COLUMNS:
+        if column not in ledger.columns:
+            ledger[column] = pd.NA
+    for column in ["signal_session_date", "next_session_date", "settled_at"]:
+        ledger[column] = pd.to_datetime(ledger[column], errors="coerce", utc=True)
+    for column in ["next_session_open", "next_session_close", "gross_return", "net_return", "benchmark_return", "transaction_cost_bps", "starting_equity", "ending_equity"]:
+        ledger[column] = pd.to_numeric(ledger[column], errors="coerce")
+    return ledger[PAPER_TRADE_LEDGER_COLUMNS].copy()
+
+
+def ensure_paper_equity_curve_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    curve = frame.copy()
+    for column in PAPER_EQUITY_CURVE_COLUMNS:
+        if column not in curve.columns:
+            curve[column] = pd.NA
+    for column in ["signal_session_date", "next_session_date", "settled_at"]:
+        curve[column] = pd.to_datetime(curve[column], errors="coerce", utc=True)
+    for column in ["equity", "return_pct"]:
+        curve[column] = pd.to_numeric(curve[column], errors="coerce")
+    return curve[PAPER_EQUITY_CURVE_COLUMNS].copy()
+
+
+def ensure_paper_benchmark_curve_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    curve = frame.copy()
+    for column in PAPER_BENCHMARK_CURVE_COLUMNS:
+        if column not in curve.columns:
+            curve[column] = pd.NA
+    for column in ["signal_session_date", "next_session_date", "settled_at"]:
+        curve[column] = pd.to_datetime(curve[column], errors="coerce", utc=True)
+    for column in ["equity", "return_pct"]:
+        curve[column] = pd.to_numeric(curve[column], errors="coerce")
+    curve["benchmark_name"] = curve["benchmark_name"].fillna("always_long_spy").astype(str)
+    return curve[PAPER_BENCHMARK_CURVE_COLUMNS].copy()
+
+
+def paper_config_matches_live(config: PaperPortfolioConfig | None, live_config: LiveMonitorConfig) -> bool:
+    if config is None or config.is_archived:
+        return False
+    return (
+        str(config.portfolio_run_id or "") == str(live_config.portfolio_run_id or "")
+        and str(config.deployment_variant or "") == str(live_config.deployment_variant or "")
+        and str(config.fallback_mode or "SPY").upper() == str(live_config.fallback_mode or "SPY").upper()
+    )
+
+
+class PaperTradingService:
+    def __init__(self, store) -> None:
+        self.store = store
+
+    def load_current_config(self) -> PaperPortfolioConfig | None:
+        payload = self.store.read_json_artifact(PAPER_PORTFOLIO_CONFIG_PATH)
+        if payload is None:
+            return None
+        return PaperPortfolioConfig.from_dict(payload)
+
+    def list_portfolios(self) -> pd.DataFrame:
+        registry = ensure_paper_portfolio_registry_frame(self.store.read_frame("paper_portfolio_registry"))
+        if registry.empty:
+            return registry
+        registry = registry.sort_values(["created_at", "paper_portfolio_id"], ascending=[False, False]).reset_index(drop=True)
+        return registry
+
+    def save_current_config(self, config: PaperPortfolioConfig) -> None:
+        self.store.save_json_artifact(PAPER_PORTFOLIO_CONFIG_PATH, config.to_dict())
+        registry = ensure_paper_portfolio_registry_frame(self.store.read_frame("paper_portfolio_registry"))
+        registry = registry.loc[registry["paper_portfolio_id"].astype(str) != str(config.paper_portfolio_id)].copy()
+        registry = pd.concat([registry, pd.DataFrame([asdict(config)])], ignore_index=True)
+        registry = ensure_paper_portfolio_registry_frame(registry)
+        registry = registry.sort_values(["created_at", "paper_portfolio_id"], ascending=[False, False]).reset_index(drop=True)
+        self.store.save_frame(
+            "paper_portfolio_registry",
+            registry,
+            metadata={"row_count": int(len(registry)), "active_count": int(registry["archived_at"].isna().sum())},
+        )
+
+    def build_config(
+        self,
+        live_config: LiveMonitorConfig,
+        portfolio_run_name: str,
+        transaction_cost_bps: float,
+        starting_cash: float = 100000.0,
+        enabled: bool = True,
+        now: pd.Timestamp | None = None,
+    ) -> PaperPortfolioConfig:
+        created_at = pd.Timestamp.now(tz="UTC") if now is None else pd.Timestamp(now)
+        if created_at.tzinfo is None:
+            created_at = created_at.tz_localize("UTC")
+        else:
+            created_at = created_at.tz_convert("UTC")
+        return PaperPortfolioConfig(
+            paper_portfolio_id=f"paper-{uuid4().hex[:12]}",
+            portfolio_run_id=str(live_config.portfolio_run_id or ""),
+            portfolio_run_name=str(portfolio_run_name or live_config.portfolio_run_name or live_config.portfolio_run_id or ""),
+            deployment_variant=str(live_config.deployment_variant or ""),
+            fallback_mode=str(live_config.fallback_mode or "SPY").upper(),
+            transaction_cost_bps=float(transaction_cost_bps or 0.0),
+            starting_cash=float(starting_cash or 100000.0),
+            enabled=bool(enabled),
+            created_at=created_at.isoformat(),
+            archived_at="",
+        )
+
+    def archive_current_config(self, now: pd.Timestamp | None = None) -> PaperPortfolioConfig | None:
+        current = self.load_current_config()
+        if current is None or current.is_archived:
+            return current
+        archived_at = pd.Timestamp.now(tz="UTC") if now is None else pd.Timestamp(now)
+        if archived_at.tzinfo is None:
+            archived_at = archived_at.tz_localize("UTC")
+        else:
+            archived_at = archived_at.tz_convert("UTC")
+        archived = PaperPortfolioConfig(
+            paper_portfolio_id=current.paper_portfolio_id,
+            portfolio_run_id=current.portfolio_run_id,
+            portfolio_run_name=current.portfolio_run_name,
+            deployment_variant=current.deployment_variant,
+            fallback_mode=current.fallback_mode,
+            transaction_cost_bps=current.transaction_cost_bps,
+            starting_cash=current.starting_cash,
+            enabled=False,
+            created_at=current.created_at,
+            archived_at=archived_at.isoformat(),
+        )
+        self.save_current_config(archived)
+        return archived
+
+    def upsert_current_for_live_config(
+        self,
+        live_config: LiveMonitorConfig,
+        portfolio_run_name: str,
+        transaction_cost_bps: float,
+        starting_cash: float = 100000.0,
+        enabled: bool = True,
+        reset: bool = False,
+        now: pd.Timestamp | None = None,
+    ) -> PaperPortfolioConfig:
+        current = self.load_current_config()
+        if reset or not paper_config_matches_live(current, live_config):
+            if current is not None and not current.is_archived:
+                self.archive_current_config(now=now)
+            current = self.build_config(
+                live_config=live_config,
+                portfolio_run_name=portfolio_run_name,
+                transaction_cost_bps=transaction_cost_bps,
+                starting_cash=starting_cash,
+                enabled=enabled,
+                now=now,
+            )
+        else:
+            current = PaperPortfolioConfig(
+                paper_portfolio_id=current.paper_portfolio_id,
+                portfolio_run_id=current.portfolio_run_id,
+                portfolio_run_name=current.portfolio_run_name,
+                deployment_variant=current.deployment_variant,
+                fallback_mode=current.fallback_mode,
+                transaction_cost_bps=current.transaction_cost_bps,
+                starting_cash=current.starting_cash,
+                enabled=bool(enabled),
+                created_at=current.created_at,
+                archived_at=current.archived_at,
+            )
+        self.save_current_config(current)
+        return current
+
+    def _replace_portfolio_rows(self, dataset_name: str, frame: pd.DataFrame, paper_portfolio_id: str) -> None:
+        existing = self.store.read_frame(dataset_name)
+        if "paper_portfolio_id" in existing.columns:
+            existing = existing.loc[existing["paper_portfolio_id"].astype(str) != str(paper_portfolio_id)].copy()
+        combined = pd.concat([existing, frame], ignore_index=True) if not existing.empty or not frame.empty else pd.DataFrame()
+        self.store.save_frame(dataset_name, combined, metadata={"row_count": int(len(combined))})
+
+    def _spy_price_lookup(self) -> pd.DataFrame:
+        asset_daily = self.store.read_frame("asset_daily")
+        if not asset_daily.empty:
+            normalized = asset_daily.copy()
+            normalized["symbol"] = normalized["symbol"].astype(str).str.upper()
+            spy_rows = normalized.loc[normalized["symbol"] == "SPY"].copy()
+            if not spy_rows.empty:
+                return spy_rows
+        spy_daily = self.store.read_frame("spy_daily")
+        if spy_daily.empty:
+            return pd.DataFrame()
+        spy_rows = spy_daily.copy()
+        spy_rows["symbol"] = "SPY"
+        return spy_rows
+
+    @staticmethod
+    def _price_lookup(frame: pd.DataFrame, symbol: str, trade_date: pd.Timestamp) -> tuple[float | None, float | None]:
+        if frame.empty:
+            return None, None
+        normalized = frame.copy()
+        if "symbol" not in normalized.columns:
+            normalized["symbol"] = symbol
+        normalized["symbol"] = normalized["symbol"].astype(str).str.upper()
+        normalized["trade_date"] = pd.to_datetime(normalized["trade_date"], errors="coerce").dt.tz_localize(None)
+        rows = normalized.loc[
+            (normalized["symbol"] == str(symbol).upper())
+            & (normalized["trade_date"] == pd.Timestamp(trade_date).tz_localize(None) if pd.Timestamp(trade_date).tzinfo is not None else pd.Timestamp(trade_date))
+        ].copy()
+        if rows.empty:
+            return None, None
+        row = rows.iloc[-1]
+        return (
+            float(pd.to_numeric(row.get("open"), errors="coerce")) if pd.notna(pd.to_numeric(row.get("open"), errors="coerce")) else None,
+            float(pd.to_numeric(row.get("close"), errors="coerce")) if pd.notna(pd.to_numeric(row.get("close"), errors="coerce")) else None,
+        )
+
+    @staticmethod
+    def _fallback_cutoff(next_session_date: pd.Timestamp | None) -> pd.Timestamp | None:
+        if next_session_date is None or pd.isna(next_session_date):
+            return None
+        local = pd.Timestamp(next_session_date)
+        if local.tzinfo is not None:
+            local = local.tz_convert(EASTERN)
+        else:
+            local = local.tz_localize(EASTERN)
+        cutoff = pd.Timestamp(f"{local.date()} 09:30", tz=EASTERN)
+        return cutoff.tz_convert("UTC")
+
+    def capture_authoritative_decisions(
+        self,
+        config: PaperPortfolioConfig,
+        as_of: pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        journal = ensure_paper_decision_journal_frame(self.store.read_frame("paper_decision_journal"))
+        if not config.enabled or config.is_archived:
+            return journal
+
+        live_assets = self.store.read_frame("live_asset_snapshots")
+        if live_assets.empty:
+            return journal
+        board = live_assets.copy()
+        board["run_id"] = board.get("run_id", "").astype(str)
+        board = board.loc[board["run_id"] == str(config.portfolio_run_id)].copy()
+        if "variant_name" in board.columns and str(config.deployment_variant or ""):
+            board = board.loc[board["variant_name"].astype(str) == str(config.deployment_variant)].copy()
+        if board.empty:
+            return journal
+        board["generated_at"] = pd.to_datetime(board["generated_at"], errors="coerce", utc=True)
+        board["signal_session_date"] = pd.to_datetime(board["signal_session_date"], errors="coerce", utc=True)
+        board["next_session_date"] = pd.to_datetime(board["next_session_date"], errors="coerce", utc=True)
+        board["next_session_open_ts"] = pd.to_datetime(board.get("next_session_open_ts"), errors="coerce", utc=True)
+        board = board.dropna(subset=["generated_at", "signal_session_date"]).copy()
+        if board.empty:
+            return journal
+
+        current_ts = pd.Timestamp.now(tz="UTC") if as_of is None else pd.Timestamp(as_of)
+        if current_ts.tzinfo is None:
+            current_ts = current_ts.tz_localize("UTC")
+        else:
+            current_ts = current_ts.tz_convert("UTC")
+
+        existing_sessions = set(
+            journal.loc[
+                journal["paper_portfolio_id"].astype(str) == str(config.paper_portfolio_id),
+                "signal_session_date",
+            ]
+            .dropna()
+            .tolist(),
+        )
+        new_rows: list[dict[str, object]] = []
+        grouped = board.groupby(board["signal_session_date"].dt.normalize(), sort=True)
+        for _, session_rows in grouped:
+            session_key = pd.Timestamp(session_rows["signal_session_date"].iloc[0]).normalize()
+            if session_key.tzinfo is None:
+                session_key = session_key.tz_localize("UTC")
+            else:
+                session_key = session_key.tz_convert("UTC")
+            if session_key in existing_sessions:
+                continue
+            cutoff_candidates = session_rows["next_session_open_ts"].dropna()
+            cutoff_ts = cutoff_candidates.min() if not cutoff_candidates.empty else self._fallback_cutoff(session_rows["next_session_date"].dropna().min() if not session_rows["next_session_date"].dropna().empty else None)
+            if cutoff_ts is None or current_ts < cutoff_ts:
+                continue
+            eligible_snapshots = session_rows.loc[session_rows["generated_at"] < cutoff_ts].copy()
+            if eligible_snapshots.empty:
+                continue
+            latest_generated_at = eligible_snapshots["generated_at"].max()
+            latest_board = eligible_snapshots.loc[eligible_snapshots["generated_at"] == latest_generated_at].copy()
+            ranked_board, decision = rank_portfolio_candidates(latest_board, fallback_mode=config.fallback_mode, require_tradeable=False)
+            if decision.empty:
+                continue
+            decision_row = decision.iloc[0]
+            record = PaperDecisionRecord(
+                paper_portfolio_id=str(config.paper_portfolio_id),
+                generated_at=pd.Timestamp(latest_generated_at),
+                signal_session_date=pd.Timestamp(decision_row["signal_session_date"]),
+                next_session_date=pd.Timestamp(decision_row["next_session_date"]) if pd.notna(decision_row["next_session_date"]) else None,
+                decision_cutoff_ts=pd.Timestamp(cutoff_ts),
+                portfolio_run_id=str(config.portfolio_run_id),
+                portfolio_run_name=str(config.portfolio_run_name),
+                deployment_variant=str(config.deployment_variant),
+                winning_asset=str(decision_row.get("winning_asset", "") or ""),
+                winning_run_id=str(decision_row.get("winning_run_id", "") or ""),
+                decision_source=str(decision_row.get("decision_source", "") or ""),
+                fallback_mode=str(decision_row.get("fallback_mode", config.fallback_mode) or config.fallback_mode),
+                stance=str(decision_row.get("stance", "") or ""),
+                winner_score=float(decision_row.get("winner_score", 0.0) or 0.0),
+                runner_up_asset=str(decision_row.get("runner_up_asset", "") or ""),
+                runner_up_score=float(decision_row.get("runner_up_score", 0.0) or 0.0),
+                eligible_asset_count=int(decision_row.get("eligible_asset_count", 0) or 0),
+                settlement_status="pending",
+                settled_at=None,
+            )
+            new_rows.append(record.to_dict())
+
+        if not new_rows:
+            return journal
+        updated = pd.concat([journal, pd.DataFrame(new_rows)], ignore_index=True)
+        updated = ensure_paper_decision_journal_frame(updated)
+        updated = updated.drop_duplicates(subset=["paper_portfolio_id", "signal_session_date"], keep="last")
+        updated = updated.sort_values(["signal_session_date", "generated_at"]).reset_index(drop=True)
+        self.store.save_frame(
+            "paper_decision_journal",
+            updated,
+            metadata={"row_count": int(len(updated)), "portfolio_count": int(updated["paper_portfolio_id"].nunique()) if not updated.empty else 0},
+        )
+        return updated
+
+    def settle_portfolio(
+        self,
+        config: PaperPortfolioConfig,
+        as_of: pd.Timestamp | None = None,
+    ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        journal = ensure_paper_decision_journal_frame(self.store.read_frame("paper_decision_journal"))
+        if journal.empty:
+            empty_trades = ensure_paper_trade_ledger_frame(pd.DataFrame())
+            empty_curve = ensure_paper_equity_curve_frame(pd.DataFrame())
+            empty_benchmark = ensure_paper_benchmark_curve_frame(pd.DataFrame())
+            return journal, empty_trades, empty_curve, empty_benchmark
+
+        current_ts = pd.Timestamp.now(tz="UTC") if as_of is None else pd.Timestamp(as_of)
+        if current_ts.tzinfo is None:
+            current_ts = current_ts.tz_localize("UTC")
+        else:
+            current_ts = current_ts.tz_convert("UTC")
+
+        asset_daily = self.store.read_frame("asset_daily")
+        spy_daily = self._spy_price_lookup()
+        portfolio_journal = journal.loc[journal["paper_portfolio_id"].astype(str) == str(config.paper_portfolio_id)].copy()
+        if portfolio_journal.empty:
+            empty_trades = ensure_paper_trade_ledger_frame(pd.DataFrame())
+            empty_curve = ensure_paper_equity_curve_frame(pd.DataFrame())
+            empty_benchmark = ensure_paper_benchmark_curve_frame(pd.DataFrame())
+            return journal, empty_trades, empty_curve, empty_benchmark
+
+        for idx, row in portfolio_journal.loc[portfolio_journal["settlement_status"].astype(str) == "pending"].iterrows():
+            next_session_date = row.get("next_session_date")
+            if pd.isna(next_session_date):
+                continue
+            benchmark_open, benchmark_close = self._price_lookup(spy_daily, "SPY", pd.Timestamp(next_session_date))
+            if benchmark_open is None or benchmark_close is None:
+                continue
+            winning_asset = str(row.get("winning_asset", "") or "").upper()
+            if not winning_asset:
+                portfolio_journal.loc[idx, "settlement_status"] = "flat"
+                portfolio_journal.loc[idx, "settled_at"] = current_ts
+                continue
+            trade_open, trade_close = self._price_lookup(asset_daily if not asset_daily.empty else spy_daily, winning_asset, pd.Timestamp(next_session_date))
+            if trade_open is None or trade_close is None:
+                continue
+            portfolio_journal.loc[idx, "settlement_status"] = "settled"
+            portfolio_journal.loc[idx, "settled_at"] = current_ts
+
+        updated_journal = journal.loc[journal["paper_portfolio_id"].astype(str) != str(config.paper_portfolio_id)].copy()
+        updated_journal = pd.concat([updated_journal, portfolio_journal], ignore_index=True)
+        updated_journal = ensure_paper_decision_journal_frame(updated_journal)
+        updated_journal = updated_journal.sort_values(["signal_session_date", "generated_at"]).reset_index(drop=True)
+        self.store.save_frame(
+            "paper_decision_journal",
+            updated_journal,
+            metadata={"row_count": int(len(updated_journal)), "portfolio_count": int(updated_journal["paper_portfolio_id"].nunique()) if not updated_journal.empty else 0},
+        )
+
+        settled_rows = portfolio_journal.loc[
+            portfolio_journal["settlement_status"].astype(str).isin(["settled", "flat"])
+        ].sort_values("signal_session_date").reset_index(drop=True)
+        trade_rows: list[dict[str, object]] = []
+        equity_rows: list[dict[str, object]] = []
+        benchmark_rows: list[dict[str, object]] = []
+        strategy_equity = float(config.starting_cash)
+        benchmark_equity = float(config.starting_cash)
+        round_trip_cost = (float(config.transaction_cost_bps) / 10000.0) * 2.0
+        for _, row in settled_rows.iterrows():
+            signal_session_date = pd.Timestamp(row["signal_session_date"])
+            next_session_date = pd.Timestamp(row["next_session_date"]) if pd.notna(row["next_session_date"]) else None
+            benchmark_open, benchmark_close = self._price_lookup(spy_daily, "SPY", next_session_date) if next_session_date is not None else (None, None)
+            benchmark_return = 0.0
+            if benchmark_open is not None and benchmark_close is not None and benchmark_open != 0:
+                benchmark_return = float(benchmark_close / benchmark_open - 1.0)
+
+            settled_at = pd.Timestamp(row["settled_at"]) if pd.notna(row["settled_at"]) else current_ts
+            starting_equity = strategy_equity
+            winning_asset = str(row.get("winning_asset", "") or "").upper()
+            if winning_asset:
+                trade_open, trade_close = self._price_lookup(asset_daily if not asset_daily.empty else spy_daily, winning_asset, next_session_date)
+                if trade_open is not None and trade_close is not None and trade_open != 0:
+                    gross_return = float(trade_close / trade_open - 1.0)
+                    net_return = gross_return - round_trip_cost
+                    ending_equity = starting_equity * (1.0 + net_return)
+                    trade = PaperTradeRecord(
+                        paper_portfolio_id=str(config.paper_portfolio_id),
+                        signal_session_date=signal_session_date,
+                        next_session_date=next_session_date,
+                        asset_symbol=winning_asset,
+                        run_id=str(row.get("winning_run_id", "") or ""),
+                        decision_source=str(row.get("decision_source", "") or ""),
+                        stance=str(row.get("stance", "") or ""),
+                        next_session_open=float(trade_open),
+                        next_session_close=float(trade_close),
+                        gross_return=float(gross_return),
+                        net_return=float(net_return),
+                        benchmark_return=float(benchmark_return),
+                        transaction_cost_bps=float(config.transaction_cost_bps),
+                        starting_equity=float(starting_equity),
+                        ending_equity=float(ending_equity),
+                        settled_at=settled_at,
+                    )
+                    trade_rows.append(trade.to_dict())
+                    strategy_equity = ending_equity
+                else:
+                    net_return = 0.0
+            else:
+                net_return = 0.0
+
+            benchmark_equity = benchmark_equity * (1.0 + benchmark_return)
+            equity_rows.append(
+                PaperEquityPoint(
+                    paper_portfolio_id=str(config.paper_portfolio_id),
+                    signal_session_date=signal_session_date,
+                    next_session_date=next_session_date,
+                    equity=float(strategy_equity),
+                    return_pct=float(net_return),
+                    settled_at=settled_at,
+                ).to_dict(),
+            )
+            benchmark_rows.append(
+                {
+                    "paper_portfolio_id": str(config.paper_portfolio_id),
+                    "benchmark_name": "always_long_spy",
+                    "signal_session_date": signal_session_date,
+                    "next_session_date": next_session_date,
+                    "equity": float(benchmark_equity),
+                    "return_pct": float(benchmark_return),
+                    "settled_at": settled_at,
+                },
+            )
+
+        trades = ensure_paper_trade_ledger_frame(pd.DataFrame(trade_rows))
+        equity_curve = ensure_paper_equity_curve_frame(pd.DataFrame(equity_rows))
+        benchmark_curve = ensure_paper_benchmark_curve_frame(pd.DataFrame(benchmark_rows))
+        self._replace_portfolio_rows("paper_trade_ledger", trades, config.paper_portfolio_id)
+        self._replace_portfolio_rows("paper_equity_curve", equity_curve, config.paper_portfolio_id)
+        self._replace_portfolio_rows("paper_benchmark_curve", benchmark_curve, config.paper_portfolio_id)
+        return updated_journal, trades, equity_curve, benchmark_curve
+
+    def process_live_history(
+        self,
+        config: PaperPortfolioConfig | None,
+        as_of: pd.Timestamp | None = None,
+    ) -> dict[str, int]:
+        if config is None or not config.enabled or config.is_archived:
+            return {"captured": 0, "settled": 0}
+        before = ensure_paper_decision_journal_frame(self.store.read_frame("paper_decision_journal"))
+        before_portfolio = before.loc[before["paper_portfolio_id"].astype(str) == str(config.paper_portfolio_id)].copy()
+        before_count = int(len(before_portfolio))
+        before_settled = int(before_portfolio["settlement_status"].astype(str).isin(["settled", "flat"]).sum()) if not before_portfolio.empty else 0
+        self.capture_authoritative_decisions(config, as_of=as_of)
+        updated_journal, _, _, _ = self.settle_portfolio(config, as_of=as_of)
+        after_portfolio = updated_journal.loc[updated_journal["paper_portfolio_id"].astype(str) == str(config.paper_portfolio_id)].copy()
+        after_count = int(len(after_portfolio))
+        after_settled = int(after_portfolio["settlement_status"].astype(str).isin(["settled", "flat"]).sum()) if not after_portfolio.empty else 0
+        return {
+            "captured": max(0, after_count - before_count),
+            "settled": max(0, after_settled - before_settled),
+        }

--- a/trump_workbench/portfolio.py
+++ b/trump_workbench/portfolio.py
@@ -21,6 +21,7 @@ PORTFOLIO_CANDIDATE_COLUMNS = [
     "tradeable",
     "next_session_open",
     "next_session_close",
+    "next_session_open_ts",
     "signal_qualifies",
     "qualifies",
     "eligible_rank",
@@ -50,6 +51,7 @@ def _normalize_portfolio_candidates(candidates: pd.DataFrame) -> pd.DataFrame:
             board[column] = pd.NA
     board["signal_session_date"] = pd.to_datetime(board["signal_session_date"], errors="coerce")
     board["next_session_date"] = pd.to_datetime(board["next_session_date"], errors="coerce")
+    board["next_session_open_ts"] = pd.to_datetime(board["next_session_open_ts"], errors="coerce", utc=True)
     board["asset_symbol"] = board["asset_symbol"].fillna("").astype(str).str.upper()
     board["run_id"] = board["run_id"].fillna("").astype(str)
     board["run_name"] = board["run_name"].fillna("").astype(str)

--- a/trump_workbench/scheduler.py
+++ b/trump_workbench/scheduler.py
@@ -10,10 +10,14 @@ import pandas as pd
 from .config import AppSettings
 from .discovery import DiscoveryService
 from .enrichment import LLMEnrichmentService
+from .experiments import ExperimentStore
 from .features import FeatureService
 from .health import DataHealthService, ensure_refresh_history_frame
 from .ingestion import IngestionService
+from .live_monitor import build_live_portfolio_run_state, validate_live_monitor_config
 from .market import MarketDataService
+from .modeling import ModelService
+from .paper_trading import PaperTradingService, paper_config_matches_live
 from .runtime import missing_core_datasets, refresh_datasets
 from .storage import DuckDBStore
 
@@ -106,6 +110,9 @@ def run_scheduler_once(settings: AppSettings) -> SchedulerDecision:
         health_service = DataHealthService()
         enrichment_service = LLMEnrichmentService(store)
         feature_service = FeatureService(enrichment_service)
+        experiment_store = ExperimentStore(store)
+        model_service = ModelService()
+        paper_service = PaperTradingService(store)
         refresh_datasets(
             settings=settings,
             store=store,
@@ -119,6 +126,25 @@ def run_scheduler_once(settings: AppSettings) -> SchedulerDecision:
             incremental=decision.incremental,
             refresh_mode=decision.refresh_mode,
         )
+        live_config = experiment_store.load_live_monitor_config()
+        if live_config is not None:
+            runs = experiment_store.list_runs()
+            live_errors = validate_live_monitor_config(live_config, runs)
+            if not live_errors and str(live_config.mode or "portfolio_run") == "portfolio_run":
+                generated_at = pd.Timestamp.utcnow().floor("s")
+                board, decision_row, _, _warnings = build_live_portfolio_run_state(
+                    store=store,
+                    model_service=model_service,
+                    experiment_store=experiment_store,
+                    config=live_config,
+                    generated_at=generated_at,
+                )
+                if not board.empty and not decision_row.empty:
+                    experiment_store.save_live_asset_snapshots(board)
+                    experiment_store.save_live_decision_snapshots(decision_row)
+                    paper_config = paper_service.load_current_config()
+                    if paper_config_matches_live(paper_config, live_config):
+                        paper_service.process_live_history(paper_config, as_of=generated_at)
         return decision
     finally:
         release_refresh_lock(settings, lock_fd)

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -49,9 +49,24 @@ from .modeling import (
 from .live_monitor import (
     LIVE_ASSET_SNAPSHOT_COLUMNS,
     LIVE_DECISION_SNAPSHOT_COLUMNS,
+    build_live_portfolio_run_state,
     seed_live_monitor_config,
     rank_live_asset_snapshots,
     validate_live_monitor_config,
+)
+from .paper_trading import (
+    PAPER_BENCHMARK_CURVE_COLUMNS,
+    PAPER_DECISION_JOURNAL_COLUMNS,
+    PAPER_EQUITY_CURVE_COLUMNS,
+    PAPER_PORTFOLIO_REGISTRY_COLUMNS,
+    PAPER_TRADE_LEDGER_COLUMNS,
+    PaperTradingService,
+    ensure_paper_benchmark_curve_frame,
+    ensure_paper_decision_journal_frame,
+    ensure_paper_equity_curve_frame,
+    ensure_paper_portfolio_registry_frame,
+    ensure_paper_trade_ledger_frame,
+    paper_config_matches_live,
 )
 from .runtime import (
     append_refresh_history as runtime_append_refresh_history,
@@ -370,6 +385,7 @@ def _build_live_monitor_state_from_asset_model_set(
                 "threshold": float(threshold if threshold is not None else 0.0),
                 "min_post_count": int(min_post_count if min_post_count is not None else 1),
                 "post_count": int(latest_prediction.get("post_count", 0) or 0),
+                "next_session_open_ts": latest_prediction.get("next_session_open_ts"),
             },
         )
         explanation_lookup[asset_symbol] = {
@@ -460,120 +476,13 @@ def _build_live_monitor_state_from_portfolio_run(
     config: LiveMonitorConfig,
     generated_at: pd.Timestamp | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, dict[str, Any]], list[str]]:
-    warnings: list[str] = []
-    explanation_lookup: dict[str, dict[str, Any]] = {}
-    snapshot_time = pd.Timestamp.utcnow().floor("s") if generated_at is None else pd.Timestamp(generated_at)
-    run_id = str(config.portfolio_run_id or "")
-    if not run_id:
-        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["Select and save a joint portfolio run first."]
-
-    run_bundle = experiment_store.load_run(run_id)
-    if run_bundle is None:
-        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, [f"Saved portfolio run `{run_id}` could not be loaded."]
-
-    portfolio_bundle = run_bundle.get("portfolio_model_bundle", {}) or {}
-    deployment_variant = str(config.deployment_variant or portfolio_bundle.get("deployment_variant") or "")
-    variant_payload = (portfolio_bundle.get("variants", {}) or {}).get(deployment_variant, {})
-    if not variant_payload:
-        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, [f"Deployment variant `{deployment_variant}` is not available in the pinned portfolio run."]
-
-    selected_symbols = [str(symbol).upper() for symbol in (variant_payload.get("selected_symbols") or portfolio_bundle.get("selected_symbols") or [])]
-    asset_session_features = store.read_frame("asset_session_features")
-    asset_post_mappings = store.read_frame("asset_post_mappings")
-    if asset_session_features.empty:
-        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["Refresh datasets first so `asset_session_features` is available."]
-    live_rows = asset_session_features.copy()
-    live_rows["asset_symbol"] = live_rows["asset_symbol"].astype(str).str.upper()
-    if selected_symbols:
-        live_rows = live_rows.loc[live_rows["asset_symbol"].isin(selected_symbols)].copy()
-    feature_version = str(variant_payload.get("feature_version") or portfolio_bundle.get("feature_version") or "")
-    if feature_version and "feature_version" in live_rows.columns:
-        matching = live_rows.loc[live_rows["feature_version"].astype(str) == feature_version].copy()
-        if not matching.empty:
-            live_rows = matching
-    llm_enabled = bool(variant_payload.get("llm_enabled", portfolio_bundle.get("llm_enabled", False)))
-    if "llm_enabled" in live_rows.columns:
-        matching = live_rows.loc[live_rows["llm_enabled"].fillna(False).astype(bool) == llm_enabled].copy()
-        if not matching.empty:
-            live_rows = matching
-    if live_rows.empty:
-        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["No live asset-session rows matched the pinned portfolio run."]
-
-    latest_rows = (
-        live_rows.sort_values(["asset_symbol", "signal_session_date"])
-        .groupby("asset_symbol", as_index=False, sort=False)
-        .tail(1)
-        .reset_index(drop=True)
-    )
-    weighted_rows = _apply_live_account_weight(latest_rows, float(variant_payload.get("account_weight", 1.0) or 1.0))
-    scored_rows, explanation_models = _predict_portfolio_live_variant(
+    return build_live_portfolio_run_state(
+        store=store,
         model_service=model_service,
-        feature_rows=weighted_rows,
-        variant_payload=variant_payload,
-        selected_symbols=selected_symbols,
+        experiment_store=experiment_store,
+        config=config,
+        generated_at=generated_at,
     )
-    if scored_rows.empty:
-        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["The pinned portfolio models could not score any live rows."]
-
-    threshold = float(variant_payload.get("threshold", 0.0) or 0.0)
-    min_post_count = int(variant_payload.get("min_post_count", 1) or 1)
-    run_name = str(config.portfolio_run_name or run_bundle.get("run", {}).get("run_name", run_id) or run_id)
-    snapshot_rows: list[dict[str, Any]] = []
-    for _, row in scored_rows.sort_values("signal_session_date").iterrows():
-        asset_symbol = str(row.get("asset_symbol", "") or "").upper()
-        snapshot_rows.append(
-            {
-                "generated_at": snapshot_time,
-                "variant_name": deployment_variant,
-                "signal_session_date": row.get("signal_session_date"),
-                "next_session_date": row.get("next_session_date"),
-                "asset_symbol": asset_symbol,
-                "run_id": run_id,
-                "run_name": run_name,
-                "feature_version": str(row.get("feature_version", feature_version) or feature_version),
-                "model_version": str(row.get("model_version", "") or ""),
-                "expected_return_score": float(row.get("expected_return_score", 0.0) or 0.0),
-                "confidence": float(row.get("prediction_confidence", 0.0) or 0.0),
-                "threshold": threshold,
-                "min_post_count": min_post_count,
-                "post_count": int(row.get("post_count", 0) or 0),
-                "target_available": bool(row.get("target_available", False)),
-                "tradeable": bool(row.get("tradeable", row.get("target_available", False))),
-                "next_session_open": row.get("next_session_open"),
-                "next_session_close": row.get("next_session_close"),
-            },
-        )
-        session_date = _normalize_session_date(row.get("signal_session_date"))
-        if asset_post_mappings.empty or session_date is None:
-            post_attribution = pd.DataFrame()
-        else:
-            post_rows = asset_post_mappings.copy()
-            post_rows["asset_symbol"] = post_rows["asset_symbol"].astype(str).str.upper()
-            session_mask = pd.to_datetime(post_rows["session_date"], errors="coerce").dt.normalize() == session_date
-            post_rows = post_rows.loc[(post_rows["asset_symbol"] == asset_symbol) & session_mask].copy()
-            post_attribution = build_post_attribution(post_rows)
-        account_attribution = build_account_attribution(post_attribution)
-        explanation_payload = explanation_models.get(asset_symbol, {})
-        explanation_lookup[asset_symbol] = {
-            "prediction_row": row,
-            "feature_contributions": explanation_payload.get("feature_contributions", pd.DataFrame()),
-            "post_attribution": post_attribution,
-            "account_attribution": account_attribution,
-            "variant_name": deployment_variant,
-        }
-
-    snapshots = pd.DataFrame(snapshot_rows)
-    if snapshots.empty:
-        return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, ["No live portfolio snapshots were produced."]
-
-    ranked_board, decision = rank_live_asset_snapshots(snapshots, config.fallback_mode)
-    decision["deployment_variant"] = deployment_variant
-    for asset_symbol, payload in explanation_lookup.items():
-        board_match = ranked_board.loc[ranked_board["asset_symbol"].astype(str) == asset_symbol]
-        if board_match.empty:
-            continue
-        payload["board_row"] = board_match.iloc[0]
-    return ranked_board, decision, explanation_lookup, warnings
 
 
 def _build_live_runner_up_frame(board: pd.DataFrame, decision_row: pd.Series) -> pd.DataFrame:
@@ -3197,6 +3106,21 @@ def render_live_monitor(
             st.error(message)
         return
 
+    paper_service = PaperTradingService(store)
+    active_run_rows = joint_portfolio_runs.loc[
+        joint_portfolio_runs["run_id"].astype(str) == str(active_config.portfolio_run_id)
+    ].copy()
+    active_run_row = active_run_rows.iloc[0] if not active_run_rows.empty else pd.Series(dtype=object)
+    active_run_name = str(
+        active_run_row.get("run_name", active_config.portfolio_run_name or active_config.portfolio_run_id)
+        or active_config.portfolio_run_name
+        or active_config.portfolio_run_id
+    )
+    active_run_params = active_run_row.get("selected_params_json", {}) or {}
+    active_transaction_cost_bps = float(active_run_params.get("transaction_cost_bps", 0.0) or 0.0)
+    current_paper_config = paper_service.load_current_config()
+    active_paper_config = current_paper_config if paper_config_matches_live(current_paper_config, active_config) else None
+
     posts = store.read_frame("normalized_posts")
     spy = store.read_frame("spy_daily")
     tracked_accounts = store.read_frame("tracked_accounts")
@@ -3231,13 +3155,17 @@ def render_live_monitor(
         experiment_store.save_live_decision_snapshots(decision_history_row)
         st.session_state["live_monitor_last_persisted_at"] = board_generated_at.isoformat()
 
+    paper_update = {"captured": 0, "settled": 0}
+    if active_paper_config is not None and active_paper_config.enabled:
+        paper_update = paper_service.process_live_history(active_paper_config, as_of=board_generated_at)
+
     decision_row = decision_history_row.iloc[0]
     winner_asset = str(decision_row.get("winning_asset", "") or "")
     winner_rows = board.loc[board["is_winner"]].copy()
     winner_row = winner_rows.iloc[0] if not winner_rows.empty else None
     winner_confidence = float(winner_row["confidence"]) if winner_row is not None else 0.0
     display_asset = winner_asset or "FLAT"
-    tabs = st.tabs(["Current Decision", "Why This Asset Won", "History"])
+    tabs = st.tabs(["Current Decision", "Why This Asset Won", "History", "Paper Portfolio"])
 
     with tabs[0]:
         metric_cols = st.columns(7)
@@ -3422,6 +3350,209 @@ def render_live_monitor(
                 use_container_width=True,
                 hide_index=True,
             )
+
+    with tabs[3]:
+        registry = paper_service.list_portfolios()
+        active_paper_config = paper_service.load_current_config()
+        active_matching_paper = active_paper_config if paper_config_matches_live(active_paper_config, active_config) else None
+        current_journal = ensure_paper_decision_journal_frame(store.read_frame("paper_decision_journal"))
+        current_trades = ensure_paper_trade_ledger_frame(store.read_frame("paper_trade_ledger"))
+        current_equity = ensure_paper_equity_curve_frame(store.read_frame("paper_equity_curve"))
+        current_benchmark = ensure_paper_benchmark_curve_frame(store.read_frame("paper_benchmark_curve"))
+
+        st.markdown("**Paper trading controls**")
+        if not can_write:
+            st.info("Public visitors can inspect the paper portfolio history, but enabling, resetting, and archiving paper trading requires admin access.")
+
+        if active_matching_paper is None:
+            st.info("Paper trading is not enabled for the currently pinned portfolio run.")
+            if can_write:
+                with st.form("paper-portfolio-enable-form"):
+                    starting_cash = st.number_input(
+                        "Starting cash",
+                        min_value=1000.0,
+                        value=100000.0,
+                        step=1000.0,
+                    )
+                    enable_paper = st.form_submit_button("Enable paper trading for pinned run")
+                if enable_paper:
+                    paper_service.upsert_current_for_live_config(
+                        live_config=active_config,
+                        portfolio_run_name=active_run_name,
+                        transaction_cost_bps=active_transaction_cost_bps,
+                        starting_cash=float(starting_cash),
+                        enabled=True,
+                        reset=False,
+                        now=board_generated_at,
+                    )
+                    st.rerun()
+        else:
+            control_cols = st.columns(3)
+            control_cols[0].metric("Paper portfolio", active_matching_paper.paper_portfolio_id)
+            control_cols[1].metric("Status", "Enabled" if active_matching_paper.enabled else "Disabled")
+            control_cols[2].metric("Starting cash", f"${active_matching_paper.starting_cash:,.0f}")
+            toggle_label = "Disable paper trading" if active_matching_paper.enabled else "Enable paper trading"
+            toggle_disabled = not can_write
+            if control_cols[0].button(toggle_label, use_container_width=True, disabled=toggle_disabled):
+                paper_service.upsert_current_for_live_config(
+                    live_config=active_config,
+                    portfolio_run_name=active_run_name,
+                    transaction_cost_bps=active_matching_paper.transaction_cost_bps,
+                    starting_cash=active_matching_paper.starting_cash,
+                    enabled=not active_matching_paper.enabled,
+                    reset=False,
+                    now=board_generated_at,
+                )
+                st.rerun()
+            if control_cols[1].button("Archive current portfolio", use_container_width=True, disabled=not can_write):
+                paper_service.archive_current_config(now=board_generated_at)
+                st.rerun()
+            with control_cols[2].form("paper-portfolio-reset-form"):
+                reset_cash = st.number_input(
+                    "Reset starting cash",
+                    min_value=1000.0,
+                    value=float(active_matching_paper.starting_cash),
+                    step=1000.0,
+                )
+                reset_paper = st.form_submit_button("Reset portfolio", disabled=not can_write)
+            if reset_paper:
+                paper_service.upsert_current_for_live_config(
+                    live_config=active_config,
+                    portfolio_run_name=active_run_name,
+                    transaction_cost_bps=active_transaction_cost_bps or active_matching_paper.transaction_cost_bps,
+                    starting_cash=float(reset_cash),
+                    enabled=True,
+                    reset=True,
+                    now=board_generated_at,
+                )
+                st.rerun()
+
+        if paper_update["captured"] or paper_update["settled"]:
+            st.caption(
+                f"Latest capture cycle: {paper_update['captured']} decision(s) captured, "
+                f"{paper_update['settled']} decision(s) settled."
+            )
+
+        registry = paper_service.list_portfolios()
+        current_journal = ensure_paper_decision_journal_frame(store.read_frame("paper_decision_journal"))
+        current_trades = ensure_paper_trade_ledger_frame(store.read_frame("paper_trade_ledger"))
+        current_equity = ensure_paper_equity_curve_frame(store.read_frame("paper_equity_curve"))
+        current_benchmark = ensure_paper_benchmark_curve_frame(store.read_frame("paper_benchmark_curve"))
+
+        if registry.empty:
+            st.info("No paper portfolios have been created yet.")
+        else:
+            registry_view = registry.copy()
+            registry_view["status"] = np.where(registry_view["archived_at"].notna(), "archived", np.where(registry_view["enabled"], "active", "disabled"))
+            option_ids = registry_view["paper_portfolio_id"].astype(str).tolist()
+            default_portfolio_id = (
+                active_matching_paper.paper_portfolio_id
+                if active_matching_paper is not None
+                else option_ids[0]
+            )
+            selected_paper_id = st.selectbox(
+                "View paper portfolio",
+                options=option_ids,
+                index=option_ids.index(default_portfolio_id) if default_portfolio_id in option_ids else 0,
+                format_func=lambda paper_id: (
+                    lambda row: f"{paper_id} | {row['status']} | {row['portfolio_run_name']} | {row['deployment_variant'] or 'n/a'}"
+                )(registry_view.loc[registry_view["paper_portfolio_id"].astype(str) == str(paper_id)].iloc[0]),
+                key="paper-portfolio-select",
+            )
+            selected_registry_row = registry_view.loc[
+                registry_view["paper_portfolio_id"].astype(str) == str(selected_paper_id)
+            ].iloc[0]
+            selected_journal = current_journal.loc[
+                current_journal["paper_portfolio_id"].astype(str) == str(selected_paper_id)
+            ].copy()
+            selected_trades = current_trades.loc[
+                current_trades["paper_portfolio_id"].astype(str) == str(selected_paper_id)
+            ].copy()
+            selected_equity = current_equity.loc[
+                current_equity["paper_portfolio_id"].astype(str) == str(selected_paper_id)
+            ].copy()
+            selected_benchmark = current_benchmark.loc[
+                current_benchmark["paper_portfolio_id"].astype(str) == str(selected_paper_id)
+            ].copy()
+
+            latest_equity = float(selected_equity["equity"].iloc[-1]) if not selected_equity.empty else float(selected_registry_row["starting_cash"])
+            cumulative_return = latest_equity / float(selected_registry_row["starting_cash"]) - 1.0 if float(selected_registry_row["starting_cash"]) else 0.0
+            unsettled_count = int((selected_journal["settlement_status"].astype(str) == "pending").sum()) if not selected_journal.empty else 0
+            settled_rows = selected_journal.loc[
+                selected_journal["settlement_status"].astype(str).isin(["settled", "flat"])
+            ].copy()
+            last_settled = settled_rows["next_session_date"].max() if not settled_rows.empty else pd.NaT
+            status_cols = st.columns(6)
+            status_cols[0].metric("Portfolio status", str(selected_registry_row["status"]).title())
+            status_cols[1].metric("Current equity", f"${latest_equity:,.2f}")
+            status_cols[2].metric("Cumulative return", f"{cumulative_return:+.2%}")
+            status_cols[3].metric("Realized trades", f"{len(selected_trades):,}")
+            status_cols[4].metric("Open or unsettled", f"{unsettled_count:,}")
+            status_cols[5].metric(
+                "Last settled session",
+                f"{pd.Timestamp(last_settled):%Y-%m-%d}" if pd.notna(last_settled) else "n/a",
+            )
+
+            capture_cols = st.columns(3)
+            last_captured = selected_journal["generated_at"].max() if not selected_journal.empty else pd.NaT
+            last_trade_settled = selected_trades["settled_at"].max() if not selected_trades.empty else pd.NaT
+            capture_cols[0].metric("Scheduler capture", "Enabled" if settings.scheduler_enabled else "Disabled")
+            capture_cols[1].metric(
+                "Last paper decision",
+                f"{pd.Timestamp(last_captured):%Y-%m-%d %H:%M UTC}" if pd.notna(last_captured) else "n/a",
+            )
+            capture_cols[2].metric(
+                "Last trade settled",
+                f"{pd.Timestamp(last_trade_settled):%Y-%m-%d %H:%M UTC}" if pd.notna(last_trade_settled) else "n/a",
+            )
+
+            if selected_equity.empty:
+                st.info("No settled paper portfolio history yet.")
+            else:
+                paper_fig = go.Figure()
+                paper_fig.add_trace(
+                    go.Scatter(
+                        x=selected_equity["next_session_date"],
+                        y=selected_equity["equity"],
+                        mode="lines+markers",
+                        name="Paper portfolio",
+                    ),
+                )
+                if not selected_benchmark.empty:
+                    paper_fig.add_trace(
+                        go.Scatter(
+                            x=selected_benchmark["next_session_date"],
+                            y=selected_benchmark["equity"],
+                            mode="lines+markers",
+                            name="SPY benchmark",
+                        ),
+                    )
+                paper_fig.update_layout(
+                    title="Paper portfolio equity vs SPY",
+                    xaxis_title="Next session date",
+                    yaxis_title="Equity",
+                )
+                st.plotly_chart(paper_fig, use_container_width=True)
+
+            st.markdown("**Recent decision journal**")
+            if selected_journal.empty:
+                st.info("No paper decisions have been recorded for this portfolio yet.")
+            else:
+                st.dataframe(
+                    selected_journal.tail(25),
+                    use_container_width=True,
+                    hide_index=True,
+                )
+
+            st.markdown("**Recent trade ledger**")
+            if selected_trades.empty:
+                st.info("No paper trades have settled for this portfolio yet.")
+            else:
+                st.dataframe(
+                    selected_trades.tail(25),
+                    use_container_width=True,
+                    hide_index=True,
+                )
 
 
 def render_historical_replay_view(


### PR DESCRIPTION
## Summary
- add a paper-trading layer on top of the joint portfolio live console
- capture one authoritative live decision per signal session using the latest persisted pre-open snapshot
- settle paper trades against next-session open/close prices and track realized equity vs SPY
- extend the scheduler so live snapshots and paper portfolio state advance even when no browser session is open

## What changed
- added `trump_workbench/paper_trading.py`
  - paper portfolio config
  - decision journal capture
  - trade settlement
  - equity and SPY benchmark tracking
  - portfolio archive/reset behavior
- extended `trump_workbench/contracts.py`
  - `PaperPortfolioConfig`
  - `PaperDecisionRecord`
  - `PaperTradeRecord`
  - `PaperEquityPoint`
- extended `trump_workbench/live_monitor.py`
  - reusable live portfolio-run state builder
  - live snapshots now carry `next_session_open_ts` so paper capture can use a real cutoff
- updated `trump_workbench/portfolio.py`
  - candidate normalization now includes `next_session_open_ts`
- updated `trump_workbench/scheduler.py`
  - scheduler now persists live portfolio-run snapshots
  - scheduler advances paper decision capture and trade settlement
- updated `trump_workbench/ui.py`
  - added a `Paper Portfolio` tab to `Live Monitor`
  - added admin-only enable/disable, reset, and archive controls
  - added public-readable paper portfolio status, equity, decision journal, and trade ledger
- added `tests/test_paper_trading.py`

## Behavior
- paper trading only supports pinned joint portfolio runs
- the authoritative decision for a session is the latest persisted live decision strictly before the next session open
- `FLAT` sessions are journaled but do not create trade rows
- switching the pinned portfolio run creates a new paper portfolio context rather than mixing ledgers
- the first benchmark is always-long `SPY`

## Validation
- `bash scripts/ci.sh`
- `./.venv/bin/python -m unittest discover -s tests -v`

## Results
- `110` tests passing
- `91%` total coverage
- Streamlit smoke check passed

## Notes
- branch: `codex/live-paper-portfolio-and-decision-audit`
- commit: `9c2bafd`
- PR creation via `gh` was blocked by token permissions, so this PR is being opened from the GitHub compare page
