### PR TITLE
[codex] Add narrative signal modeling ablations

### DIFF
--- a/tests/test_config_contracts.py
+++ b/tests/test_config_contracts.py
@@ -139,6 +139,7 @@ class ConfigAndContractsTests(unittest.TestCase):
             selected_symbols=("SPY", "QQQ"),
             model_families=("ridge", "hist_gradient_boosting_regressor"),
             topology_variants=("per_asset", "pooled"),
+            narrative_feature_modes=("baseline", "hybrid"),
             deployment_variant="pooled",
         )
         snapshot = PredictionSnapshot(
@@ -198,6 +199,7 @@ class ConfigAndContractsTests(unittest.TestCase):
         self.assertEqual(config.to_dict()["threshold_grid"], list(config.threshold_grid))
         self.assertEqual(portfolio_config.to_dict()["component_run_ids"], ["spy-run", "qqq-run"])
         self.assertEqual(portfolio_config.to_dict()["selected_symbols"], ["SPY", "QQQ"])
+        self.assertEqual(portfolio_config.to_dict()["narrative_feature_modes"], ["baseline", "hybrid"])
         self.assertEqual(snapshot.to_dict()["target_asset"], "SPY")
         self.assertEqual(snapshot.to_dict()["stance"], "long")
         self.assertEqual(backtest_run.to_dict()["run_id"], "run-1")

--- a/tests/test_live_monitor.py
+++ b/tests/test_live_monitor.py
@@ -599,6 +599,7 @@ class LiveMonitorStateIntegrationTests(unittest.TestCase):
             selected_params={
                 "fallback_mode": "SPY",
                 "deployment_variant": "per_asset",
+                "deployment_narrative_feature_mode": "baseline",
                 "selected_symbols": ["SPY", "QQQ"],
             },
             run_type="portfolio_allocator",
@@ -642,6 +643,7 @@ class LiveMonitorStateIntegrationTests(unittest.TestCase):
                     "per_asset": {
                         "variant_name": "per_asset",
                         "topology": "per_asset",
+                        "narrative_feature_mode": "baseline",
                         "model_family": "ridge",
                         "threshold": 0.0,
                         "min_post_count": 1,
@@ -698,6 +700,8 @@ class LiveMonitorStateIntegrationTests(unittest.TestCase):
         self.assertFalse(warnings)
         self.assertEqual(decision.iloc[0]["winning_asset"], "QQQ")
         self.assertEqual(decision.iloc[0]["deployment_variant"], "per_asset")
+        self.assertEqual(decision.iloc[0]["narrative_feature_mode"], "baseline")
+        self.assertEqual(board["narrative_feature_mode"].dropna().astype(str).unique().tolist(), ["baseline"])
         self.assertSetEqual(set(board["asset_symbol"].astype(str)), {"SPY", "QQQ"})
         self.assertIn("QQQ", explanation_lookup)
         self.assertFalse(explanation_lookup["QQQ"]["feature_contributions"].empty)

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import unittest
+
+import pandas as pd
+
+from trump_workbench.modeling import ModelService
+
+
+class ModelFeatureSelectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.service = ModelService()
+        self.frame = pd.DataFrame(
+            {
+                "signal_session_date": pd.date_range("2025-02-03", periods=3),
+                "asset_symbol": ["SPY", "QQQ", "NVDA"],
+                "target_next_session_return": [0.01, -0.002, 0.005],
+                "post_count": [3, 4, 5],
+                "sentiment_avg": [0.2, -0.1, 0.4],
+                "session_return": [0.001, -0.002, 0.003],
+                "semantic_market_relevance_avg": [0.7, 0.3, 0.9],
+                "semantic_topic_trade": [1.0, 0.0, 1.0],
+                "policy_trade": [1.0, 0.0, 0.0],
+                "semantic_matched_post_count": [2, 0, 3],
+                "primary_match_post_count": [1, 0, 2],
+                "asset_relevance_score_avg": [0.8, 0.1, 0.6],
+                "asset_semantic_match_score_avg": [0.7, 0.0, 0.5],
+            },
+        )
+
+    def test_baseline_excludes_narrative_columns(self) -> None:
+        features = self.service.select_feature_columns(self.frame, llm_enabled=True, feature_mode="baseline")
+
+        self.assertIn("post_count", features)
+        self.assertIn("sentiment_avg", features)
+        self.assertNotIn("semantic_market_relevance_avg", features)
+        self.assertNotIn("semantic_topic_trade", features)
+        self.assertNotIn("policy_trade", features)
+        self.assertNotIn("semantic_matched_post_count", features)
+        self.assertNotIn("asset_semantic_match_score_avg", features)
+
+    def test_narrative_only_uses_narrative_columns(self) -> None:
+        features = self.service.select_feature_columns(self.frame, llm_enabled=True, feature_mode="narrative_only")
+
+        self.assertNotIn("post_count", features)
+        self.assertNotIn("sentiment_avg", features)
+        self.assertIn("semantic_market_relevance_avg", features)
+        self.assertIn("semantic_topic_trade", features)
+        self.assertIn("policy_trade", features)
+        self.assertIn("semantic_matched_post_count", features)
+        self.assertIn("asset_semantic_match_score_avg", features)
+
+    def test_hybrid_includes_baseline_and_narrative_columns(self) -> None:
+        features = self.service.select_feature_columns(self.frame, llm_enabled=True, feature_mode="hybrid")
+
+        self.assertIn("post_count", features)
+        self.assertIn("sentiment_avg", features)
+        self.assertIn("semantic_market_relevance_avg", features)
+        self.assertIn("policy_trade", features)
+
+    def test_missing_narrative_columns_degrade_safely(self) -> None:
+        baseline_frame = self.frame[["signal_session_date", "target_next_session_return", "post_count", "sentiment_avg"]].copy()
+
+        features = self.service.select_feature_columns(
+            baseline_frame,
+            llm_enabled=True,
+            feature_mode="narrative_only",
+        )
+
+        self.assertEqual(features, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -242,7 +242,7 @@ class PortfolioAllocatorIntegrationTests(unittest.TestCase):
                         "next_session_date": next_session_date,
                         "asset_symbol": asset_symbol,
                         "feature_version": "asset-v1",
-                        "llm_enabled": False,
+                        "llm_enabled": True,
                         "target_next_session_return": target_return if pd.notna(next_session_date) else np.nan,
                         "target_available": pd.notna(next_session_date),
                         "tradeable": pd.notna(next_session_date),
@@ -262,6 +262,16 @@ class PortfolioAllocatorIntegrationTests(unittest.TestCase):
                         "rolling_vol_5d": 0.01 + asset_offset * 0.001,
                         "close_vs_ma_5": score * 0.1,
                         "volume_z_5": 0.2 + asset_offset * 0.03,
+                        "semantic_market_relevance_avg": 0.8 if asset_symbol == strong_asset else 0.2,
+                        "semantic_urgency_avg": 0.7 if asset_symbol == strong_asset else 0.1,
+                        "semantic_topic_trade": 1.0 if asset_symbol == strong_asset else 0.0,
+                        "semantic_topic_markets": 1.0,
+                        "policy_trade": 1.0 if asset_symbol == strong_asset else 0.0,
+                        "policy_economy": 0.5,
+                        "semantic_matched_post_count": 3 if asset_symbol == strong_asset else 1,
+                        "primary_match_post_count": 2 if asset_symbol == strong_asset else 0,
+                        "asset_relevance_score_avg": 0.8 if asset_symbol == strong_asset else 0.2,
+                        "asset_semantic_match_score_avg": 0.75 if asset_symbol == strong_asset else 0.15,
                     },
                 )
         return pd.DataFrame(rows)
@@ -275,7 +285,7 @@ class PortfolioAllocatorIntegrationTests(unittest.TestCase):
             transaction_cost_bps=2.0,
             universe_symbols=("SPY", "QQQ", "NVDA"),
             selected_symbols=("SPY", "QQQ", "NVDA"),
-            llm_enabled=False,
+            llm_enabled=True,
             feature_version="asset-v1",
             train_window=24,
             validation_window=12,
@@ -283,9 +293,10 @@ class PortfolioAllocatorIntegrationTests(unittest.TestCase):
             step_size=12,
             threshold_grid=(0.0, 0.001),
             minimum_signal_grid=(1, 2),
-            account_weight_grid=(0.5, 1.0),
-            model_families=("ridge", "hist_gradient_boosting_regressor"),
+            account_weight_grid=(1.0,),
+            model_families=("ridge",),
             topology_variants=("per_asset", "pooled"),
+            narrative_feature_modes=("baseline", "narrative_only", "hybrid"),
         )
 
         with warnings.catch_warnings():
@@ -294,14 +305,31 @@ class PortfolioAllocatorIntegrationTests(unittest.TestCase):
 
         self.assertEqual(run.run_type, "portfolio_allocator")
         self.assertEqual(run.allocator_mode, "joint_model")
-        self.assertIn(run.deployment_variant, {"per_asset", "pooled"})
-        self.assertSetEqual(set(artifacts["variant_summary"]["variant_name"].astype(str)), {"per_asset", "pooled"})
+        expected_variants = {
+            "per_asset_baseline",
+            "per_asset_narrative_only",
+            "per_asset_hybrid",
+            "pooled_baseline",
+            "pooled_narrative_only",
+            "pooled_hybrid",
+        }
+        self.assertIn(run.deployment_variant, expected_variants)
+        self.assertSetEqual(set(artifacts["variant_summary"]["variant_name"].astype(str)), expected_variants)
+        self.assertSetEqual(set(artifacts["variant_summary"]["topology"].astype(str)), {"per_asset", "pooled"})
+        self.assertSetEqual(
+            set(artifacts["variant_summary"]["narrative_feature_mode"].astype(str)),
+            {"baseline", "narrative_only", "hybrid"},
+        )
         self.assertIn("deployment_winner", artifacts["variant_summary"].columns)
-        self.assertSetEqual(set(artifacts["candidate_predictions"]["variant_name"].astype(str)), {"per_asset", "pooled"})
-        self.assertSetEqual(set(artifacts["predictions"]["variant_name"].astype(str)), {"per_asset", "pooled"})
-        self.assertSetEqual(set(artifacts["trades"]["variant_name"].astype(str)), {"per_asset", "pooled"})
-        self.assertSetEqual(set(artifacts["benchmarks"]["variant_name"].astype(str)), {"per_asset", "pooled"})
+        self.assertSetEqual(set(artifacts["candidate_predictions"]["variant_name"].astype(str)), expected_variants)
+        self.assertSetEqual(set(artifacts["predictions"]["variant_name"].astype(str)), expected_variants)
+        self.assertSetEqual(set(artifacts["trades"]["variant_name"].astype(str)), expected_variants)
+        self.assertSetEqual(set(artifacts["benchmarks"]["variant_name"].astype(str)), expected_variants)
         self.assertIn(run.deployment_variant, artifacts["portfolio_model_bundle"]["variants"])
+        self.assertEqual(
+            artifacts["portfolio_model_bundle"]["variants"][run.deployment_variant]["narrative_feature_mode"],
+            run.selected_params["deployment_narrative_feature_mode"],
+        )
         self.assertEqual(
             artifacts["portfolio_model_bundle"]["deployment_variant"],
             run.deployment_variant,

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -15,7 +15,9 @@ from trump_workbench.ui import (
     _build_replay_comparison_frame,
     _bundle_feature_names,
     _build_feature_diff_table,
+    _build_feature_family_summary,
     _build_metric_comparison_table,
+    _build_narrative_lift_table,
     _build_setting_diff_table,
     _bundle_to_run_config,
     _eligible_replay_sessions,
@@ -23,6 +25,7 @@ from trump_workbench.ui import (
     _replay_option_label,
     _save_watchlist,
     _summarize_run_changes,
+    _variant_summary_with_narrative_defaults,
     _watchlist_symbols,
     _watchlist_text_value,
 )
@@ -272,6 +275,67 @@ class UiHelperTests(unittest.TestCase):
             _bundle_feature_names(bundle),
             ["asset_indicator__spy", "post_count", "sentiment_avg"],
         )
+
+    def test_narrative_variant_helpers_build_lift_and_family_summary(self) -> None:
+        variant_summary = pd.DataFrame(
+            {
+                "variant_name": ["per_asset_baseline", "per_asset_hybrid", "pooled_baseline"],
+                "topology": ["per_asset", "per_asset", "pooled"],
+                "narrative_feature_mode": ["baseline", "hybrid", "baseline"],
+                "validation_robust_score": [1.0, 1.25, 0.9],
+                "validation_total_return": [0.08, 0.1, 0.07],
+                "test_robust_score": [0.8, 0.95, 0.7],
+                "test_total_return": [0.06, 0.09, 0.05],
+            },
+        )
+        lift = _build_narrative_lift_table(variant_summary)
+
+        self.assertEqual(lift.iloc[0]["variant_name"], "per_asset_hybrid")
+        self.assertAlmostEqual(float(lift.iloc[0]["validation_robust_lift"]), 0.25)
+        self.assertAlmostEqual(float(lift.iloc[0]["test_return_lift"]), 0.03)
+
+        legacy_summary = _variant_summary_with_narrative_defaults(pd.DataFrame({"variant_name": ["per_asset"]}))
+        self.assertEqual(legacy_summary.iloc[0]["narrative_feature_mode"], "unspecified")
+
+        bundle = {
+            "run": {
+                "run_id": "portfolio-run",
+                "run_name": "portfolio-run",
+                "run_type": "portfolio_allocator",
+                "allocator_mode": "joint_model",
+                "target_asset": "PORTFOLIO",
+            },
+            "config": {},
+            "selected_params": {"deployment_variant": "per_asset_hybrid"},
+            "model_artifact": LinearModelArtifact(model_version="portfolio-placeholder", feature_names=[]),
+            "portfolio_model_bundle": {
+                "deployment_variant": "per_asset_hybrid",
+                "variants": {
+                    "per_asset_hybrid": {
+                        "models": {
+                            "SPY": {
+                                "feature_names": [
+                                    "post_count",
+                                    "sentiment_avg",
+                                    "semantic_market_relevance_avg",
+                                    "policy_trade",
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        importance = pd.DataFrame(
+            {
+                "variant_name": ["per_asset_hybrid", "per_asset_hybrid", "per_asset_hybrid"],
+                "feature_name": ["semantic_market_relevance_avg", "policy_trade", "post_count"],
+                "abs_coefficient": [0.5, 0.2, 0.1],
+            },
+        )
+        family_summary = _build_feature_family_summary(bundle, variant_name="per_asset_hybrid", importance=importance)
+        self.assertEqual(family_summary.iloc[0]["feature_family"], "semantic")
+        self.assertIn("policy", family_summary["feature_family"].tolist())
 
     def test_replay_helpers_build_session_list_config_and_summary(self) -> None:
         feature_rows = pd.DataFrame(

--- a/trump_workbench/backtesting.py
+++ b/trump_workbench/backtesting.py
@@ -11,9 +11,11 @@ import pandas as pd
 
 from .contracts import BacktestRun, ModelRunConfig, PortfolioRunConfig
 from .modeling import (
+    NARRATIVE_FEATURE_MODES,
     SUPPORTED_PORTFOLIO_MODEL_FAMILIES,
     ModelService,
     add_asset_indicator_columns,
+    normalize_narrative_feature_mode,
 )
 from .portfolio import build_portfolio_decision_history
 
@@ -476,6 +478,40 @@ def _flatten_metric_payload(prefix: str, metrics: dict[str, float]) -> dict[str,
     }
 
 
+def _resolve_narrative_feature_modes(run_config: PortfolioRunConfig) -> tuple[str, ...]:
+    requested = tuple(
+        normalize_narrative_feature_mode(value)
+        for value in (run_config.narrative_feature_modes or ())
+    )
+    if not requested:
+        requested = ("hybrid",) if run_config.llm_enabled else ("baseline",)
+    if not run_config.llm_enabled:
+        requested = tuple(value for value in requested if value == "baseline") or ("baseline",)
+    deduped: list[str] = []
+    for mode in requested:
+        if mode not in NARRATIVE_FEATURE_MODES or mode in deduped:
+            continue
+        deduped.append(mode)
+    return tuple(deduped or ("baseline",))
+
+
+def _joint_variant_name(topology: str, narrative_feature_mode: str) -> str:
+    return f"{topology}_{narrative_feature_mode}"
+
+
+def _is_skippable_joint_variant_error(exc: RuntimeError) -> bool:
+    message = str(exc)
+    return any(
+        fragment in message
+        for fragment in [
+            "No numeric feature columns",
+            "No trainable rows",
+            "No trainable asset rows",
+            "could not train any candidate models",
+        ]
+    )
+
+
 def build_joint_portfolio_leakage_audit(
     feature_rows: pd.DataFrame,
     candidate_predictions: pd.DataFrame,
@@ -871,6 +907,7 @@ class BacktestService:
         selected_symbols = tuple(window_plan["selected_symbols"])
         topology_variants = tuple(run_config.topology_variants or ("per_asset", "pooled"))
         model_families = tuple(run_config.model_families or SUPPORTED_PORTFOLIO_MODEL_FAMILIES)
+        narrative_feature_modes = _resolve_narrative_feature_modes(run_config)
 
         all_variant_predictions: list[pd.DataFrame] = []
         all_variant_decisions: list[pd.DataFrame] = []
@@ -885,27 +922,36 @@ class BacktestService:
         variant_test_metrics: dict[str, dict[str, float]] = {}
         variant_validation_metrics: dict[str, dict[str, float]] = {}
 
-        for variant_name in topology_variants:
-            variant_result = self._train_joint_variant(
-                run_config=run_config,
-                feature_rows=usable,
-                variant_name=variant_name,
-                model_families=model_families,
-                selected_symbols=selected_symbols,
-                windows=window_plan["windows"],
-            )
-            variant_bundles[variant_name] = variant_result["portfolio_model_bundle"]
-            variant_validation_metrics[variant_name] = variant_result["validation_metrics"]
-            variant_test_metrics[variant_name] = variant_result["test_metrics"]
-            all_variant_predictions.append(variant_result["candidate_predictions"])
-            all_variant_decisions.append(variant_result["decision_history"])
-            all_variant_trades.append(variant_result["trades"])
-            all_variant_benchmarks.append(variant_result["benchmarks"])
-            all_variant_curves.append(variant_result["benchmark_curves"])
-            all_variant_diagnostics.append(variant_result["diagnostics"])
-            all_variant_importance.append(variant_result["importance"])
-            all_window_rows.append(variant_result["window_summary"])
-            variant_summary_rows.append(variant_result["variant_summary"])
+        for topology in topology_variants:
+            for narrative_feature_mode in narrative_feature_modes:
+                variant_name = _joint_variant_name(str(topology), narrative_feature_mode)
+                try:
+                    variant_result = self._train_joint_variant(
+                        run_config=run_config,
+                        feature_rows=usable,
+                        variant_name=variant_name,
+                        topology=str(topology),
+                        narrative_feature_mode=narrative_feature_mode,
+                        model_families=model_families,
+                        selected_symbols=selected_symbols,
+                        windows=window_plan["windows"],
+                    )
+                except RuntimeError as exc:
+                    if not _is_skippable_joint_variant_error(exc):
+                        raise
+                    continue
+                variant_bundles[variant_name] = variant_result["portfolio_model_bundle"]
+                variant_validation_metrics[variant_name] = variant_result["validation_metrics"]
+                variant_test_metrics[variant_name] = variant_result["test_metrics"]
+                all_variant_predictions.append(variant_result["candidate_predictions"])
+                all_variant_decisions.append(variant_result["decision_history"])
+                all_variant_trades.append(variant_result["trades"])
+                all_variant_benchmarks.append(variant_result["benchmarks"])
+                all_variant_curves.append(variant_result["benchmark_curves"])
+                all_variant_diagnostics.append(variant_result["diagnostics"])
+                all_variant_importance.append(variant_result["importance"])
+                all_window_rows.append(variant_result["window_summary"])
+                variant_summary_rows.append(variant_result["variant_summary"])
 
         variant_summary = pd.DataFrame(variant_summary_rows).reset_index(drop=True)
         if variant_summary.empty:
@@ -939,6 +985,7 @@ class BacktestService:
         run_config_payload["selected_symbols"] = list(selected_symbols)
         run_config_payload["topology_variants"] = list(topology_variants)
         run_config_payload["model_families"] = list(model_families)
+        run_config_payload["narrative_feature_modes"] = list(narrative_feature_modes)
         run_config_payload["deployment_variant"] = deployment_variant
 
         chosen_summary = variant_summary.loc[variant_summary["variant_name"].astype(str) == deployment_variant].iloc[0]
@@ -966,6 +1013,8 @@ class BacktestService:
                 "transaction_cost_bps": float(run_config.transaction_cost_bps),
                 "selected_symbols": list(selected_symbols),
                 "deployment_variant": deployment_variant,
+                "deployment_topology": str(chosen_summary.get("topology", "")),
+                "deployment_narrative_feature_mode": str(chosen_summary.get("narrative_feature_mode", "")),
                 "deployment_model_family": str(chosen_summary.get("model_family", "")),
                 "deployment_threshold": float(chosen_summary.get("threshold", 0.0) or 0.0),
                 "deployment_min_post_count": int(chosen_summary.get("min_post_count", 1) or 1),
@@ -980,6 +1029,7 @@ class BacktestService:
             topology_variants=list(topology_variants),
             model_families=list(model_families),
             selected_symbols=list(selected_symbols),
+            narrative_feature_modes=list(narrative_feature_modes),
         )
 
         portfolio_model_bundle = {
@@ -988,6 +1038,7 @@ class BacktestService:
             "fallback_mode": run_config.fallback_mode,
             "feature_version": run_config.feature_version,
             "llm_enabled": bool(run_config.llm_enabled),
+            "narrative_feature_modes": list(narrative_feature_modes),
             "variants": variant_bundles,
         }
         placeholder_model_artifact = {
@@ -1004,6 +1055,8 @@ class BacktestService:
                 "allocator_mode": run.allocator_mode,
                 "target_asset": run.target_asset,
                 "deployment_variant": deployment_variant,
+                "deployment_topology": str(chosen_summary.get("topology", "")),
+                "deployment_narrative_feature_mode": str(chosen_summary.get("narrative_feature_mode", "")),
             },
         }
         artifacts = {
@@ -1189,6 +1242,8 @@ class BacktestService:
         run_config: PortfolioRunConfig,
         feature_rows: pd.DataFrame,
         variant_name: str,
+        topology: str,
+        narrative_feature_mode: str,
         model_families: tuple[str, ...],
         selected_symbols: tuple[str, ...],
         windows: list[dict[str, Any]],
@@ -1214,25 +1269,34 @@ class BacktestService:
                     weighted_validation = self._apply_account_weight(validation_rows, float(account_weight))
                     weighted_test = self._apply_account_weight(test_rows, float(account_weight))
 
-                    trained = self._fit_joint_variant_models(
-                        variant_name=variant_name,
-                        train_rows=weighted_train,
-                        model_family=model_family,
-                        llm_enabled=bool(run_config.llm_enabled),
-                        run_name=run_config.run_name,
-                        window_suffix=f"window-{window['window_id']}",
-                        selected_symbols=selected_symbols,
-                    )
+                    try:
+                        trained = self._fit_joint_variant_models(
+                            variant_name=variant_name,
+                            topology=topology,
+                            narrative_feature_mode=narrative_feature_mode,
+                            train_rows=weighted_train,
+                            model_family=model_family,
+                            llm_enabled=bool(run_config.llm_enabled),
+                            run_name=run_config.run_name,
+                            window_suffix=f"window-{window['window_id']}",
+                            selected_symbols=selected_symbols,
+                        )
+                    except RuntimeError as exc:
+                        if not _is_skippable_joint_variant_error(exc):
+                            raise
+                        continue
                     validation_prediction = self._predict_joint_variant_models(
                         trained_models=trained,
                         prediction_rows=weighted_validation,
                         variant_name=variant_name,
+                        topology=topology,
                         selected_symbols=selected_symbols,
                     )
                     test_prediction = self._predict_joint_variant_models(
                         trained_models=trained,
                         prediction_rows=weighted_test,
                         variant_name=variant_name,
+                        topology=topology,
                         selected_symbols=selected_symbols,
                     )
                     if validation_prediction.empty or test_prediction.empty:
@@ -1249,6 +1313,8 @@ class BacktestService:
                     window_rows.append(
                         {
                             "variant_name": variant_name,
+                            "topology": topology,
+                            "narrative_feature_mode": narrative_feature_mode,
                             "window_id": int(window["window_id"]),
                             "model_family": model_family,
                             "account_weight": float(account_weight),
@@ -1301,6 +1367,8 @@ class BacktestService:
                 candidate_rows.append(
                     {
                         "variant_name": variant_name,
+                        "topology": topology,
+                        "narrative_feature_mode": narrative_feature_mode,
                         "model_family": model_family,
                         "account_weight": float(account_weight),
                         "threshold": float(best_params["threshold"]),
@@ -1327,6 +1395,8 @@ class BacktestService:
         final_target_rows = final_rows.loc[final_rows["target_available"]].copy()
         final_models = self._fit_joint_variant_models(
             variant_name=variant_name,
+            topology=topology,
+            narrative_feature_mode=narrative_feature_mode,
             train_rows=final_target_rows,
             model_family=str(best_candidate["model_family"]),
             llm_enabled=bool(run_config.llm_enabled),
@@ -1338,6 +1408,7 @@ class BacktestService:
             trained_models=final_models,
             prediction_rows=final_rows,
             variant_name=variant_name,
+            topology=topology,
             selected_symbols=selected_symbols,
         )
         final_board = self._prepare_portfolio_prediction_board(
@@ -1360,6 +1431,8 @@ class BacktestService:
             transaction_cost_bps=float(run_config.transaction_cost_bps),
         )
         final_trades["variant_name"] = variant_name
+        final_trades["topology"] = topology
+        final_trades["narrative_feature_mode"] = narrative_feature_mode
         final_benchmarks, final_curves = build_portfolio_benchmark_suite(
             decision_history=final_decisions,
             candidate_predictions=final_board,
@@ -1368,22 +1441,36 @@ class BacktestService:
             transaction_cost_bps=float(run_config.transaction_cost_bps),
         )
         final_benchmarks["variant_name"] = variant_name
+        final_benchmarks["topology"] = topology
+        final_benchmarks["narrative_feature_mode"] = narrative_feature_mode
         final_diagnostics = build_portfolio_decision_diagnostics(final_decisions, final_board)
         final_diagnostics["variant_name"] = variant_name
+        final_diagnostics["topology"] = topology
+        final_diagnostics["narrative_feature_mode"] = narrative_feature_mode
         final_decisions["variant_name"] = variant_name
+        final_decisions["topology"] = topology
+        final_decisions["narrative_feature_mode"] = narrative_feature_mode
         final_board["variant_name"] = variant_name
+        final_board["topology"] = topology
+        final_board["narrative_feature_mode"] = narrative_feature_mode
         final_curves = final_curves.copy()
         if not final_curves.empty:
             final_curves["variant_name"] = variant_name
+            final_curves["topology"] = topology
+            final_curves["narrative_feature_mode"] = narrative_feature_mode
 
         final_importance = final_models.get("importance", pd.DataFrame()).copy()
         if not final_importance.empty:
             final_importance["variant_name"] = variant_name
+            final_importance["topology"] = topology
+            final_importance["narrative_feature_mode"] = narrative_feature_mode
         if importance_rows:
             final_importance = pd.concat([*importance_rows, final_importance], ignore_index=True)
 
         variant_summary = {
             "variant_name": variant_name,
+            "topology": topology,
+            "narrative_feature_mode": narrative_feature_mode,
             "model_family": str(best_candidate["model_family"]),
             "threshold": float(best_candidate["threshold"]),
             "min_post_count": int(best_candidate["min_post_count"]),
@@ -1394,7 +1481,8 @@ class BacktestService:
         }
         portfolio_model_bundle = {
             "variant_name": variant_name,
-            "topology": variant_name,
+            "topology": topology,
+            "narrative_feature_mode": narrative_feature_mode,
             "model_family": str(best_candidate["model_family"]),
             "threshold": float(best_candidate["threshold"]),
             "min_post_count": int(best_candidate["min_post_count"]),
@@ -1437,6 +1525,8 @@ class BacktestService:
         self,
         *,
         variant_name: str,
+        topology: str,
+        narrative_feature_mode: str,
         train_rows: pd.DataFrame,
         model_family: str,
         llm_enabled: bool,
@@ -1444,17 +1534,25 @@ class BacktestService:
         window_suffix: str,
         selected_symbols: tuple[str, ...],
     ) -> dict[str, Any]:
-        if variant_name == "pooled":
+        if topology == "pooled":
             pooled_train = add_asset_indicator_columns(train_rows, selected_symbols)
             artifact, importance = self.model_service.train_with_family(
                 pooled_train,
                 llm_enabled=llm_enabled,
                 model_family=model_family,
                 model_version=f"{run_name}-{variant_name}-{model_family}-{window_suffix}",
-                metadata={"variant_name": variant_name, "selected_symbols": list(selected_symbols)},
+                metadata={
+                    "variant_name": variant_name,
+                    "topology": topology,
+                    "narrative_feature_mode": narrative_feature_mode,
+                    "selected_symbols": list(selected_symbols),
+                },
+                feature_mode=narrative_feature_mode,
             )
             return {
                 "variant_name": variant_name,
+                "topology": topology,
+                "narrative_feature_mode": narrative_feature_mode,
                 "model_family": model_family,
                 "models": {
                     "pooled": artifact.to_dict(),
@@ -1473,7 +1571,13 @@ class BacktestService:
                 llm_enabled=llm_enabled,
                 model_family=model_family,
                 model_version=f"{run_name}-{variant_name}-{asset_symbol.lower()}-{model_family}-{window_suffix}",
-                metadata={"variant_name": variant_name, "asset_symbol": asset_symbol},
+                metadata={
+                    "variant_name": variant_name,
+                    "topology": topology,
+                    "narrative_feature_mode": narrative_feature_mode,
+                    "asset_symbol": asset_symbol,
+                },
+                feature_mode=narrative_feature_mode,
             )
             models[asset_symbol] = artifact.to_dict()
             if not importance.empty:
@@ -1484,6 +1588,8 @@ class BacktestService:
             raise RuntimeError(f"No trainable asset rows were available for `{variant_name}`.")
         return {
             "variant_name": variant_name,
+            "topology": topology,
+            "narrative_feature_mode": narrative_feature_mode,
             "model_family": model_family,
             "models": models,
             "importance": pd.concat(importance_frames, ignore_index=True) if importance_frames else pd.DataFrame(),
@@ -1495,13 +1601,14 @@ class BacktestService:
         trained_models: dict[str, Any],
         prediction_rows: pd.DataFrame,
         variant_name: str,
+        topology: str,
         selected_symbols: tuple[str, ...],
     ) -> pd.DataFrame:
         if prediction_rows.empty:
             return pd.DataFrame()
 
         rows: list[pd.DataFrame] = []
-        if variant_name == "pooled":
+        if topology == "pooled":
             artifact_payload = (trained_models.get("models", {}) or {}).get("pooled")
             if not artifact_payload:
                 return pd.DataFrame()

--- a/trump_workbench/contracts.py
+++ b/trump_workbench/contracts.py
@@ -223,6 +223,7 @@ class BacktestRun:
     topology_variants: list[str] = field(default_factory=list)
     model_families: list[str] = field(default_factory=list)
     selected_symbols: list[str] = field(default_factory=list)
+    narrative_feature_modes: list[str] = field(default_factory=list)
     artifact_paths: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -287,6 +288,7 @@ class PortfolioRunConfig:
     account_weight_grid: tuple[float, ...] = (0.5, 1.0, 1.5)
     model_families: tuple[str, ...] = ()
     topology_variants: tuple[str, ...] = ()
+    narrative_feature_modes: tuple[str, ...] = ()
     deployment_variant: str = ""
     notes: str = ""
 
@@ -300,6 +302,7 @@ class PortfolioRunConfig:
         payload["account_weight_grid"] = list(self.account_weight_grid)
         payload["model_families"] = list(self.model_families)
         payload["topology_variants"] = list(self.topology_variants)
+        payload["narrative_feature_modes"] = list(self.narrative_feature_modes)
         return payload
 
 

--- a/trump_workbench/experiments.py
+++ b/trump_workbench/experiments.py
@@ -115,6 +115,7 @@ class ExperimentStore:
         leakage_audit: dict[str, Any],
         variant_summary: pd.DataFrame | None = None,
         portfolio_model_bundle: dict[str, Any] | None = None,
+        importance: pd.DataFrame | None = None,
     ) -> SavedRunArtifacts:
         run_dir = self.store.artifact_path("runs", run.run_id)
         run_dir.mkdir(parents=True, exist_ok=True)
@@ -144,7 +145,7 @@ class ExperimentStore:
         trades.to_parquet(trades_path, index=False)
         decision_history.to_parquet(predictions_path, index=False)
         component_summary.to_parquet(windows_path, index=False)
-        pd.DataFrame().to_parquet(importance_path, index=False)
+        (importance if importance is not None else pd.DataFrame()).to_parquet(importance_path, index=False)
         candidate_predictions.to_parquet(candidate_predictions_path, index=False)
         benchmarks.to_parquet(benchmarks_path, index=False)
         diagnostics.to_parquet(diagnostics_path, index=False)

--- a/trump_workbench/live_monitor.py
+++ b/trump_workbench/live_monitor.py
@@ -13,11 +13,15 @@ LIVE_MONITOR_CONFIG_PATH = "live_monitor/config.json"
 LIVE_ASSET_SNAPSHOT_COLUMNS = [
     "generated_at",
     "variant_name",
+    "topology",
+    "narrative_feature_mode",
     *PORTFOLIO_CANDIDATE_COLUMNS,
 ]
 LIVE_DECISION_SNAPSHOT_COLUMNS = [
     "generated_at",
     "deployment_variant",
+    "topology",
+    "narrative_feature_mode",
     *PORTFOLIO_DECISION_COLUMNS,
 ]
 
@@ -255,6 +259,8 @@ def build_live_portfolio_run_state(
     if not variant_payload:
         return pd.DataFrame(columns=LIVE_ASSET_SNAPSHOT_COLUMNS), pd.DataFrame(columns=LIVE_DECISION_SNAPSHOT_COLUMNS), explanation_lookup, [f"Deployment variant `{deployment_variant}` is not available in the pinned portfolio run."]
 
+    topology = str(variant_payload.get("topology", "") or deployment_variant or "")
+    narrative_feature_mode = str(variant_payload.get("narrative_feature_mode", "") or "unspecified")
     selected_symbols = [str(symbol).upper() for symbol in (variant_payload.get("selected_symbols") or portfolio_bundle.get("selected_symbols") or [])]
     asset_session_features = store.read_frame("asset_session_features")
     asset_post_mappings = store.read_frame("asset_post_mappings")
@@ -303,6 +309,8 @@ def build_live_portfolio_run_state(
             {
                 "generated_at": snapshot_time,
                 "variant_name": deployment_variant,
+                "topology": topology,
+                "narrative_feature_mode": narrative_feature_mode,
                 "signal_session_date": row.get("signal_session_date"),
                 "next_session_date": row.get("next_session_date"),
                 "asset_symbol": asset_symbol,
@@ -339,6 +347,8 @@ def build_live_portfolio_run_state(
             "post_attribution": post_attribution,
             "account_attribution": account_attribution,
             "variant_name": deployment_variant,
+            "topology": topology,
+            "narrative_feature_mode": narrative_feature_mode,
         }
 
     snapshots = pd.DataFrame(snapshot_rows)
@@ -347,6 +357,8 @@ def build_live_portfolio_run_state(
 
     ranked_board, decision = rank_live_asset_snapshots(snapshots, config.fallback_mode)
     decision["deployment_variant"] = deployment_variant
+    decision["topology"] = topology
+    decision["narrative_feature_mode"] = narrative_feature_mode
     decision["portfolio_run_id"] = run_id
     decision["portfolio_run_name"] = run_name
     for asset_symbol, payload in explanation_lookup.items():

--- a/trump_workbench/modeling.py
+++ b/trump_workbench/modeling.py
@@ -17,6 +17,15 @@ SUPPORTED_PORTFOLIO_MODEL_FAMILIES = (
     "random_forest_regressor",
     "hist_gradient_boosting_regressor",
 )
+NARRATIVE_FEATURE_MODES = ("baseline", "narrative_only", "hybrid")
+NARRATIVE_FEATURE_NAMES = {
+    "semantic_matched_post_count",
+    "primary_match_post_count",
+    "asset_relevance_score_avg",
+    "asset_semantic_match_score_avg",
+    "semantic_market_relevance_avg",
+    "semantic_urgency_avg",
+}
 LINEAR_MODEL_FAMILIES = {"custom_linear", "ridge", "lasso", "elastic_net"}
 ASSET_INDICATOR_PREFIX = "asset_indicator__"
 
@@ -73,12 +82,12 @@ def _import_sklearn() -> dict[str, Any]:
 
 
 def classify_feature_family(feature_name: str) -> str:
+    if is_narrative_feature(feature_name):
+        if feature_name.startswith("policy_"):
+            return "policy"
+        return "semantic"
     if feature_name.startswith(ASSET_INDICATOR_PREFIX):
         return "asset_identity"
-    if feature_name.startswith("semantic_"):
-        return "semantic"
-    if feature_name.startswith("policy_"):
-        return "policy"
     if feature_name.startswith("prev_") or feature_name in {"session_return", "rolling_vol_5d", "close_vs_ma_5", "volume_z_5"}:
         return "market_context"
     if "sentiment" in feature_name:
@@ -90,6 +99,16 @@ def classify_feature_family(feature_name: str) -> str:
     if "post" in feature_name or "mention" in feature_name:
         return "activity"
     return "other"
+
+
+def normalize_narrative_feature_mode(feature_mode: str | None) -> str:
+    normalized = str(feature_mode or "hybrid").strip().lower().replace("-", "_")
+    return normalized if normalized in NARRATIVE_FEATURE_MODES else "hybrid"
+
+
+def is_narrative_feature(feature_name: str) -> bool:
+    name = str(feature_name)
+    return name.startswith("semantic_") or name.startswith("policy_") or name in NARRATIVE_FEATURE_NAMES
 
 
 def _feature_stats(X: pd.DataFrame) -> tuple[pd.Series, pd.Series]:
@@ -197,17 +216,24 @@ class ModelService:
         df: pd.DataFrame,
         llm_enabled: bool,
         extra_feature_columns: list[str] | None = None,
+        feature_mode: str | None = "hybrid",
     ) -> list[str]:
         numeric_columns = [
             column
             for column in df.columns
             if column not in META_COLUMNS and pd.api.types.is_numeric_dtype(df[column])
         ]
-        if not llm_enabled:
+        mode = normalize_narrative_feature_mode(feature_mode)
+        narrative_columns = {column for column in numeric_columns if is_narrative_feature(column)}
+        if mode == "baseline":
+            numeric_columns = [column for column in numeric_columns if column not in narrative_columns]
+        elif mode == "narrative_only":
+            numeric_columns = [column for column in numeric_columns if column in narrative_columns]
+        elif not llm_enabled:
             numeric_columns = [
                 column
                 for column in numeric_columns
-                if not column.startswith("semantic_") and not column.startswith("policy_")
+                if column not in narrative_columns
             ]
         if extra_feature_columns:
             for column in extra_feature_columns:
@@ -250,13 +276,18 @@ class ModelService:
         model_version: str,
         metadata: dict[str, Any],
         feature_columns: list[str] | None = None,
+        feature_mode: str | None = "hybrid",
         regularization: float = 1.0,
         compute_importance: bool = True,
     ) -> tuple[LinearModelArtifact, pd.DataFrame]:
         train_df = feature_rows.dropna(subset=["target_next_session_return"]).copy()
         if train_df.empty:
             raise RuntimeError("No trainable rows were available for the model.")
-        selected_columns = feature_columns or self.select_feature_columns(train_df, llm_enabled=llm_enabled)
+        selected_columns = feature_columns or self.select_feature_columns(
+            train_df,
+            llm_enabled=llm_enabled,
+            feature_mode=feature_mode,
+        )
         if not selected_columns:
             raise RuntimeError("No numeric feature columns were available for the model.")
 

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -41,6 +41,7 @@ from .ingestion import IngestionService, TruthSocialArchiveAdapter, XCsvAdapter
 from .market import MarketDataService, build_asset_universe, build_watchlist_frame, normalize_symbols
 from .modeling import (
     ASSET_INDICATOR_PREFIX,
+    NARRATIVE_FEATURE_MODES,
     ModelService,
     SUPPORTED_PORTFOLIO_MODEL_FAMILIES,
     add_asset_indicator_columns,
@@ -2020,6 +2021,15 @@ def _comparison_settings(run_bundle: dict[str, Any]) -> dict[str, Any]:
     selected = run_bundle.get("selected_params", {}) or {}
     artifact = run_bundle.get("model_artifact")
     run_meta = run_bundle.get("run", {}) or {}
+    portfolio_bundle = run_bundle.get("portfolio_model_bundle", {}) or {}
+    deployment_variant = str(
+        selected.get("deployment_variant")
+        or config.get("deployment_variant")
+        or run_meta.get("deployment_variant")
+        or portfolio_bundle.get("deployment_variant")
+        or "",
+    )
+    variant_payload = (portfolio_bundle.get("variants", {}) or {}).get(deployment_variant, {})
     return {
         "run_type": str(run_meta.get("run_type") or getattr(artifact, "metadata", {}).get("run_type", "asset_model")),
         "allocator_mode": str(
@@ -2053,13 +2063,25 @@ def _comparison_settings(run_bundle: dict[str, Any]) -> dict[str, Any]:
                 config.get("selected_symbols", run_meta.get("selected_symbols", [])),
             ),
         ),
-        "deployment_variant": str(
-            selected.get("deployment_variant")
-            or config.get("deployment_variant")
-            or run_meta.get("deployment_variant")
+        "deployment_variant": deployment_variant,
+        "deployment_topology": str(
+            selected.get("deployment_topology")
+            or variant_payload.get("topology")
+            or deployment_variant
             or "",
         ),
+        "deployment_narrative_feature_mode": str(
+            selected.get("deployment_narrative_feature_mode")
+            or variant_payload.get("narrative_feature_mode")
+            or "unspecified",
+        ),
         "topology_variants": tuple(config.get("topology_variants", run_meta.get("topology_variants", []))),
+        "narrative_feature_modes": tuple(
+            config.get(
+                "narrative_feature_modes",
+                run_meta.get("narrative_feature_modes", portfolio_bundle.get("narrative_feature_modes", [])),
+            ),
+        ),
         "model_families": tuple(config.get("model_families", run_meta.get("model_families", []))),
         "deploy_threshold": selected.get("threshold"),
         "deploy_min_post_count": selected.get("min_post_count"),
@@ -2105,6 +2127,7 @@ def _build_metric_comparison_table(base_run_id: str, run_bundles: dict[str, dict
                 "allocator_mode": _comparison_settings(bundle).get("allocator_mode", ""),
                 "target_asset": _comparison_settings(bundle).get("target_asset", "SPY"),
                 "deployment_variant": _comparison_settings(bundle).get("deployment_variant", ""),
+                "deployment_narrative_feature_mode": _comparison_settings(bundle).get("deployment_narrative_feature_mode", ""),
                 "total_return": metrics.get("total_return", 0.0),
                 "sharpe": metrics.get("sharpe", 0.0),
                 "sortino": metrics.get("sortino", 0.0),
@@ -2157,6 +2180,7 @@ def _build_feature_diff_table(base_run_id: str, run_bundles: dict[str, dict[str,
                 "run_name": bundle.get("run", {}).get("run_name", run_id),
                 "target_asset": _comparison_settings(bundle).get("target_asset", "SPY"),
                 "deployment_variant": _comparison_settings(bundle).get("deployment_variant", ""),
+                "deployment_narrative_feature_mode": _comparison_settings(bundle).get("deployment_narrative_feature_mode", ""),
                 "feature_count": len(feature_names),
                 "semantic_features": families.get("semantic", 0),
                 "policy_features": families.get("policy", 0),
@@ -2171,6 +2195,108 @@ def _build_feature_diff_table(base_run_id: str, run_bundles: dict[str, dict[str,
             },
         )
     return pd.DataFrame(rows).sort_values(["unique_vs_base_count", "feature_count"], ascending=[False, False]).reset_index(drop=True)
+
+
+def _variant_summary_with_narrative_defaults(variant_summary: pd.DataFrame) -> pd.DataFrame:
+    normalized = variant_summary.copy()
+    if normalized.empty:
+        return normalized
+    if "variant_name" not in normalized.columns:
+        normalized["variant_name"] = ""
+    if "topology" not in normalized.columns:
+        normalized["topology"] = normalized["variant_name"].astype(str)
+    if "narrative_feature_mode" not in normalized.columns:
+        normalized["narrative_feature_mode"] = "unspecified"
+    normalized["topology"] = normalized["topology"].replace("", pd.NA).fillna(normalized["variant_name"].astype(str))
+    normalized["narrative_feature_mode"] = normalized["narrative_feature_mode"].replace("", "unspecified").fillna("unspecified")
+    return normalized
+
+
+def _build_narrative_lift_table(variant_summary: pd.DataFrame) -> pd.DataFrame:
+    summary = _variant_summary_with_narrative_defaults(variant_summary)
+    if summary.empty or "baseline" not in set(summary["narrative_feature_mode"].astype(str)):
+        return pd.DataFrame()
+    rows: list[dict[str, Any]] = []
+    metric_pairs = [
+        ("validation_robust_score", "validation_robust_lift"),
+        ("validation_total_return", "validation_return_lift"),
+        ("test_robust_score", "test_robust_lift"),
+        ("test_total_return", "test_return_lift"),
+    ]
+    baseline_rows = summary.loc[summary["narrative_feature_mode"].astype(str) == "baseline"].copy()
+    for _, row in summary.iterrows():
+        mode = str(row.get("narrative_feature_mode", "unspecified") or "unspecified")
+        if mode in {"baseline", "unspecified"}:
+            continue
+        topology = str(row.get("topology", "") or "")
+        baseline = baseline_rows.loc[baseline_rows["topology"].astype(str) == topology]
+        if baseline.empty:
+            continue
+        baseline_row = baseline.iloc[0]
+        lift_row = {
+            "variant_name": row.get("variant_name", ""),
+            "topology": topology,
+            "narrative_feature_mode": mode,
+            "baseline_variant": baseline_row.get("variant_name", ""),
+        }
+        for metric_column, output_column in metric_pairs:
+            current_value = pd.to_numeric(pd.Series([row.get(metric_column)]), errors="coerce").iloc[0]
+            baseline_value = pd.to_numeric(pd.Series([baseline_row.get(metric_column)]), errors="coerce").iloc[0]
+            lift_row[output_column] = (
+                float(current_value - baseline_value)
+                if pd.notna(current_value) and pd.notna(baseline_value)
+                else np.nan
+            )
+        rows.append(lift_row)
+    return pd.DataFrame(rows).sort_values("validation_robust_lift", ascending=False).reset_index(drop=True) if rows else pd.DataFrame()
+
+
+def _build_feature_family_summary(
+    run_bundle: dict[str, Any],
+    variant_name: str | None = None,
+    importance: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    importance_frame = pd.DataFrame() if importance is None else importance.copy()
+    if not importance_frame.empty and "feature_name" in importance_frame.columns:
+        if variant_name and "variant_name" in importance_frame.columns:
+            filtered = importance_frame.loc[importance_frame["variant_name"].astype(str) == variant_name].copy()
+            if not filtered.empty:
+                importance_frame = filtered
+        feature_names = importance_frame["feature_name"].dropna().astype(str).tolist()
+        importance_frame["feature_family"] = importance_frame["feature_name"].astype(str).map(classify_feature_family)
+        value_column = "importance" if "importance" in importance_frame.columns else "abs_coefficient"
+        if value_column not in importance_frame.columns:
+            value_column = None
+        rows: list[dict[str, Any]] = []
+        for family, family_rows in importance_frame.groupby("feature_family", sort=True):
+            top_features = family_rows.copy()
+            if value_column is not None:
+                top_features[value_column] = pd.to_numeric(top_features[value_column], errors="coerce").fillna(0.0)
+                top_features = top_features.sort_values(value_column, ascending=False)
+            rows.append(
+                {
+                    "feature_family": family,
+                    "feature_count": int(family_rows["feature_name"].nunique()),
+                    "total_importance": float(pd.to_numeric(family_rows[value_column], errors="coerce").fillna(0.0).sum()) if value_column else np.nan,
+                    "top_features": ", ".join(top_features["feature_name"].dropna().astype(str).head(5).tolist()),
+                },
+            )
+        return pd.DataFrame(rows).sort_values(["total_importance", "feature_count"], ascending=[False, False]).reset_index(drop=True)
+
+    feature_names = _bundle_feature_names(run_bundle, variant_name=variant_name)
+    families = Counter(classify_feature_family(feature_name) for feature_name in feature_names)
+    rows = [
+        {
+            "feature_family": family,
+            "feature_count": int(count),
+            "total_importance": np.nan,
+            "top_features": ", ".join(
+                feature_name for feature_name in feature_names if classify_feature_family(feature_name) == family
+            ),
+        }
+        for family, count in families.items()
+    ]
+    return pd.DataFrame(rows).sort_values("feature_count", ascending=False).reset_index(drop=True) if rows else pd.DataFrame()
 
 
 def _build_benchmark_delta_table(base_run_id: str, run_bundles: dict[str, dict[str, Any]]) -> pd.DataFrame:
@@ -2243,6 +2369,12 @@ def _summarize_run_changes(base_run_id: str, run_bundles: dict[str, dict[str, An
             parts.append(f"account weight {base_settings.get('deploy_account_weight')} -> {settings.get('deploy_account_weight')}")
         if settings.get("deployment_variant") != base_settings.get("deployment_variant"):
             parts.append(f"deployment variant {base_settings.get('deployment_variant') or 'n/a'} -> {settings.get('deployment_variant') or 'n/a'}")
+        if settings.get("deployment_narrative_feature_mode") != base_settings.get("deployment_narrative_feature_mode"):
+            parts.append(
+                "narrative mode "
+                f"{base_settings.get('deployment_narrative_feature_mode') or 'n/a'} -> "
+                f"{settings.get('deployment_narrative_feature_mode') or 'n/a'}",
+            )
         unique_vs_base = sorted(features - base_features)
         omitted_vs_base = sorted(base_features - features)
         if unique_vs_base:
@@ -2575,6 +2707,21 @@ def render_models_view(
             feature_versions = sorted(asset_session_features.get("feature_version", pd.Series(["asset-v1"])).dropna().astype(str).unique().tolist()) or ["asset-v1"]
             joint_feature_version = st.selectbox("Feature version", options=feature_versions, index=0)
             joint_llm_enabled = st.checkbox("Use semantic enrichment rows", value="llm" in joint_feature_version.lower())
+            narrative_mode_labels = {
+                "baseline": "Baseline",
+                "narrative_only": "Narrative only",
+                "hybrid": "Hybrid",
+            }
+            default_narrative_modes = list(NARRATIVE_FEATURE_MODES) if joint_llm_enabled else ["baseline"]
+            joint_narrative_feature_modes = st.multiselect(
+                "Narrative feature modes",
+                options=list(NARRATIVE_FEATURE_MODES),
+                default=default_narrative_modes,
+                format_func=lambda mode: narrative_mode_labels.get(str(mode), str(mode)),
+                disabled=not joint_llm_enabled,
+            )
+            if not joint_llm_enabled:
+                joint_narrative_feature_modes = ["baseline"]
             window_cols = st.columns(4)
             joint_train_window = int(window_cols[0].number_input("Train window", min_value=20, max_value=252, value=90, step=5))
             joint_validation_window = int(window_cols[1].number_input("Validation window", min_value=10, max_value=126, value=30, step=5))
@@ -2608,6 +2755,9 @@ def render_models_view(
                 if not model_families:
                     st.error("Select at least one model family.")
                     return
+                if not joint_narrative_feature_modes:
+                    st.error("Select at least one narrative feature mode.")
+                    return
                 try:
                     portfolio_config = PortfolioRunConfig(
                         run_name=joint_run_name,
@@ -2627,6 +2777,7 @@ def render_models_view(
                         account_weight_grid=tuple(float(value) for value in _parse_grid(joint_account_weight_grid, float)),
                         model_families=tuple(str(value) for value in model_families),
                         topology_variants=tuple(str(value) for value in topology_variants),
+                        narrative_feature_modes=tuple(str(value) for value in joint_narrative_feature_modes),
                     )
                 except ValueError as exc:
                     st.error(f"Invalid grid input: {exc}")
@@ -2651,6 +2802,7 @@ def render_models_view(
                             leakage_audit=portfolio_artifacts["leakage_audit"],
                             variant_summary=portfolio_artifacts["variant_summary"],
                             portfolio_model_bundle=portfolio_artifacts["portfolio_model_bundle"],
+                            importance=portfolio_artifacts["importance"],
                         )
                     except RuntimeError as exc:
                         st.error(str(exc))
@@ -2823,7 +2975,7 @@ def render_models_view(
 
     if selected_run_type == "portfolio_allocator":
         selected_variant = str(selected_settings.get("deployment_variant", "") or "")
-        variant_summary = loaded.get("variant_summary", pd.DataFrame()).copy()
+        variant_summary = _variant_summary_with_narrative_defaults(loaded.get("variant_summary", pd.DataFrame()).copy())
         if not variant_summary.empty:
             st.markdown("**Variant comparison**")
             st.dataframe(variant_summary, use_container_width=True, hide_index=True)
@@ -2835,6 +2987,18 @@ def render_models_view(
                     index=variant_options.index(selected_variant) if selected_variant in variant_options else 0,
                     key=f"portfolio-variant-{selected_run_id}",
                 )
+            narrative_lift = _build_narrative_lift_table(variant_summary)
+            if not narrative_lift.empty:
+                st.markdown("**Narrative lift vs. matching baseline**")
+                st.dataframe(narrative_lift, use_container_width=True, hide_index=True)
+        family_summary = _build_feature_family_summary(
+            loaded,
+            variant_name=selected_variant,
+            importance=loaded.get("importance", pd.DataFrame()),
+        )
+        if not family_summary.empty:
+            st.markdown("**Feature-family impact for selected variant**")
+            st.dataframe(family_summary, use_container_width=True, hide_index=True)
         if not loaded["windows"].empty:
             allocator_windows = loaded["windows"].copy()
             if "variant_name" in allocator_windows.columns and selected_variant:
@@ -3073,8 +3237,10 @@ def render_live_monitor(
         selected_params = selected_row.get("selected_params_json", {}) or {}
         selected_symbols = selected_params.get("selected_symbols", [])
         deployment_variant = str(selected_params.get("deployment_variant", "") or "")
+        deployment_narrative_mode = str(selected_params.get("deployment_narrative_feature_mode", "") or "")
         st.caption(
             f"Deployment variant: `{deployment_variant or 'n/a'}` | "
+            f"narrative mode: `{deployment_narrative_mode or 'n/a'}` | "
             f"selected symbols: `{', '.join(selected_symbols) if selected_symbols else 'n/a'}`",
         )
         save_config = st.form_submit_button("Save pinned portfolio run", disabled=not can_write)
@@ -3168,7 +3334,7 @@ def render_live_monitor(
     tabs = st.tabs(["Current Decision", "Why This Asset Won", "History", "Paper Portfolio"])
 
     with tabs[0]:
-        metric_cols = st.columns(7)
+        metric_cols = st.columns(8)
         metric_cols[0].metric("Winning asset", display_asset)
         metric_cols[1].metric(
             "Signal session",
@@ -3179,6 +3345,7 @@ def render_live_monitor(
         metric_cols[4].metric("Winner score", f"{float(decision_row['winner_score']):+.3%}")
         metric_cols[5].metric("Winner confidence", f"{winner_confidence:.2f}")
         metric_cols[6].metric("Deployment variant", str(decision_row.get("deployment_variant", active_config.deployment_variant) or "n/a"))
+        metric_cols[7].metric("Narrative mode", str(decision_row.get("narrative_feature_mode", "") or "n/a"))
 
         st.json(
             {
@@ -3191,6 +3358,8 @@ def render_live_monitor(
         board_view = board.rename(
             columns={
                 "variant_name": "Variant",
+                "topology": "Topology",
+                "narrative_feature_mode": "Narrative mode",
                 "asset_symbol": "Asset",
                 "run_name": "Run",
                 "expected_return_score": "Score",
@@ -3210,6 +3379,8 @@ def render_live_monitor(
             board_view[
                 [
                     "Variant",
+                    "Topology",
+                    "Narrative mode",
                     "Asset",
                     "Run",
                     "Score",


### PR DESCRIPTION
## Summary
Closes #34.

Adds narrative signal ablation variants to joint portfolio modeling so a run can train and compare baseline, narrative-only, and hybrid feature sets across selected portfolio topologies.

## Changes
- Adds a narrative feature mode contract: `baseline`, `narrative_only`, and `hybrid`.
- Extends joint portfolio training to produce topology-by-narrative-mode variants with persisted `topology` and `narrative_feature_mode` metadata.
- Updates feature selection so baseline excludes narrative columns, narrative-only uses narrative-derived columns, and hybrid uses both.
- Surfaces narrative mode in Live Monitor snapshots/current decision without changing winner-selection logic.
- Adds Models & Backtests UI controls plus narrative lift and feature-family impact panels.
- Persists portfolio importance artifacts for feature-family inspection.

## Validation
- `bash scripts/ci.sh`
- 117 tests passed
- Coverage gate passed at 91%
- Streamlit smoke test passed on `127.0.0.1:8513`
