### PR TITLE
Add Research Export Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Use it to:
 - see S&P 500 price history with post-session markers
 - inspect sentiment candlesticks built from mapped post sessions
 - review session-level and post-level tables
+- download a ZIP research pack for the current filters
 - drill into an intraday SPY reaction window for a selected post
 
 Important note:

--- a/tests/test_research_exports.py
+++ b/tests/test_research_exports.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+import zipfile
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from trump_workbench.research_exports import (
+    EXPORT_TABLE_COLUMNS,
+    build_research_export_bundle,
+    build_research_export_manifest,
+    research_export_filename,
+)
+
+
+class ResearchExportTests(unittest.TestCase):
+    def test_research_export_bundle_contains_manifest_chart_summary_and_csvs(self) -> None:
+        manifest = build_research_export_manifest(
+            filters={
+                "date_start": "2025-02-03",
+                "date_end": "2025-02-05",
+                "platforms": ["Truth Social"],
+                "keyword": "",
+                "include_reshares": False,
+                "tracked_only": False,
+                "trump_authored_only": True,
+            },
+            source_mode={
+                "mode": "truth_only",
+                "has_truth_posts": True,
+                "has_x_posts": False,
+                "truth_post_count": 2,
+                "x_post_count": 0,
+            },
+            headline_metrics={
+                "sessions_with_posts": 1,
+                "posts_in_view": 1,
+                "truth_posts": 1,
+                "tracked_x_posts": 0,
+                "mean_sentiment": 0.8,
+                "sp500_change": 0.02,
+            },
+            generated_at=pd.Timestamp("2026-04-19 12:00:00", tz="UTC"),
+        )
+        chart = go.Figure()
+        chart.update_layout(title="Research View: social activity vs. market baseline")
+        sessions = pd.DataFrame(
+            {
+                "trade_date": [pd.Timestamp("2025-02-03").date()],
+                "post_count": [1],
+                "sp500_close": [100.0],
+                "sentiment_avg": [0.8],
+            },
+        )
+        posts = pd.DataFrame(
+            {
+                "source_platform": ["Truth Social"],
+                "author_handle": ["realDonaldTrump"],
+                "post_time_et": ["2025-02-03 08:00"],
+                "session_date": [pd.Timestamp("2025-02-03").date()],
+                "sentiment_score": [0.8],
+                "post_text": ["Great growth"],
+            },
+        )
+
+        bundle = build_research_export_bundle(
+            manifest=manifest,
+            chart=chart,
+            sessions=sessions,
+            posts=posts,
+            narrative_frequency=pd.DataFrame(),
+            narrative_returns=pd.DataFrame(),
+            narrative_asset_heatmap=pd.DataFrame(),
+            narrative_posts=pd.DataFrame(),
+            narrative_events=pd.DataFrame(),
+        )
+
+        with zipfile.ZipFile(io.BytesIO(bundle)) as archive:
+            self.assertEqual(
+                set(archive.namelist()),
+                {
+                    "manifest.json",
+                    "summary.md",
+                    "social_activity_chart.html",
+                    "sessions.csv",
+                    "posts.csv",
+                    "narrative_frequency.csv",
+                    "narrative_returns.csv",
+                    "narrative_asset_heatmap.csv",
+                    "narrative_posts.csv",
+                    "narrative_events.csv",
+                },
+            )
+            manifest_payload = json.loads(archive.read("manifest.json"))
+            self.assertEqual(manifest_payload["schema_version"], "research-export-v1")
+            self.assertTrue(manifest_payload["filters"]["trump_authored_only"])
+            self.assertEqual(manifest_payload["filters"]["platforms"], ["Truth Social"])
+            self.assertEqual(manifest_payload["source_mode"]["mode"], "truth_only")
+            self.assertEqual(manifest_payload["headline_metrics"]["posts_in_view"], 1)
+            self.assertEqual(manifest_payload["files"]["sessions.csv"]["rows"], 1)
+            self.assertEqual(
+                manifest_payload["files"]["narrative_frequency.csv"]["columns"],
+                EXPORT_TABLE_COLUMNS["narrative_frequency.csv"],
+            )
+
+            chart_html = archive.read("social_activity_chart.html").decode("utf-8")
+            self.assertIn("Research View: social activity vs. market baseline", chart_html)
+            summary = archive.read("summary.md").decode("utf-8")
+            self.assertIn("Trump-authored only: True", summary)
+
+            session_rows = pd.read_csv(io.BytesIO(archive.read("sessions.csv")))
+            self.assertEqual(session_rows.iloc[0]["post_count"], 1)
+            self.assertIn("sp500_close", session_rows.columns)
+            narrative_frequency = pd.read_csv(io.BytesIO(archive.read("narrative_frequency.csv")))
+            self.assertEqual(narrative_frequency.columns.tolist(), EXPORT_TABLE_COLUMNS["narrative_frequency.csv"])
+
+    def test_research_export_filename_uses_date_range(self) -> None:
+        self.assertEqual(
+            research_export_filename(pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-05")),
+            "research-pack-20250203-20250205.zip",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -401,6 +401,15 @@ class UiHelperTests(unittest.TestCase):
         self.assertIn("Truth Social-only mode detected", source)
         self.assertIn('source_mode_name == "truth_only"', source)
 
+    def test_research_view_exposes_export_download_for_filtered_slice(self) -> None:
+        source = inspect.getsource(render_research_view)
+
+        self.assertIn("Export current research pack", source)
+        self.assertIn("st.download_button", source)
+        self.assertIn("build_research_export_bundle", source)
+        self.assertIn("sessions=session_table", source)
+        self.assertIn("posts=post_table", source)
+
     def test_datasets_view_exposes_operating_mode(self) -> None:
         source = inspect.getsource(render_datasets_view)
 

--- a/trump_workbench/research_exports.py
+++ b/trump_workbench/research_exports.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import datetime as dt
+import io
+import json
+from collections.abc import Mapping
+from typing import Any
+import zipfile
+
+import pandas as pd
+import plotly.graph_objects as go
+
+EXPORT_SCHEMA_VERSION = "research-export-v1"
+
+EXPORT_TABLE_COLUMNS: dict[str, list[str]] = {
+    "sessions.csv": [
+        "trade_date",
+        "post_count",
+        "truth_posts",
+        "x_posts",
+        "tracked_account_posts",
+        "positive_posts",
+        "neutral_posts",
+        "negative_posts",
+        "sp500_close",
+        "session_return",
+        "next_session_return",
+        "sentiment_open",
+        "sentiment_high",
+        "sentiment_low",
+        "sentiment_close",
+        "sentiment_avg",
+        "sentiment_range",
+        "sample_posts",
+    ],
+    "posts.csv": [
+        "source_platform",
+        "author_handle",
+        "author_display_name",
+        "post_time_et",
+        "session_date",
+        "mapping_reason",
+        "mentions_trump",
+        "is_active_tracked_account",
+        "sentiment_score",
+        "sentiment_label",
+        "post_text",
+        "post_url",
+    ],
+    "narrative_frequency.csv": [
+        "session_date",
+        "semantic_topic",
+        "post_count",
+        "avg_market_relevance",
+        "avg_urgency",
+    ],
+    "narrative_returns.csv": [
+        "semantic_topic",
+        "avg_next_session_return",
+        "median_next_session_return",
+        "session_count",
+        "total_posts",
+        "avg_market_relevance",
+        "bucket_field",
+    ],
+    "narrative_asset_heatmap.csv": [
+        "semantic_topic",
+        "asset_symbol",
+        "post_count",
+        "avg_asset_relevance",
+        "avg_market_relevance",
+    ],
+    "narrative_posts.csv": [
+        "session_date",
+        "post_time_et",
+        "source_platform",
+        "author_handle",
+        "semantic_topic",
+        "semantic_policy_bucket",
+        "semantic_stance",
+        "semantic_primary_asset",
+        "semantic_asset_targets",
+        "semantic_market_relevance",
+        "semantic_urgency",
+        "urgency_band",
+        "semantic_provider",
+        "semantic_cache_hit",
+        "semantic_summary",
+        "post_text",
+        "post_url",
+    ],
+    "narrative_events.csv": [
+        "trade_date",
+        "post_count",
+        "avg_sentiment",
+        "avg_market_relevance",
+        "avg_urgency",
+        "primary_topics",
+        "primary_assets",
+        "sample_posts",
+        "next_session_return",
+    ],
+}
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, pd.Timestamp):
+        return value.isoformat()
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    if isinstance(value, pd.Timedelta):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+    return value
+
+
+def build_research_export_manifest(
+    *,
+    filters: Mapping[str, Any],
+    source_mode: Mapping[str, Any],
+    headline_metrics: Mapping[str, Any],
+    generated_at: pd.Timestamp | None = None,
+) -> dict[str, Any]:
+    generated = pd.Timestamp.now(tz="UTC").floor("s") if generated_at is None else pd.Timestamp(generated_at).floor("s")
+    if generated.tzinfo is None:
+        generated = generated.tz_localize("UTC")
+    else:
+        generated = generated.tz_convert("UTC")
+    return {
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "generated_at": generated.isoformat(),
+        "filters": _json_safe(dict(filters)),
+        "source_mode": _json_safe(dict(source_mode)),
+        "headline_metrics": _json_safe(dict(headline_metrics)),
+    }
+
+
+def build_research_export_summary(manifest: Mapping[str, Any]) -> str:
+    filters = dict(manifest.get("filters", {}) or {})
+    metrics = dict(manifest.get("headline_metrics", {}) or {})
+    source_mode = dict(manifest.get("source_mode", {}) or {})
+    platforms = ", ".join(str(item) for item in filters.get("platforms", []) or []) or "none"
+    lines = [
+        "# Research Export Pack",
+        "",
+        f"Generated: {manifest.get('generated_at', 'unknown')}",
+        f"Source mode: {source_mode.get('mode', 'unknown')}",
+        "",
+        "## Scope",
+        "",
+        f"- Date range: {filters.get('date_start', 'n/a')} to {filters.get('date_end', 'n/a')}",
+        f"- Platforms: {platforms}",
+        f"- Keyword: {filters.get('keyword', '') or '(none)'}",
+        f"- Include reshares: {bool(filters.get('include_reshares', False))}",
+        f"- Tracked accounts only: {bool(filters.get('tracked_only', False))}",
+        f"- Trump-authored only: {bool(filters.get('trump_authored_only', False))}",
+        "",
+        "## Headline Metrics",
+        "",
+        f"- Sessions with posts: {metrics.get('sessions_with_posts', 0)}",
+        f"- Posts in view: {metrics.get('posts_in_view', 0)}",
+        f"- Truth posts: {metrics.get('truth_posts', 0)}",
+        f"- Tracked X posts: {metrics.get('tracked_x_posts', 0)}",
+        f"- Mean sentiment: {metrics.get('mean_sentiment', 'n/a')}",
+        f"- S&P 500 change: {metrics.get('sp500_change', 'n/a')}",
+        "",
+        "## Notes",
+        "",
+        "- This pack reflects the current Research View filters at download time.",
+        "- Research outputs are descriptive and are not proof of causality.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _csv_bytes(frame: pd.DataFrame, columns: list[str]) -> bytes:
+    export_frame = frame.copy() if isinstance(frame, pd.DataFrame) else pd.DataFrame()
+    if export_frame.empty:
+        export_frame = export_frame.reindex(columns=columns)
+    return export_frame.to_csv(index=False).encode("utf-8")
+
+
+def build_research_export_bundle(
+    *,
+    manifest: Mapping[str, Any],
+    chart: go.Figure,
+    sessions: pd.DataFrame,
+    posts: pd.DataFrame,
+    narrative_frequency: pd.DataFrame,
+    narrative_returns: pd.DataFrame,
+    narrative_asset_heatmap: pd.DataFrame,
+    narrative_posts: pd.DataFrame,
+    narrative_events: pd.DataFrame,
+) -> bytes:
+    table_frames = {
+        "sessions.csv": sessions,
+        "posts.csv": posts,
+        "narrative_frequency.csv": narrative_frequency,
+        "narrative_returns.csv": narrative_returns,
+        "narrative_asset_heatmap.csv": narrative_asset_heatmap,
+        "narrative_posts.csv": narrative_posts,
+        "narrative_events.csv": narrative_events,
+    }
+    manifest_payload = dict(manifest)
+    manifest_payload["files"] = {
+        filename: {
+            "rows": int(len(frame)) if isinstance(frame, pd.DataFrame) else 0,
+            "columns": (
+                list(frame.columns)
+                if isinstance(frame, pd.DataFrame) and not frame.empty
+                else EXPORT_TABLE_COLUMNS[filename]
+            ),
+        }
+        for filename, frame in table_frames.items()
+    }
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps(_json_safe(manifest_payload), indent=2, sort_keys=True))
+        archive.writestr("summary.md", build_research_export_summary(manifest_payload))
+        archive.writestr(
+            "social_activity_chart.html",
+            chart.to_html(full_html=True, include_plotlyjs=True),
+        )
+        for filename, frame in table_frames.items():
+            archive.writestr(filename, _csv_bytes(frame, EXPORT_TABLE_COLUMNS[filename]))
+    return buffer.getvalue()
+
+
+def research_export_filename(date_start: pd.Timestamp, date_end: pd.Timestamp) -> str:
+    start_label = pd.Timestamp(date_start).strftime("%Y%m%d")
+    end_label = pd.Timestamp(date_end).strftime("%Y%m%d")
+    return f"research-pack-{start_label}-{end_label}.zip"

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -106,6 +106,11 @@ from .research import (
     make_post_table,
     make_session_table,
 )
+from .research_exports import (
+    build_research_export_bundle,
+    build_research_export_manifest,
+    research_export_filename,
+)
 from .storage import DuckDBStore
 from .utils import fmt_score
 
@@ -1324,15 +1329,31 @@ def render_research_view(
             & (narrative_asset_view["session_date"] <= end_date.normalize())
         ].copy()
 
-    metric_cols = st.columns(6)
-    metric_cols[0].metric("Sessions with posts", f"{int((events['post_count'] > 0).sum()):,}")
-    metric_cols[1].metric("Posts in view", f"{int(events['post_count'].sum()):,}")
-    metric_cols[2].metric("Truth posts", f"{int(mapped.loc[mapped['author_is_trump']].shape[0]):,}")
-    metric_cols[3].metric("Tracked X posts", f"{int(mapped.loc[_series_or_false(mapped, 'is_active_tracked_account')].shape[0]):,}")
-    metric_cols[4].metric("Mean sentiment", fmt_score(mapped["sentiment_score"].mean() if not mapped.empty else 0.0))
-    metric_cols[5].metric("S&P 500 change", f"{((events['close'].iloc[-1] / events['close'].iloc[0]) - 1.0):+.2%}" if len(events) > 1 else "n/a")
+    sessions_with_posts = int((events["post_count"] > 0).sum()) if "post_count" in events.columns else 0
+    posts_in_view = int(events["post_count"].sum()) if "post_count" in events.columns else 0
+    truth_posts = int(mapped.loc[_series_or_false(mapped, "author_is_trump").astype(bool)].shape[0]) if not mapped.empty else 0
+    tracked_x_posts = int(mapped.loc[_series_or_false(mapped, "is_active_tracked_account").astype(bool)].shape[0]) if not mapped.empty else 0
+    mean_sentiment = float(mapped["sentiment_score"].mean()) if not mapped.empty and "sentiment_score" in mapped.columns else 0.0
+    sp500_change = float((events["close"].iloc[-1] / events["close"].iloc[0]) - 1.0) if len(events) > 1 else None
+    headline_metrics = {
+        "sessions_with_posts": sessions_with_posts,
+        "posts_in_view": posts_in_view,
+        "truth_posts": truth_posts,
+        "tracked_x_posts": tracked_x_posts,
+        "mean_sentiment": mean_sentiment,
+        "sp500_change": sp500_change,
+    }
 
-    st.plotly_chart(build_combined_chart(events, scale_markers=scale_markers), use_container_width=True)
+    metric_cols = st.columns(6)
+    metric_cols[0].metric("Sessions with posts", f"{sessions_with_posts:,}")
+    metric_cols[1].metric("Posts in view", f"{posts_in_view:,}")
+    metric_cols[2].metric("Truth posts", f"{truth_posts:,}")
+    metric_cols[3].metric("Tracked X posts", f"{tracked_x_posts:,}")
+    metric_cols[4].metric("Mean sentiment", fmt_score(mean_sentiment))
+    metric_cols[5].metric("S&P 500 change", f"{sp500_change:+.2%}" if sp500_change is not None else "n/a")
+
+    combined_chart = build_combined_chart(events, scale_markers=scale_markers)
+    st.plotly_chart(combined_chart, use_container_width=True)
 
     session_table = make_session_table(events)
     if not session_table.empty:
@@ -1347,6 +1368,53 @@ def render_research_view(
     if not post_table.empty:
         with st.expander("Underlying posts", expanded=False):
             st.dataframe(post_table, use_container_width=True, hide_index=True)
+
+    export_narrative_frequency = build_narrative_frequency_frame(mapped)
+    export_narrative_returns = build_narrative_return_frame(mapped, market, bucket_field="semantic_topic")
+    export_narrative_asset_heatmap = build_narrative_asset_heatmap_frame(narrative_asset_view)
+    export_narrative_posts = make_narrative_post_table(mapped).head(25)
+    export_narrative_events = make_narrative_event_table(mapped, market)
+    export_manifest = build_research_export_manifest(
+        filters={
+            "date_start": start_date.date().isoformat(),
+            "date_end": end_date.date().isoformat(),
+            "platforms": list(selected_platforms),
+            "keyword": keyword,
+            "include_reshares": include_reshares,
+            "tracked_only": tracked_only,
+            "trump_authored_only": trump_authored_only,
+            "narrative_bucket_field": "semantic_topic",
+        },
+        source_mode=source_mode,
+        headline_metrics=headline_metrics,
+    )
+    export_bundle = build_research_export_bundle(
+        manifest=export_manifest,
+        chart=combined_chart,
+        sessions=session_table,
+        posts=post_table,
+        narrative_frequency=export_narrative_frequency,
+        narrative_returns=export_narrative_returns,
+        narrative_asset_heatmap=export_narrative_asset_heatmap,
+        narrative_posts=export_narrative_posts,
+        narrative_events=export_narrative_events,
+    )
+    st.markdown("**Export current research pack**")
+    st.caption(
+        "Download a ZIP bundle for the current Research View filters. Includes a manifest, Markdown summary, "
+        "social activity chart HTML, session/post CSVs, and all-narrative CSV outputs for this filtered slice.",
+    )
+    export_cols = st.columns([1.2, 1, 1])
+    export_cols[0].metric("Files", "10")
+    export_cols[1].metric("Session rows", f"{len(session_table):,}")
+    export_cols[2].metric("Post rows", f"{len(post_table):,}")
+    st.download_button(
+        "Download research pack (.zip)",
+        data=export_bundle,
+        file_name=research_export_filename(start_date, end_date),
+        mime="application/zip",
+        use_container_width=True,
+    )
 
     narratives_tab, asset_tab = st.tabs(["Narratives", "Multi-Asset Comparison"])
 


### PR DESCRIPTION
## Summary
- add a pure Research Export Pack builder that emits manifest, Markdown summary, chart HTML, and CSV files in a ZIP bundle
- wire a read-only download section into Research View using the current filtered session/post/narrative tables
- document the Research View ZIP export and add export bundle/UI coverage

## Tests
- .venv/bin/python -m unittest tests.test_research_exports tests.test_ui
- bash scripts/ci.sh