### PR TITLE
Add Truth Social-only guided UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In plain English, the app helps you:
 - [Hosting On Render](#hosting-on-render)
 - [Hosted Environment Variables](#hosted-environment-variables)
 - [Recommended First Run](#recommended-first-run)
+- [Trump Truth Social-Only Workflow](#trump-truth-social-only-workflow)
 - [How To Work With Each Page](#how-to-work-with-each-page)
   - [`Datasets`](#datasets)
 - [`Discovery`](#discovery)
@@ -200,11 +201,24 @@ If you are new to the app, follow this order:
 1. Open `Datasets`.
 2. Click `Refresh full datasets`.
 3. If you have X data, upload CSVs or point the app at a remote CSV URL.
-4. Open `Discovery` and review the tracked-account universe.
+4. Open `Discovery` and review the tracked-account universe if you loaded X/mention data.
 5. Open `Research View` to inspect mapped posts and market context.
 6. Open `Models & Backtests` and run a baseline walk-forward backtest.
 7. Save a joint portfolio run in `Models & Backtests`.
 8. Open `Live Monitor` to pin that run, inspect the live board, and optionally enable paper trading.
+
+## Trump Truth Social-Only Workflow
+
+Use this workflow when you want to review sentiment based only on Donald Trump's Truth Social posts.
+
+1. Open `Datasets`.
+2. Click `Refresh full datasets` or `Bootstrap datasets`.
+3. Open `Research View`.
+4. Confirm `Platforms` is set to `Truth Social`.
+5. Confirm `Trump-authored only` is enabled.
+6. Ignore `Discovery` unless you also want to load X/mention CSVs and rank non-Trump X accounts.
+
+When the stored dataset contains only Truth Social rows, the app auto-detects that mode and seeds the Research View controls to the Truth-only scope.
 
 ## How To Work With Each Page
 

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -271,6 +271,12 @@ class ResearchTests(unittest.TestCase):
         chart = build_combined_chart(events, scale_markers=True)
         self.assertGreaterEqual(len(chart.data), 2)
         self.assertEqual(chart.layout.title.text, "Research View: social activity vs. market baseline")
+        hover_templates = "\n".join(str(trace.hovertemplate or "") for trace in chart.data)
+        self.assertNotIn("%{text}", hover_templates)
+        self.assertNotIn("Sample posts", hover_templates)
+        self.assertNotIn("First post", hover_templates)
+        self.assertNotIn("Last post", hover_templates)
+        self.assertIn("7-session activity", hover_templates)
 
         session_table = make_session_table(events)
         self.assertIn("sp500_close", session_table.columns)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -25,10 +25,14 @@ from trump_workbench.ui import (
     _latest_ranking_snapshot,
     _replay_option_label,
     _save_watchlist,
+    _source_mode,
+    _source_mode_label,
     _summarize_run_changes,
     _variant_summary_with_narrative_defaults,
     _watchlist_symbols,
     _watchlist_text_value,
+    render_datasets_view,
+    render_discovery_view,
     render_models_view,
     render_research_view,
 )
@@ -176,6 +180,27 @@ class UiHelperTests(unittest.TestCase):
         self.assertEqual(len(snapshot), 2)
         self.assertEqual(snapshot.iloc[0]["author_account_id"], "acct-a")
         self.assertEqual(snapshot.iloc[0]["discovery_score"], 11.0)
+
+    def test_source_mode_detects_empty_truth_only_and_mixed_sources(self) -> None:
+        empty_mode = _source_mode(pd.DataFrame())
+        self.assertEqual(empty_mode["mode"], "unknown")
+        self.assertEqual(_source_mode_label(empty_mode), "No source data")
+
+        truth_only = _source_mode(pd.DataFrame({"source_platform": ["Truth Social", "Truth Social"]}))
+        self.assertEqual(truth_only["mode"], "truth_only")
+        self.assertTrue(truth_only["has_truth_posts"])
+        self.assertFalse(truth_only["has_x_posts"])
+        self.assertEqual(truth_only["truth_post_count"], 2)
+        self.assertEqual(truth_only["x_post_count"], 0)
+        self.assertEqual(_source_mode_label(truth_only), "Truth Social-only")
+
+        mixed = _source_mode(pd.DataFrame({"source_platform": ["Truth Social", "X", "X"]}))
+        self.assertEqual(mixed["mode"], "truth_plus_x")
+        self.assertTrue(mixed["has_truth_posts"])
+        self.assertTrue(mixed["has_x_posts"])
+        self.assertEqual(mixed["truth_post_count"], 1)
+        self.assertEqual(mixed["x_post_count"], 2)
+        self.assertEqual(_source_mode_label(mixed), "Truth Social + X mentions")
 
     def test_watchlist_helpers_save_symbols_and_build_text(self) -> None:
         watchlist, asset_universe = _save_watchlist(self.store, [" msft ", "spy", "nvda", "NVDA"])
@@ -367,6 +392,27 @@ class UiHelperTests(unittest.TestCase):
         self.assertIn("Trump-authored only", source)
         self.assertIn("research_trump_authored_only", source)
         self.assertIn("trump_authored_only=trump_authored_only", source)
+
+    def test_research_view_seeds_truth_only_defaults(self) -> None:
+        source = inspect.getsource(render_research_view)
+
+        self.assertIn("research_source_mode_seeded", source)
+        self.assertIn("research_platforms", source)
+        self.assertIn("Truth Social-only mode detected", source)
+        self.assertIn('source_mode_name == "truth_only"', source)
+
+    def test_datasets_view_exposes_operating_mode(self) -> None:
+        source = inspect.getsource(render_datasets_view)
+
+        self.assertIn("Operating mode", source)
+        self.assertIn("_source_mode_label(source_mode)", source)
+
+    def test_discovery_view_explains_truth_only_empty_state(self) -> None:
+        source = inspect.getsource(render_discovery_view)
+
+        self.assertIn("This dataset is currently Truth Social-only", source)
+        self.assertIn("Discovery ranks non-Trump X accounts that mention Trump", source)
+        self.assertIn("Load X/mention CSVs", source)
 
     def test_replay_helpers_build_session_list_config_and_summary(self) -> None:
         feature_rows = pd.DataFrame(

--- a/trump_workbench/research.py
+++ b/trump_workbench/research.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-import html
 from typing import Any
 
 import numpy as np
@@ -662,17 +660,15 @@ def build_combined_chart(events: pd.DataFrame, scale_markers: bool) -> go.Figure
             else activity_events["has_posts"].astype(int).astype(float)
         )
         activity_events["activity_signal"] = raw_activity.rolling(7, min_periods=1).mean()
-        activity_events["hover_text"] = activity_events.apply(
-            lambda row: (
-                f"<b>{pd.Timestamp(row['trade_date']):%Y-%m-%d}</b><br>"
-                f"Posts mapped to session: {int(row['post_count'])}<br>"
-                f"Truth Social: {int(row['truth_posts'])} | X: {int(row['x_posts'])}<br>"
-                f"Tracked accounts: {int(row.get('tracked_account_posts', 0))}<br>"
-                f"Avg sentiment: {fmt_score(row.get('sentiment_avg', np.nan))}<br>"
-                f"Smoothed activity: {float(row['activity_signal']):.1f}<br>"
-                f"Sample posts: {html.escape(str(row.get('sample_posts', '')))}"
-            ),
-            axis=1,
+        activity_customdata = np.stack(
+            [
+                activity_events["post_count"].astype(float).to_numpy(),
+                activity_events["truth_posts"].astype(float).to_numpy(),
+                activity_events["x_posts"].astype(float).to_numpy(),
+                activity_events.get("tracked_account_posts", pd.Series(0, index=activity_events.index)).astype(float).to_numpy(),
+                activity_events["sentiment_avg"].astype(float).to_numpy(),
+            ],
+            axis=-1,
         )
         fig.add_trace(
             go.Scatter(
@@ -683,8 +679,15 @@ def build_combined_chart(events: pd.DataFrame, scale_markers: bool) -> go.Figure
                 line={"color": "rgba(59, 130, 246, 0.8)", "width": 1.4},
                 fill="tozeroy",
                 fillcolor="rgba(37, 99, 235, 0.14)",
-                text=activity_events["hover_text"],
-                hovertemplate="%{text}<extra></extra>",
+                customdata=activity_customdata,
+                hovertemplate=(
+                    "<b>%{x|%Y-%m-%d}</b><br>"
+                    "Posts: %{customdata[0]:.0f}<br>"
+                    "Truth: %{customdata[1]:.0f} | X: %{customdata[2]:.0f}<br>"
+                    "Tracked: %{customdata[3]:.0f}<br>"
+                    "Avg sentiment: %{customdata[4]:+.3f}<br>"
+                    "7-session activity: %{y:.1f}<extra></extra>"
+                ),
             ),
             row=1,
             col=1,
@@ -698,19 +701,15 @@ def build_combined_chart(events: pd.DataFrame, scale_markers: bool) -> go.Figure
             "#86efac",
             "#fda4af",
         )
-        sentiment_events["hover_text"] = sentiment_events.apply(
-            lambda row: (
-                f"<b>{pd.Timestamp(row['trade_date']):%Y-%m-%d}</b><br>"
-                f"Posts mapped: {int(row['post_count'])}<br>"
-                f"Open: {fmt_score(row['sentiment_open'])}<br>"
-                f"High: {fmt_score(row['sentiment_high'])}<br>"
-                f"Low: {fmt_score(row['sentiment_low'])}<br>"
-                f"Close: {fmt_score(row['sentiment_close'])}<br>"
-                f"Average: {fmt_score(row['sentiment_avg'])}<br>"
-                f"First post: {html.escape(str(row.get('first_post_summary', '')))}<br>"
-                f"Last post: {html.escape(str(row.get('last_post_summary', '')))}"
-            ),
-            axis=1,
+        sentiment_customdata = np.stack(
+            [
+                sentiment_events["post_count"].astype(float).to_numpy(),
+                sentiment_events["sentiment_open"].astype(float).to_numpy(),
+                sentiment_events["sentiment_high"].astype(float).to_numpy(),
+                sentiment_events["sentiment_low"].astype(float).to_numpy(),
+                sentiment_events["sentiment_close"].astype(float).to_numpy(),
+            ],
+            axis=-1,
         )
         fig.add_trace(
             go.Scatter(
@@ -733,8 +732,7 @@ def build_combined_chart(events: pd.DataFrame, scale_markers: bool) -> go.Figure
                 line={"color": "rgba(148, 163, 184, 0.2)", "width": 1},
                 fill="tonexty",
                 fillcolor="rgba(148, 163, 184, 0.18)",
-                text=sentiment_events["hover_text"],
-                hovertemplate="%{text}<extra></extra>",
+                hoverinfo="skip",
             ),
             row=2,
             col=1,
@@ -751,8 +749,16 @@ def build_combined_chart(events: pd.DataFrame, scale_markers: bool) -> go.Figure
                     "color": sentiment_events["marker_color"],
                     "line": {"color": "rgba(15, 23, 42, 0.8)", "width": 0.6},
                 },
-                text=sentiment_events["hover_text"],
-                hovertemplate="%{text}<extra></extra>",
+                customdata=sentiment_customdata,
+                hovertemplate=(
+                    "<b>%{x|%Y-%m-%d}</b><br>"
+                    "Posts: %{customdata[0]:.0f}<br>"
+                    "Open: %{customdata[1]:+.3f}<br>"
+                    "High: %{customdata[2]:+.3f}<br>"
+                    "Low: %{customdata[3]:+.3f}<br>"
+                    "Close: %{customdata[4]:+.3f}<br>"
+                    "Average: %{y:+.3f}<extra></extra>"
+                ),
             ),
             row=2,
             col=1,

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -124,6 +124,40 @@ def _refresh_required_message(settings: AppSettings, base_message: str) -> str:
     return base_message
 
 
+def _source_mode(posts: pd.DataFrame) -> dict[str, Any]:
+    if posts.empty or "source_platform" not in posts.columns:
+        return {
+            "mode": "unknown",
+            "has_truth_posts": False,
+            "has_x_posts": False,
+            "truth_post_count": 0,
+            "x_post_count": 0,
+        }
+
+    platforms = posts["source_platform"].fillna("").astype(str)
+    truth_post_count = int((platforms == "Truth Social").sum())
+    x_post_count = int((platforms == "X").sum())
+    has_truth_posts = truth_post_count > 0
+    has_x_posts = x_post_count > 0
+    mode = "truth_plus_x" if has_x_posts else "truth_only" if has_truth_posts else "unknown"
+    return {
+        "mode": mode,
+        "has_truth_posts": has_truth_posts,
+        "has_x_posts": has_x_posts,
+        "truth_post_count": truth_post_count,
+        "x_post_count": x_post_count,
+    }
+
+
+def _source_mode_label(source_mode: dict[str, Any]) -> str:
+    mode = str(source_mode.get("mode", "unknown"))
+    if mode == "truth_only":
+        return "Truth Social-only"
+    if mode == "truth_plus_x":
+        return "Truth Social + X mentions"
+    return "No source data"
+
+
 def _render_sidebar_access_panel(settings: AppSettings) -> None:
     st.sidebar.markdown("---")
     st.sidebar.markdown("**Access**")
@@ -737,6 +771,8 @@ def render_datasets_view(
     st.caption("Refresh historical sources, store normalized datasets, and inspect the local DuckDB + Parquet catalog.")
     can_write = _writes_enabled(settings)
     missing_datasets = missing_core_datasets(store)
+    posts = store.read_frame("normalized_posts")
+    source_mode = _source_mode(posts)
     if is_public_mode(settings) and not can_write:
         st.info("This hosted deployment is in public read-only mode. Unlock admin access in the sidebar to refresh data, edit the watchlist, or change live configuration.")
 
@@ -747,16 +783,17 @@ def render_datasets_view(
     summary = health_state["summary"]
 
     st.markdown("**Hosted Operations**")
-    ops_cols = st.columns(5)
-    ops_cols[0].metric("App mode", _app_mode_label(settings).replace("_", " ").title())
-    ops_cols[1].metric("Scheduler", "Enabled" if settings.scheduler_enabled else "Disabled")
-    ops_cols[2].metric("Last refresh mode", str(summary.get("last_refresh_mode", "n/a")).upper())
+    ops_cols = st.columns(6)
+    ops_cols[0].metric("Operating mode", _source_mode_label(source_mode))
+    ops_cols[1].metric("App mode", _app_mode_label(settings).replace("_", " ").title())
+    ops_cols[2].metric("Scheduler", "Enabled" if settings.scheduler_enabled else "Disabled")
+    ops_cols[3].metric("Last refresh mode", str(summary.get("last_refresh_mode", "n/a")).upper())
     last_refresh_at = summary.get("last_refresh_at", pd.NaT)
-    ops_cols[3].metric(
+    ops_cols[4].metric(
         "Last refresh at",
         pd.Timestamp(last_refresh_at).tz_convert(EASTERN).strftime("%Y-%m-%d %H:%M") if pd.notna(last_refresh_at) else "n/a",
     )
-    ops_cols[4].metric("Missing core datasets", f"{len(missing_datasets):,}")
+    ops_cols[5].metric("Missing core datasets", f"{len(missing_datasets):,}")
     st.caption(f"State root: `{settings.state_root}` | DuckDB: `{settings.db_path}`")
 
     if missing_datasets:
@@ -1002,7 +1039,6 @@ def render_datasets_view(
         ]
         st.dataframe(asset_session_features[keep].tail(20), use_container_width=True, hide_index=True)
 
-    posts = store.read_frame("normalized_posts")
     if not posts.empty:
         st.markdown("**Normalized Post Sample**")
         sample_columns = [
@@ -1031,6 +1067,7 @@ def render_discovery_view(
     tracked_accounts = store.read_frame("tracked_accounts")
     ranking_history = store.read_frame("account_rankings")
     overrides = discovery_service.normalize_manual_overrides(store.read_frame("manual_account_overrides"))
+    source_mode = _source_mode(posts)
 
     if posts.empty:
         st.info(_refresh_required_message(settings, "Refresh datasets first so the workbench has posts to analyze."))
@@ -1138,6 +1175,12 @@ def render_discovery_view(
             _rebuild_discovery_state(store, discovery_service, posts, posts["post_timestamp"].max())
             st.success(f"Saved {action} override for @{selected_row['author_handle']}.")
             st.rerun()
+    elif source_mode["mode"] == "truth_only":
+        st.info(
+            "This dataset is currently Truth Social-only. Discovery ranks non-Trump X accounts that mention Trump, "
+            "so it is optional for reviewing sentiment based only on Donald Trump's Truth Social posts. "
+            "Load X/mention CSVs in `Datasets` if you want to populate account discovery.",
+        )
     else:
         st.info("No discovery ranking snapshot is available yet. Add or refresh X mention data to populate this view.")
 
@@ -1192,6 +1235,7 @@ def render_research_view(
     asset_post_mappings = store.read_frame("asset_post_mappings")
     asset_session_features = store.read_frame("asset_session_features")
     tracked_accounts = store.read_frame("tracked_accounts")
+    source_mode = _source_mode(posts)
     if posts.empty or sp500.empty:
         st.info(_refresh_required_message(settings, "Refresh datasets first so the research view has source data."))
         return
@@ -1204,21 +1248,39 @@ def render_research_view(
         min_value=settings.term_start.date(),
         max_value=today_et.date(),
     )
+    source_mode_name = str(source_mode["mode"])
+    if st.session_state.get("research_source_mode_seeded") != source_mode_name:
+        st.session_state["research_platforms"] = ["Truth Social"] if source_mode_name == "truth_only" else ["Truth Social", "X"]
+        st.session_state["research_trump_authored_only"] = source_mode_name == "truth_only"
+        st.session_state["research_source_mode_seeded"] = source_mode_name
     selected_platforms = controls[1].multiselect(
         "Platforms",
         options=["Truth Social", "X"],
-        default=["Truth Social", "X"],
+        key="research_platforms",
     )
     include_reshares = controls[2].checkbox("Include reshares", value=False)
     tracked_only = controls[3].checkbox("Tracked accounts only", value=False)
     trump_authored_only = controls[4].checkbox(
         "Trump-authored only",
-        value=False,
         help="Restrict research inputs to posts where the normalized author is Donald Trump's account.",
         key="research_trump_authored_only",
     )
     scale_markers = controls[5].checkbox("Scale markers", value=True)
     keyword = st.text_input("Keyword filter", value="")
+
+    if source_mode["mode"] == "truth_only":
+        if selected_platforms == ["Truth Social"] and trump_authored_only:
+            st.info(
+                f"Truth Social-only mode detected: the current analysis is scoped to Donald Trump's Truth Social posts "
+                f"from {int(source_mode['truth_post_count']):,} stored Truth Social rows. Use `Platforms` and "
+                "`Trump-authored only` above to verify or change the research scope.",
+            )
+        else:
+            st.info(
+                f"Truth Social-only mode detected with {int(source_mode['truth_post_count']):,} stored Truth Social rows. "
+                "The default scope is `Platforms = Truth Social` and `Trump-authored only`; adjust the controls above "
+                "if you intentionally want a broader or different view.",
+            )
 
     if isinstance(date_range, tuple) and len(date_range) == 2:
         start_date = pd.Timestamp(date_range[0])


### PR DESCRIPTION
## Summary
- auto-detect Truth Social-only datasets and surface that operating mode in Datasets
- seed Research View defaults to Truth Social + Trump-authored only for Truth-only datasets without repeatedly overriding user changes
- clarify Discovery empty state and README instructions for Trump Truth Social-only review

## Tests
- .venv/bin/python -m unittest tests.test_ui
- bash scripts/ci.sh