### PR TITLE
[codex] Add Trump-authored Research View filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ This is the descriptive analysis page.
 Use it to:
 
 - filter by date range, platform, keyword, and reshare behavior
+- restrict the view to posts authored by Donald Trump's account
 - see S&P 500 price history with post-session markers
 - inspect sentiment candlesticks built from mapped post sessions
 - review session-level and post-level tables
@@ -258,6 +259,7 @@ Important note:
 
 - The research page is for exploration, not proof of causality
 - Intraday drill-down depends on Alpha Vantage data and is optional
+- For a Truth Social-only review, set `Platforms` to `Truth Social` and enable `Trump-authored only`
 
 ## `Models & Backtests`
 

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -171,6 +171,7 @@ class ResearchTests(unittest.TestCase):
                 platforms=["X"],
                 keyword="Trump",
                 tracked_only=True,
+                trump_authored_only=False,
             ).empty,
         )
 
@@ -182,10 +183,25 @@ class ResearchTests(unittest.TestCase):
             platforms=["X"],
             keyword="tariff",
             tracked_only=True,
+            trump_authored_only=False,
         )
 
         self.assertEqual(len(filtered), 1)
         self.assertEqual(filtered.iloc[0]["author_handle"], "macroalpha")
+
+        trump_only = filter_posts(
+            self.posts,
+            pd.Timestamp("2025-02-03"),
+            pd.Timestamp("2025-02-04"),
+            include_reshares=True,
+            platforms=["Truth Social", "X"],
+            keyword="",
+            tracked_only=False,
+            trump_authored_only=True,
+        )
+
+        self.assertEqual(trump_only["author_handle"].tolist(), ["realDonaldTrump"])
+        self.assertTrue(trump_only["author_is_trump"].astype(bool).all())
 
     def test_research_aggregation_tables_and_charts(self) -> None:
         summary = _format_post_summary(self.posts.iloc[0])

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -203,6 +203,59 @@ class ResearchTests(unittest.TestCase):
         self.assertEqual(trump_only["author_handle"].tolist(), ["realDonaldTrump"])
         self.assertTrue(trump_only["author_is_trump"].astype(bool).all())
 
+    def test_trump_authored_filter_composes_with_other_filters(self) -> None:
+        x_only = filter_posts(
+            self.posts,
+            pd.Timestamp("2025-02-03"),
+            pd.Timestamp("2025-02-04"),
+            include_reshares=True,
+            platforms=["X"],
+            keyword="",
+            tracked_only=False,
+            trump_authored_only=True,
+        )
+        self.assertTrue(x_only.empty)
+
+        tracked_and_trump_only = filter_posts(
+            self.posts,
+            pd.Timestamp("2025-02-03"),
+            pd.Timestamp("2025-02-04"),
+            include_reshares=True,
+            platforms=["Truth Social", "X"],
+            keyword="",
+            tracked_only=True,
+            trump_authored_only=True,
+        )
+        self.assertEqual(tracked_and_trump_only["author_handle"].tolist(), ["realDonaldTrump"])
+
+        keyword_and_trump_only = filter_posts(
+            self.posts,
+            pd.Timestamp("2025-02-03"),
+            pd.Timestamp("2025-02-04"),
+            include_reshares=True,
+            platforms=["Truth Social", "X"],
+            keyword="growth",
+            tracked_only=False,
+            trump_authored_only=True,
+        )
+        self.assertEqual(keyword_and_trump_only["author_handle"].tolist(), ["realDonaldTrump"])
+
+    def test_trump_authored_filter_handles_missing_author_flag(self) -> None:
+        posts_without_author_flag = self.posts.drop(columns=["author_is_trump"])
+
+        filtered = filter_posts(
+            posts_without_author_flag,
+            pd.Timestamp("2025-02-03"),
+            pd.Timestamp("2025-02-04"),
+            include_reshares=True,
+            platforms=["Truth Social", "X"],
+            keyword="",
+            tracked_only=False,
+            trump_authored_only=True,
+        )
+
+        self.assertTrue(filtered.empty)
+
     def test_research_aggregation_tables_and_charts(self) -> None:
         summary = _format_post_summary(self.posts.iloc[0])
         self.assertIn("@realDonaldTrump", summary)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -30,6 +30,7 @@ from trump_workbench.ui import (
     _watchlist_symbols,
     _watchlist_text_value,
     render_models_view,
+    render_research_view,
 )
 
 
@@ -359,6 +360,13 @@ class UiHelperTests(unittest.TestCase):
 
         for widget_key in required_keys:
             self.assertIn(widget_key, source)
+
+    def test_research_view_exposes_trump_authored_filter(self) -> None:
+        source = inspect.getsource(render_research_view)
+
+        self.assertIn("Trump-authored only", source)
+        self.assertIn("research_trump_authored_only", source)
+        self.assertIn("trump_authored_only=trump_authored_only", source)
 
     def test_replay_helpers_build_session_list_config_and_summary(self) -> None:
         feature_rows = pd.DataFrame(

--- a/trump_workbench/research.py
+++ b/trump_workbench/research.py
@@ -32,6 +32,7 @@ def filter_posts(
     platforms: list[str],
     keyword: str,
     tracked_only: bool,
+    trump_authored_only: bool = False,
 ) -> pd.DataFrame:
     if posts.empty:
         return posts.copy()
@@ -50,6 +51,13 @@ def filter_posts(
             else pd.Series(False, index=filtered.index)
         )
         filtered = filtered.loc[filtered["author_is_trump"] | tracked_mask].copy()
+    if trump_authored_only:
+        trump_mask = (
+            filtered["author_is_trump"]
+            if "author_is_trump" in filtered.columns
+            else pd.Series(False, index=filtered.index)
+        )
+        filtered = filtered.loc[trump_mask.astype(bool)].copy()
     keyword = keyword.strip()
     if keyword:
         filtered = filtered.loc[

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -1197,7 +1197,7 @@ def render_research_view(
         return
 
     today_et = pd.Timestamp.now(tz=settings.timezone).normalize().tz_localize(None)
-    controls = st.columns(5)
+    controls = st.columns(6)
     date_range = controls[0].date_input(
         "Date range",
         value=(settings.term_start.date(), today_et.date()),
@@ -1211,7 +1211,13 @@ def render_research_view(
     )
     include_reshares = controls[2].checkbox("Include reshares", value=False)
     tracked_only = controls[3].checkbox("Tracked accounts only", value=False)
-    scale_markers = controls[4].checkbox("Scale markers", value=True)
+    trump_authored_only = controls[4].checkbox(
+        "Trump-authored only",
+        value=False,
+        help="Restrict research inputs to posts where the normalized author is Donald Trump's account.",
+        key="research_trump_authored_only",
+    )
+    scale_markers = controls[5].checkbox("Scale markers", value=True)
     keyword = st.text_input("Keyword filter", value="")
 
     if isinstance(date_range, tuple) and len(date_range) == 2:
@@ -1230,6 +1236,7 @@ def render_research_view(
         platforms=selected_platforms,
         keyword=keyword,
         tracked_only=tracked_only,
+        trump_authored_only=trump_authored_only,
     )
     mapped = feature_service.prepare_session_posts(
         posts=filtered_posts,


### PR DESCRIPTION
## Summary
Closes #38.

Adds an explicit `Trump-authored only` filter to Research View so local Truth Social-only users can restrict sentiment review to Donald Trump's own account without relying on platform inference.

## Changes
- Adds a `Trump-authored only` checkbox to Research View controls.
- Extends `filter_posts(...)` with `trump_authored_only` and applies it before mapped sessions, charts, tables, and Narrative Lab outputs are built.
- Adds regression coverage for filtering mixed Truth Social/X rows down to only `author_is_trump` rows.
- Updates README Research View guidance for Truth Social-only review.

## Validation
- `.venv/bin/python -m py_compile trump_workbench/research.py trump_workbench/ui.py tests/test_research.py`
- `.venv/bin/python -m unittest tests.test_research tests.test_ui`
- `bash scripts/ci.sh`
- 118 tests passed
- Coverage gate passed at 91%
- Streamlit smoke test passed on `127.0.0.1:8513`
