### PR TITLE
Add live paper portfolio audit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.35
+streamlit>=1.50
 pandas>=2.2
 numpy>=1.26
 plotly>=5.20

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -3714,14 +3714,21 @@ def main() -> None:
     _ensure_bootstrap(settings, store, ingestion_service, market_service, discovery_service, feature_service, health_service)
 
     _render_sidebar_access_panel(settings)
-    page = st.sidebar.radio(
+    pages = ["Research View", "Datasets", "Discovery", "Models & Backtests", "Historical Replay", "Live Monitor"]
+    page = st.segmented_control(
         "Workbench",
-        options=["Research View", "Datasets", "Discovery", "Models & Backtests", "Historical Replay", "Live Monitor"],
+        options=pages,
+        default=pages[0],
+        key="workbench_page",
+        label_visibility="collapsed",
+        width="stretch",
     )
     st.sidebar.markdown("---")
     st.sidebar.caption("Storage: DuckDB + Parquet")
     st.sidebar.code(str(settings.state_root))
     st.sidebar.code(str(settings.db_path))
+    if page is None:
+        page = pages[0]
 
     if page == "Research View":
         render_research_view(settings, store, market_service, feature_service)


### PR DESCRIPTION
## Summary
- add a paper-trading layer on top of the joint portfolio live console
- capture one authoritative live decision per signal session using the latest persisted pre-open snapshot
- settle paper trades against next-session open/close prices and track realized equity vs SPY
- extend the scheduler so live snapshots and paper portfolio state advance even when no browser session is open
- update README workflow docs and replace sidebar radio navigation with tab-style top-level navigation

## Behavior
- paper trading only supports pinned joint portfolio runs
- the authoritative decision for a session is the latest persisted live decision strictly before the next session open
- `FLAT` sessions are journaled but do not create trade rows
- switching the pinned portfolio run creates a new paper portfolio context instead of mixing ledgers
- Streamlit navigation uses `segmented_control` to preserve one-page-at-a-time execution while presenting tab-style navigation

## Validation
- `bash scripts/ci.sh`
- `./.venv/bin/python -m unittest discover -s tests -v`

## Results
- 110 tests passing
- 91% total coverage
- Streamlit smoke check passed

Closes #30
