### PR TITLE
Add Model Performance Observatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,10 +312,12 @@ Use it to:
 - review explanation details for the winner and runner-up
 - review persisted live board and decision history over time
 - enable paper trading, inspect the paper decision journal, and track realized equity vs `SPY`
+- inspect the `Performance Observatory` for warn-only diagnostics on paper PnL, alpha, drawdown, fallback rate, score calibration, and live candidate-board drift
 
 Important note:
 
 - This page will not do much until you have already created at least one saved joint portfolio run in `Models & Backtests`
+- The `Performance Observatory` is informational only. It does not retrain models, block live decisions, or change paper-trading behavior.
 
 ## Data Inputs
 
@@ -410,6 +412,12 @@ If `Live Monitor` shows no paper portfolio history:
 - save and pin a joint portfolio run first
 - enable paper trading from the `Paper Portfolio` tab
 - use polling or let the scheduler persist live decisions before the next session opens
+
+If the `Performance Observatory` has limited diagnostics:
+
+- wait for paper decisions to settle against next-session prices
+- use polling or the scheduler to build more live snapshot history
+- treat early insufficient-sample warnings as expected until several sessions have settled
 
 If the intraday drill-down fails:
 

--- a/tests/test_integration_workflows.py
+++ b/tests/test_integration_workflows.py
@@ -23,6 +23,7 @@ from trump_workbench.paper_trading import (
     ensure_paper_portfolio_registry_frame,
     ensure_paper_trade_ledger_frame,
 )
+from trump_workbench.performance import PerformanceObservatoryService, ensure_performance_diagnostic_frame
 from trump_workbench.portfolio import rank_portfolio_candidates
 from trump_workbench.runtime import refresh_datasets
 from trump_workbench.scheduler import SchedulerDecision, run_scheduler_cycle
@@ -139,6 +140,7 @@ class IntegrationWorkflowTests(unittest.TestCase):
         self.backtests = BacktestService(self.model_service)
         self.experiments = ExperimentStore(self.store)
         self.paper_service = PaperTradingService(self.store)
+        self.performance_service = PerformanceObservatoryService(self.store)
         self.health_service = DataHealthService()
 
     def tearDown(self) -> None:
@@ -717,6 +719,7 @@ class IntegrationWorkflowTests(unittest.TestCase):
             experiment_store=self.experiments,
             model_service=self.model_service,
             paper_service=self.paper_service,
+            performance_service=self.performance_service,
             generated_at=cutoff + pd.Timedelta(hours=8),
         )
 
@@ -731,6 +734,11 @@ class IntegrationWorkflowTests(unittest.TestCase):
         self.assertEqual(str(portfolio_journal.iloc[0]["settlement_status"]), "settled")
         self.assertEqual(len(portfolio_trades), 1)
         self.assertEqual(str(portfolio_trades.iloc[0]["asset_symbol"]), "QQQ")
+        latest_performance = ensure_performance_diagnostic_frame(self.store.read_frame("model_performance_latest"))
+        performance_history = ensure_performance_diagnostic_frame(self.store.read_frame("model_performance_history"))
+        self.assertFalse(latest_performance.empty)
+        self.assertFalse(performance_history.empty)
+        self.assertEqual(set(latest_performance["paper_portfolio_id"].astype(str)), {paper_config.paper_portfolio_id})
 
 
 if __name__ == "__main__":

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from trump_workbench.config import AppSettings
+from trump_workbench.paper_trading import (
+    PAPER_BENCHMARK_CURVE_COLUMNS,
+    PAPER_DECISION_JOURNAL_COLUMNS,
+    PAPER_EQUITY_CURVE_COLUMNS,
+    PAPER_PORTFOLIO_REGISTRY_COLUMNS,
+    PAPER_TRADE_LEDGER_COLUMNS,
+)
+from trump_workbench.performance import (
+    PERFORMANCE_DIAGNOSTIC_COLUMNS,
+    PerformanceObservatoryService,
+    build_performance_summary,
+    build_score_outcome_frame,
+    ensure_performance_diagnostic_frame,
+)
+from trump_workbench.storage import DuckDBStore
+
+
+class PerformanceObservatoryServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.settings = AppSettings(base_dir=Path(self.temp_dir.name))
+        self.store = DuckDBStore(self.settings)
+        self.service = PerformanceObservatoryService(self.store)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def _registry(portfolio_ids: list[str] | None = None) -> pd.DataFrame:
+        ids = portfolio_ids or ["paper-active"]
+        rows = []
+        for idx, paper_id in enumerate(ids):
+            rows.append(
+                {
+                    "paper_portfolio_id": paper_id,
+                    "portfolio_run_id": f"run-{idx + 1}",
+                    "portfolio_run_name": f"Run {idx + 1}",
+                    "deployment_variant": "per_asset",
+                    "fallback_mode": "SPY",
+                    "transaction_cost_bps": 2.0,
+                    "starting_cash": 100000.0,
+                    "enabled": idx == 0,
+                    "created_at": pd.Timestamp("2026-04-01 12:00:00", tz="UTC") + pd.Timedelta(days=idx),
+                    "archived_at": pd.NaT if idx == 0 else pd.Timestamp("2026-04-10 12:00:00", tz="UTC"),
+                },
+            )
+        return pd.DataFrame(rows, columns=PAPER_PORTFOLIO_REGISTRY_COLUMNS)
+
+    @staticmethod
+    def _journal(paper_id: str, count: int, fallback_every: int = 0) -> pd.DataFrame:
+        rows = []
+        for idx in range(count):
+            signal_date = pd.Timestamp("2026-04-01", tz="UTC") + pd.Timedelta(days=idx)
+            fallback = bool(fallback_every and idx % fallback_every == 0)
+            rows.append(
+                {
+                    "paper_portfolio_id": paper_id,
+                    "generated_at": signal_date + pd.Timedelta(hours=12),
+                    "signal_session_date": signal_date,
+                    "next_session_date": signal_date + pd.Timedelta(days=1),
+                    "decision_cutoff_ts": signal_date + pd.Timedelta(days=1, hours=13, minutes=30),
+                    "portfolio_run_id": "run-1",
+                    "portfolio_run_name": "Run 1",
+                    "deployment_variant": "per_asset",
+                    "winning_asset": "SPY" if fallback else "QQQ",
+                    "winning_run_id": "run-1",
+                    "decision_source": "fallback" if fallback else "eligible",
+                    "fallback_mode": "SPY",
+                    "stance": "LONG",
+                    "winner_score": 0.01 + idx * 0.001,
+                    "runner_up_asset": "SPY" if not fallback else "QQQ",
+                    "runner_up_score": 0.005,
+                    "eligible_asset_count": 1 if not fallback else 0,
+                    "settlement_status": "settled",
+                    "settled_at": signal_date + pd.Timedelta(days=1, hours=21),
+                },
+            )
+        return pd.DataFrame(rows, columns=PAPER_DECISION_JOURNAL_COLUMNS)
+
+    @staticmethod
+    def _trades(paper_id: str, returns: list[float]) -> pd.DataFrame:
+        rows = []
+        equity = 100000.0
+        for idx, net_return in enumerate(returns):
+            signal_date = pd.Timestamp("2026-04-01", tz="UTC") + pd.Timedelta(days=idx)
+            starting_equity = equity
+            equity = equity * (1.0 + net_return)
+            rows.append(
+                {
+                    "paper_portfolio_id": paper_id,
+                    "signal_session_date": signal_date,
+                    "next_session_date": signal_date + pd.Timedelta(days=1),
+                    "asset_symbol": "QQQ",
+                    "run_id": "run-1",
+                    "decision_source": "eligible",
+                    "stance": "LONG",
+                    "next_session_open": 100.0,
+                    "next_session_close": 100.0 * (1.0 + net_return),
+                    "gross_return": net_return + 0.0004,
+                    "net_return": net_return,
+                    "benchmark_return": 0.001,
+                    "transaction_cost_bps": 2.0,
+                    "starting_equity": starting_equity,
+                    "ending_equity": equity,
+                    "settled_at": signal_date + pd.Timedelta(days=1, hours=21),
+                },
+            )
+        return pd.DataFrame(rows, columns=PAPER_TRADE_LEDGER_COLUMNS)
+
+    @staticmethod
+    def _equity(paper_id: str, returns: list[float], benchmark: bool = False) -> pd.DataFrame:
+        rows = []
+        equity = 100000.0
+        for idx, return_pct in enumerate(returns):
+            signal_date = pd.Timestamp("2026-04-01", tz="UTC") + pd.Timedelta(days=idx)
+            equity = equity * (1.0 + return_pct)
+            row = {
+                "paper_portfolio_id": paper_id,
+                "signal_session_date": signal_date,
+                "next_session_date": signal_date + pd.Timedelta(days=1),
+                "equity": equity,
+                "return_pct": return_pct,
+                "settled_at": signal_date + pd.Timedelta(days=1, hours=21),
+            }
+            if benchmark:
+                row["benchmark_name"] = "always_long_spy"
+            rows.append(row)
+        columns = PAPER_BENCHMARK_CURVE_COLUMNS if benchmark else PAPER_EQUITY_CURVE_COLUMNS
+        return pd.DataFrame(rows, columns=columns)
+
+    @staticmethod
+    def _live_snapshots() -> pd.DataFrame:
+        rows = []
+        generated_times = pd.date_range("2026-04-01 12:00:00", periods=14, freq="h", tz="UTC")
+        for idx, generated_at in enumerate(generated_times):
+            for asset_symbol in ["SPY", "QQQ"]:
+                rows.append(
+                    {
+                        "generated_at": generated_at,
+                        "variant_name": "per_asset",
+                        "asset_symbol": asset_symbol,
+                        "run_id": "run-1",
+                        "expected_return_score": 0.01 + idx * 0.0001 + (0.001 if asset_symbol == "QQQ" else 0.0),
+                        "confidence": 0.55 + idx * 0.001,
+                        "post_count": 3 + idx % 4,
+                    },
+                )
+        return pd.DataFrame(rows)
+
+    def _save_frames(
+        self,
+        *,
+        registry: pd.DataFrame | None = None,
+        journal: pd.DataFrame | None = None,
+        trades: pd.DataFrame | None = None,
+        equity: pd.DataFrame | None = None,
+        benchmark: pd.DataFrame | None = None,
+        live_assets: pd.DataFrame | None = None,
+    ) -> None:
+        self.store.save_frame("paper_portfolio_registry", registry if registry is not None else self._registry())
+        self.store.save_frame("paper_decision_journal", journal if journal is not None else pd.DataFrame(columns=PAPER_DECISION_JOURNAL_COLUMNS))
+        self.store.save_frame("paper_trade_ledger", trades if trades is not None else pd.DataFrame(columns=PAPER_TRADE_LEDGER_COLUMNS))
+        self.store.save_frame("paper_equity_curve", equity if equity is not None else pd.DataFrame(columns=PAPER_EQUITY_CURVE_COLUMNS))
+        self.store.save_frame("paper_benchmark_curve", benchmark if benchmark is not None else pd.DataFrame(columns=PAPER_BENCHMARK_CURVE_COLUMNS))
+        self.store.save_frame("live_asset_snapshots", live_assets if live_assets is not None else pd.DataFrame())
+
+    def test_empty_paper_and_live_history_returns_insufficient_data_warnings(self) -> None:
+        self._save_frames()
+
+        diagnostics = self.service.evaluate_paper_portfolio("paper-active", generated_at=pd.Timestamp("2026-04-20", tz="UTC"))
+
+        self.assertIn("warn", diagnostics["severity"].tolist())
+        settled_row = diagnostics.loc[diagnostics["metric_name"] == "settled_trade_count"].iloc[0]
+        drift_row = diagnostics.loc[diagnostics["metric_name"] == "live_score_history"].iloc[0]
+        self.assertEqual(settled_row["severity"], "warn")
+        self.assertEqual(drift_row["severity"], "warn")
+
+    def test_settled_trades_compute_portfolio_summary_metrics(self) -> None:
+        returns = [0.02, -0.01, 0.015, 0.005, 0.01]
+        benchmark_returns = [0.002, 0.001, 0.001, 0.001, 0.001]
+        self._save_frames(
+            journal=self._journal("paper-active", len(returns), fallback_every=3),
+            trades=self._trades("paper-active", returns),
+            equity=self._equity("paper-active", returns),
+            benchmark=self._equity("paper-active", benchmark_returns, benchmark=True),
+            live_assets=self._live_snapshots(),
+        )
+        diagnostics = self.service.evaluate_paper_portfolio("paper-active", generated_at=pd.Timestamp("2026-04-20", tz="UTC"))
+
+        summary = build_performance_summary(
+            diagnostics=diagnostics,
+            registry=self.store.read_frame("paper_portfolio_registry"),
+            journal=self.store.read_frame("paper_decision_journal"),
+            trades=self.store.read_frame("paper_trade_ledger"),
+            equity=self.store.read_frame("paper_equity_curve"),
+            benchmark=self.store.read_frame("paper_benchmark_curve"),
+            paper_portfolio_id="paper-active",
+        )
+
+        self.assertEqual(summary["trade_count"], 5)
+        self.assertAlmostEqual(summary["win_rate"], 0.8)
+        self.assertGreater(summary["total_return"], summary["benchmark_return"])
+        self.assertGreater(summary["alpha"], 0.0)
+        self.assertLessEqual(summary["max_drawdown"], 0.0)
+
+    def test_score_outcome_correlation_uses_settled_long_trades(self) -> None:
+        returns = [0.001 + idx * 0.001 for idx in range(10)]
+        self._save_frames(
+            journal=self._journal("paper-active", len(returns)),
+            trades=self._trades("paper-active", returns),
+            equity=self._equity("paper-active", returns),
+            benchmark=self._equity("paper-active", [0.001] * len(returns), benchmark=True),
+            live_assets=self._live_snapshots(),
+        )
+
+        diagnostics = self.service.evaluate_paper_portfolio("paper-active", generated_at=pd.Timestamp("2026-04-20", tz="UTC"))
+        correlation_row = diagnostics.loc[diagnostics["metric_name"] == "score_outcome_correlation"].iloc[0]
+        score_outcomes = build_score_outcome_frame(
+            self.store.read_frame("paper_decision_journal"),
+            self.store.read_frame("paper_trade_ledger"),
+            "paper-active",
+        )
+
+        self.assertEqual(len(score_outcomes), 10)
+        self.assertEqual(correlation_row["severity"], "ok")
+        self.assertGreater(float(correlation_row["observed_value"]), 0.9)
+
+    def test_archived_portfolio_selection_does_not_mix_rows(self) -> None:
+        registry = self._registry(["paper-active", "paper-archived"])
+        journal = pd.concat([self._journal("paper-active", 1), self._journal("paper-archived", 1)], ignore_index=True)
+        trades = pd.concat(
+            [self._trades("paper-active", [0.02]), self._trades("paper-archived", [-0.05])],
+            ignore_index=True,
+        )
+        equity = pd.concat(
+            [self._equity("paper-active", [0.02]), self._equity("paper-archived", [-0.05])],
+            ignore_index=True,
+        )
+        benchmark = pd.concat(
+            [
+                self._equity("paper-active", [0.001], benchmark=True),
+                self._equity("paper-archived", [0.001], benchmark=True),
+            ],
+            ignore_index=True,
+        )
+        self._save_frames(registry=registry, journal=journal, trades=trades, equity=equity, benchmark=benchmark)
+
+        active_summary = self.service.build_summary(
+            "paper-active",
+            diagnostics=self.service.evaluate_paper_portfolio("paper-active"),
+        )
+        archived_summary = self.service.build_summary(
+            "paper-archived",
+            diagnostics=self.service.evaluate_paper_portfolio("paper-archived"),
+        )
+
+        self.assertGreater(active_summary["total_return"], 0.0)
+        self.assertLess(archived_summary["total_return"], 0.0)
+        self.assertEqual(active_summary["trade_count"], 1)
+        self.assertEqual(archived_summary["trade_count"], 1)
+
+    def test_persist_snapshot_overwrites_latest_and_appends_history(self) -> None:
+        self._save_frames(live_assets=self._live_snapshots())
+
+        first = self.service.persist_snapshot("paper-active", generated_at=pd.Timestamp("2026-04-20 12:00", tz="UTC"))
+        second = self.service.persist_snapshot("paper-active", generated_at=pd.Timestamp("2026-04-21 12:00", tz="UTC"))
+
+        latest = ensure_performance_diagnostic_frame(self.store.read_frame("model_performance_latest"))
+        history = ensure_performance_diagnostic_frame(self.store.read_frame("model_performance_history"))
+        self.assertEqual(set(latest["snapshot_id"]), set(second["snapshot_id"]))
+        self.assertIn(str(first.iloc[0]["snapshot_id"]), set(history["snapshot_id"].astype(str)))
+        self.assertIn(str(second.iloc[0]["snapshot_id"]), set(history["snapshot_id"].astype(str)))
+
+    def test_ensure_performance_diagnostic_frame_fills_missing_columns(self) -> None:
+        frame = ensure_performance_diagnostic_frame(
+            pd.DataFrame(
+                [
+                    {
+                        "snapshot_id": "s1",
+                        "severity": "WARN",
+                        "observed_value": "1.5",
+                    },
+                ],
+            ),
+        )
+
+        self.assertEqual(frame.columns.tolist(), PERFORMANCE_DIAGNOSTIC_COLUMNS)
+        self.assertEqual(frame.iloc[0]["severity"], "warn")
+        self.assertAlmostEqual(float(frame.iloc[0]["observed_value"]), 1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -33,6 +33,7 @@ from trump_workbench.ui import (
     _watchlist_text_value,
     render_datasets_view,
     render_discovery_view,
+    render_live_monitor,
     render_models_view,
     render_research_view,
 )
@@ -409,6 +410,15 @@ class UiHelperTests(unittest.TestCase):
         self.assertIn("build_research_export_bundle", source)
         self.assertIn("sessions=session_table", source)
         self.assertIn("posts=post_table", source)
+
+    def test_live_monitor_exposes_performance_observatory_without_gating_decisions(self) -> None:
+        source = inspect.getsource(render_live_monitor)
+
+        self.assertIn("Performance Observatory", source)
+        self.assertIn("PerformanceObservatoryService", source)
+        self.assertIn("load_latest_for_portfolio", source)
+        self.assertIn("evaluate_paper_portfolio", source)
+        self.assertIn("These diagnostics do not gate live decisions", source)
 
     def test_datasets_view_exposes_operating_mode(self) -> None:
         source = inspect.getsource(render_datasets_view)

--- a/trump_workbench/performance.py
+++ b/trump_workbench/performance.py
@@ -1,0 +1,603 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .paper_trading import (
+    ensure_paper_benchmark_curve_frame,
+    ensure_paper_decision_journal_frame,
+    ensure_paper_equity_curve_frame,
+    ensure_paper_portfolio_registry_frame,
+    ensure_paper_trade_ledger_frame,
+)
+from .utils import stable_text_id
+
+PERFORMANCE_DIAGNOSTIC_COLUMNS = [
+    "snapshot_id",
+    "generated_at",
+    "paper_portfolio_id",
+    "portfolio_run_id",
+    "deployment_variant",
+    "scope_kind",
+    "scope_key",
+    "metric_name",
+    "severity",
+    "observed_value",
+    "baseline_value",
+    "detail",
+]
+
+PERFORMANCE_SEVERITY_ORDER = {"ok": 0, "warn": 1, "severe": 2}
+
+
+def _empty_performance_diagnostic_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=PERFORMANCE_DIAGNOSTIC_COLUMNS)
+
+
+def _coerce_utc_timestamp(value: object) -> pd.Timestamp | pd.NaT:
+    ts = pd.to_datetime(value, errors="coerce")
+    if pd.isna(ts):
+        return pd.NaT
+    if ts.tzinfo is None:
+        return ts.tz_localize("UTC")
+    return ts.tz_convert("UTC")
+
+
+def ensure_performance_diagnostic_frame(frame: pd.DataFrame | None) -> pd.DataFrame:
+    if frame is None or frame.empty:
+        return _empty_performance_diagnostic_frame()
+    out = frame.copy()
+    for column in PERFORMANCE_DIAGNOSTIC_COLUMNS:
+        if column not in out.columns:
+            out[column] = pd.NA
+    out["generated_at"] = pd.to_datetime(out["generated_at"], errors="coerce", utc=True)
+    out["severity"] = out["severity"].fillna("ok").astype(str).str.lower()
+    out["observed_value"] = pd.to_numeric(out["observed_value"], errors="coerce")
+    out["baseline_value"] = pd.to_numeric(out["baseline_value"], errors="coerce")
+    return out[PERFORMANCE_DIAGNOSTIC_COLUMNS].copy()
+
+
+def _severity_from_thresholds(
+    observed_value: float | None,
+    *,
+    warn_below: float | None = None,
+    severe_below: float | None = None,
+    warn_above: float | None = None,
+    severe_above: float | None = None,
+) -> str:
+    if observed_value is None or pd.isna(observed_value):
+        return "warn"
+    value = float(observed_value)
+    if severe_below is not None and value < severe_below:
+        return "severe"
+    if severe_above is not None and value > severe_above:
+        return "severe"
+    if warn_below is not None and value < warn_below:
+        return "warn"
+    if warn_above is not None and value > warn_above:
+        return "warn"
+    return "ok"
+
+
+def _max_drawdown(equity: pd.Series) -> float:
+    values = pd.to_numeric(equity, errors="coerce").dropna()
+    if values.empty:
+        return 0.0
+    running_max = values.cummax()
+    drawdowns = values / running_max - 1.0
+    return float(drawdowns.min())
+
+
+def _series_return(curve: pd.DataFrame, starting_cash: float) -> float:
+    if curve.empty or starting_cash == 0:
+        return 0.0
+    ordered = curve.sort_values("next_session_date")
+    latest_equity = pd.to_numeric(ordered["equity"], errors="coerce").dropna()
+    if latest_equity.empty:
+        return 0.0
+    return float(latest_equity.iloc[-1] / float(starting_cash) - 1.0)
+
+
+def _score_outcome_join(journal: pd.DataFrame, trades: pd.DataFrame, paper_portfolio_id: str) -> pd.DataFrame:
+    selected_journal = journal.loc[journal["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    selected_trades = trades.loc[trades["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    if selected_journal.empty or selected_trades.empty:
+        return pd.DataFrame(columns=["signal_session_date", "winning_asset", "winner_score", "net_return"])
+    selected_journal["signal_session_key"] = pd.to_datetime(
+        selected_journal["signal_session_date"],
+        errors="coerce",
+        utc=True,
+    ).dt.normalize()
+    selected_trades["signal_session_key"] = pd.to_datetime(
+        selected_trades["signal_session_date"],
+        errors="coerce",
+        utc=True,
+    ).dt.normalize()
+    joined = selected_journal.merge(
+        selected_trades[["signal_session_key", "asset_symbol", "net_return"]],
+        on="signal_session_key",
+        how="inner",
+    )
+    if joined.empty:
+        return pd.DataFrame(columns=["signal_session_date", "winning_asset", "winner_score", "net_return"])
+    joined["winner_score"] = pd.to_numeric(joined["winner_score"], errors="coerce")
+    joined["net_return"] = pd.to_numeric(joined["net_return"], errors="coerce")
+    joined = joined.dropna(subset=["winner_score", "net_return"]).copy()
+    return joined[
+        ["signal_session_date", "winning_asset", "asset_symbol", "winner_score", "net_return"]
+    ].reset_index(drop=True)
+
+
+def build_equity_comparison_frame(
+    equity: pd.DataFrame,
+    benchmark: pd.DataFrame,
+    paper_portfolio_id: str,
+) -> pd.DataFrame:
+    selected_equity = ensure_paper_equity_curve_frame(equity)
+    selected_benchmark = ensure_paper_benchmark_curve_frame(benchmark)
+    selected_equity = selected_equity.loc[selected_equity["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    selected_benchmark = selected_benchmark.loc[
+        (selected_benchmark["paper_portfolio_id"].astype(str) == str(paper_portfolio_id))
+        & (selected_benchmark["benchmark_name"].astype(str) == "always_long_spy")
+    ].copy()
+    if selected_equity.empty and selected_benchmark.empty:
+        return pd.DataFrame(columns=["next_session_date", "paper_portfolio_equity", "spy_benchmark_equity"])
+    left = selected_equity[["next_session_date", "equity"]].rename(columns={"equity": "paper_portfolio_equity"})
+    right = selected_benchmark[["next_session_date", "equity"]].rename(columns={"equity": "spy_benchmark_equity"})
+    merged = left.merge(right, on="next_session_date", how="outer").sort_values("next_session_date").reset_index(drop=True)
+    return merged
+
+
+def build_rolling_return_frame(
+    trades: pd.DataFrame,
+    paper_portfolio_id: str,
+    window: int = 5,
+) -> pd.DataFrame:
+    selected_trades = ensure_paper_trade_ledger_frame(trades)
+    selected_trades = selected_trades.loc[selected_trades["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    if selected_trades.empty:
+        return pd.DataFrame(columns=["next_session_date", "net_return", "rolling_net_return"])
+    selected_trades = selected_trades.sort_values("next_session_date").reset_index(drop=True)
+    selected_trades["net_return"] = pd.to_numeric(selected_trades["net_return"], errors="coerce").fillna(0.0)
+    selected_trades["rolling_net_return"] = selected_trades["net_return"].rolling(max(1, int(window)), min_periods=1).mean()
+    return selected_trades[["next_session_date", "net_return", "rolling_net_return"]].copy()
+
+
+def build_score_outcome_frame(
+    journal: pd.DataFrame,
+    trades: pd.DataFrame,
+    paper_portfolio_id: str,
+) -> pd.DataFrame:
+    return _score_outcome_join(
+        ensure_paper_decision_journal_frame(journal),
+        ensure_paper_trade_ledger_frame(trades),
+        paper_portfolio_id,
+    )
+
+
+def build_score_bucket_outcome_frame(
+    journal: pd.DataFrame,
+    trades: pd.DataFrame,
+    paper_portfolio_id: str,
+) -> pd.DataFrame:
+    scored = build_score_outcome_frame(journal, trades, paper_portfolio_id)
+    if scored.empty:
+        return pd.DataFrame(columns=["score_bucket", "trade_count", "mean_net_return", "win_rate"])
+    try:
+        scored["score_bucket"] = pd.qcut(
+            scored["winner_score"],
+            q=min(3, int(scored["winner_score"].nunique())),
+            labels=["low", "medium", "high"][: min(3, int(scored["winner_score"].nunique()))],
+            duplicates="drop",
+        ).astype(str)
+    except ValueError:
+        scored["score_bucket"] = "all"
+    grouped = (
+        scored.groupby("score_bucket", dropna=False)
+        .agg(
+            trade_count=("net_return", "size"),
+            mean_net_return=("net_return", "mean"),
+            win_rate=("net_return", lambda series: float((series > 0).mean()) if len(series) else 0.0),
+        )
+        .reset_index()
+    )
+    return grouped
+
+
+def build_winner_distribution_frame(
+    journal: pd.DataFrame,
+    paper_portfolio_id: str,
+) -> pd.DataFrame:
+    selected_journal = ensure_paper_decision_journal_frame(journal)
+    selected_journal = selected_journal.loc[selected_journal["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    if selected_journal.empty:
+        return pd.DataFrame(columns=["winning_asset", "decision_count"])
+    selected_journal["winning_asset"] = selected_journal["winning_asset"].fillna("").astype(str).replace({"": "FLAT"})
+    counts = selected_journal.groupby("winning_asset").size().reset_index(name="decision_count")
+    return counts.sort_values("decision_count", ascending=False).reset_index(drop=True)
+
+
+def build_live_score_drift_frame(
+    live_asset_snapshots: pd.DataFrame,
+    portfolio_run_id: str,
+    deployment_variant: str,
+    recent_window: int = 10,
+    baseline_window: int = 30,
+) -> pd.DataFrame:
+    if live_asset_snapshots.empty:
+        return pd.DataFrame(columns=["asset_symbol", "metric_name", "recent_mean", "baseline_mean", "baseline_std", "z_score"])
+    snapshots = live_asset_snapshots.copy()
+    snapshots["run_id"] = snapshots.get("run_id", "").astype(str)
+    snapshots = snapshots.loc[snapshots["run_id"] == str(portfolio_run_id)].copy()
+    if "variant_name" in snapshots.columns and str(deployment_variant or ""):
+        snapshots = snapshots.loc[snapshots["variant_name"].astype(str) == str(deployment_variant)].copy()
+    if snapshots.empty or "asset_symbol" not in snapshots.columns:
+        return pd.DataFrame(columns=["asset_symbol", "metric_name", "recent_mean", "baseline_mean", "baseline_std", "z_score"])
+    snapshots["generated_at"] = pd.to_datetime(snapshots["generated_at"], errors="coerce", utc=True)
+    snapshots = snapshots.dropna(subset=["generated_at"]).sort_values("generated_at").reset_index(drop=True)
+    rows: list[dict[str, object]] = []
+    for asset_symbol, group in snapshots.groupby(snapshots["asset_symbol"].astype(str).str.upper()):
+        ordered = group.sort_values("generated_at")
+        for metric_name in ["expected_return_score", "confidence", "post_count"]:
+            if metric_name not in ordered.columns:
+                continue
+            values = pd.to_numeric(ordered[metric_name], errors="coerce").dropna()
+            if values.empty:
+                continue
+            recent = values.tail(max(1, int(recent_window)))
+            prior = values.iloc[: max(0, len(values) - len(recent))].tail(max(1, int(baseline_window)))
+            recent_mean = float(recent.mean())
+            baseline_mean = float(prior.mean()) if not prior.empty else np.nan
+            baseline_std = float(prior.std(ddof=0)) if len(prior) > 1 else np.nan
+            scale = max(
+                abs(baseline_std) if pd.notna(baseline_std) else 0.0,
+                abs(baseline_mean) * 0.1 if pd.notna(baseline_mean) else 0.0,
+                1e-6,
+            )
+            z_score = abs(recent_mean - baseline_mean) / scale if pd.notna(baseline_mean) else np.nan
+            rows.append(
+                {
+                    "asset_symbol": asset_symbol,
+                    "metric_name": metric_name,
+                    "recent_mean": recent_mean,
+                    "baseline_mean": baseline_mean,
+                    "baseline_std": baseline_std,
+                    "z_score": z_score,
+                },
+            )
+    return pd.DataFrame(rows)
+
+
+def build_performance_summary(
+    diagnostics: pd.DataFrame,
+    registry: pd.DataFrame,
+    journal: pd.DataFrame,
+    trades: pd.DataFrame,
+    equity: pd.DataFrame,
+    benchmark: pd.DataFrame,
+    paper_portfolio_id: str,
+) -> dict[str, Any]:
+    checks = ensure_performance_diagnostic_frame(diagnostics)
+    selected_registry = ensure_paper_portfolio_registry_frame(registry)
+    selected_journal = ensure_paper_decision_journal_frame(journal)
+    selected_trades = ensure_paper_trade_ledger_frame(trades)
+    selected_equity = ensure_paper_equity_curve_frame(equity)
+    selected_benchmark = ensure_paper_benchmark_curve_frame(benchmark)
+
+    selected_registry = selected_registry.loc[selected_registry["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    selected_journal = selected_journal.loc[selected_journal["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    selected_trades = selected_trades.loc[selected_trades["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    selected_equity = selected_equity.loc[selected_equity["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    selected_benchmark = selected_benchmark.loc[selected_benchmark["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+    starting_cash = float(selected_registry.iloc[0]["starting_cash"]) if not selected_registry.empty else 100000.0
+
+    severity_score = int(checks["severity"].map(PERFORMANCE_SEVERITY_ORDER).fillna(0).max()) if not checks.empty else 0
+    overall_severity = next(
+        severity for severity, score in PERFORMANCE_SEVERITY_ORDER.items() if score == severity_score
+    )
+    total_return = _series_return(selected_equity, starting_cash)
+    benchmark_return = _series_return(selected_benchmark, starting_cash)
+    trade_count = int(len(selected_trades))
+    win_rate = float((pd.to_numeric(selected_trades["net_return"], errors="coerce") > 0).mean()) if trade_count else 0.0
+    pending_decisions = int((selected_journal["settlement_status"].astype(str) == "pending").sum()) if not selected_journal.empty else 0
+    fallback_rate = float((selected_journal["decision_source"].astype(str) == "fallback").mean()) if not selected_journal.empty else 0.0
+    score_outcomes = _score_outcome_join(selected_journal, selected_trades, paper_portfolio_id)
+    score_correlation = (
+        float(score_outcomes["winner_score"].corr(score_outcomes["net_return"]))
+        if len(score_outcomes) >= 2
+        else np.nan
+    )
+    max_drawdown = _max_drawdown(selected_equity["equity"]) if not selected_equity.empty else 0.0
+    return {
+        "overall_severity": overall_severity,
+        "total_return": total_return,
+        "benchmark_return": benchmark_return,
+        "alpha": total_return - benchmark_return,
+        "max_drawdown": max_drawdown,
+        "win_rate": win_rate,
+        "trade_count": trade_count,
+        "pending_decisions": pending_decisions,
+        "fallback_rate": fallback_rate,
+        "score_outcome_correlation": score_correlation,
+    }
+
+
+class PerformanceObservatoryService:
+    def __init__(self, store: Any, recent_window: int = 10, baseline_window: int = 30) -> None:
+        self.store = store
+        self.recent_window = recent_window
+        self.baseline_window = baseline_window
+
+    def evaluate_paper_portfolio(
+        self,
+        paper_portfolio_id: str,
+        generated_at: pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        generated_ts = _coerce_utc_timestamp(generated_at)
+        if pd.isna(generated_ts):
+            generated_ts = pd.Timestamp.now(tz="UTC")
+        snapshot_id = stable_text_id("performance", paper_portfolio_id, generated_ts.isoformat())
+
+        registry = ensure_paper_portfolio_registry_frame(self.store.read_frame("paper_portfolio_registry"))
+        journal = ensure_paper_decision_journal_frame(self.store.read_frame("paper_decision_journal"))
+        trades = ensure_paper_trade_ledger_frame(self.store.read_frame("paper_trade_ledger"))
+        equity = ensure_paper_equity_curve_frame(self.store.read_frame("paper_equity_curve"))
+        benchmark = ensure_paper_benchmark_curve_frame(self.store.read_frame("paper_benchmark_curve"))
+        live_assets = self.store.read_frame("live_asset_snapshots")
+
+        registry_row = registry.loc[registry["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+        portfolio_run_id = str(registry_row.iloc[0]["portfolio_run_id"]) if not registry_row.empty else ""
+        deployment_variant = str(registry_row.iloc[0]["deployment_variant"]) if not registry_row.empty else ""
+        selected_journal = journal.loc[journal["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+        selected_trades = trades.loc[trades["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+        selected_equity = equity.loc[equity["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+        selected_benchmark = benchmark.loc[benchmark["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+        starting_cash = float(registry_row.iloc[0]["starting_cash"]) if not registry_row.empty else 100000.0
+
+        rows: list[dict[str, object]] = []
+
+        def add_row(
+            scope_kind: str,
+            scope_key: str,
+            metric_name: str,
+            severity: str,
+            observed_value: float | int | None,
+            baseline_value: float | int | None = None,
+            detail: str = "",
+        ) -> None:
+            rows.append(
+                {
+                    "snapshot_id": snapshot_id,
+                    "generated_at": generated_ts,
+                    "paper_portfolio_id": str(paper_portfolio_id),
+                    "portfolio_run_id": portfolio_run_id,
+                    "deployment_variant": deployment_variant,
+                    "scope_kind": str(scope_kind),
+                    "scope_key": str(scope_key),
+                    "metric_name": str(metric_name),
+                    "severity": str(severity),
+                    "observed_value": float(observed_value) if observed_value is not None and pd.notna(observed_value) else np.nan,
+                    "baseline_value": float(baseline_value) if baseline_value is not None and pd.notna(baseline_value) else np.nan,
+                    "detail": str(detail or ""),
+                },
+            )
+
+        if registry_row.empty:
+            add_row(
+                "portfolio",
+                str(paper_portfolio_id),
+                "portfolio_registry",
+                "warn",
+                0,
+                1,
+                "No paper portfolio registry row exists for this portfolio id.",
+            )
+            return ensure_performance_diagnostic_frame(pd.DataFrame(rows, columns=PERFORMANCE_DIAGNOSTIC_COLUMNS))
+
+        settled_count = int(len(selected_trades))
+        add_row(
+            "portfolio",
+            str(paper_portfolio_id),
+            "settled_trade_count",
+            "warn" if settled_count < 5 else "ok",
+            settled_count,
+            5,
+            "At least five settled trades are needed before outcome diagnostics are reliable." if settled_count < 5 else "",
+        )
+
+        total_return = _series_return(selected_equity, starting_cash)
+        benchmark_return = _series_return(selected_benchmark, starting_cash)
+        alpha = total_return - benchmark_return
+        alpha_severity = "ok" if settled_count < 5 else _severity_from_thresholds(alpha, warn_below=-0.02, severe_below=-0.05)
+        add_row("portfolio", str(paper_portfolio_id), "strategy_total_return", "ok", total_return, 0.0)
+        add_row("portfolio", "always_long_spy", "spy_benchmark_return", "ok", benchmark_return, 0.0)
+        add_row(
+            "portfolio",
+            str(paper_portfolio_id),
+            "alpha_vs_spy",
+            alpha_severity,
+            alpha,
+            0.0,
+            "Alpha thresholds activate after at least five settled trades." if settled_count < 5 else "",
+        )
+
+        drawdown = _max_drawdown(selected_equity["equity"]) if not selected_equity.empty else 0.0
+        add_row(
+            "portfolio",
+            str(paper_portfolio_id),
+            "max_drawdown",
+            _severity_from_thresholds(drawdown, warn_below=-0.05, severe_below=-0.10),
+            drawdown,
+            -0.05,
+        )
+        win_rate = float((pd.to_numeric(selected_trades["net_return"], errors="coerce") > 0).mean()) if settled_count else 0.0
+        avg_net_return = float(pd.to_numeric(selected_trades["net_return"], errors="coerce").mean()) if settled_count else 0.0
+        add_row("portfolio", str(paper_portfolio_id), "win_rate", "ok", win_rate, 0.5)
+        add_row("portfolio", str(paper_portfolio_id), "average_net_return", "ok", avg_net_return, 0.0)
+
+        pending_count = int((selected_journal["settlement_status"].astype(str) == "pending").sum()) if not selected_journal.empty else 0
+        decision_count = int(len(selected_journal))
+        fallback_rate = float((selected_journal["decision_source"].astype(str) == "fallback").mean()) if decision_count else 0.0
+        flat_rate = (
+            float((selected_journal["stance"].astype(str).str.upper() == "FLAT").mean())
+            if decision_count
+            else 0.0
+        )
+        eligible_rate = float((selected_journal["decision_source"].astype(str) == "eligible").mean()) if decision_count else 0.0
+        fallback_severity = "ok" if decision_count < 10 else _severity_from_thresholds(fallback_rate, warn_above=0.50, severe_above=0.75)
+        add_row("decision_quality", str(paper_portfolio_id), "pending_decision_count", "ok", pending_count, 0)
+        add_row(
+            "decision_quality",
+            str(paper_portfolio_id),
+            "fallback_decision_rate",
+            fallback_severity,
+            fallback_rate,
+            0.50,
+            "Fallback-rate thresholds activate after at least ten decisions." if decision_count < 10 else "",
+        )
+        add_row("decision_quality", str(paper_portfolio_id), "flat_decision_rate", "ok", flat_rate, 0.0)
+        add_row("decision_quality", str(paper_portfolio_id), "eligible_decision_rate", "ok", eligible_rate, 1.0)
+
+        score_outcomes = _score_outcome_join(journal, trades, paper_portfolio_id)
+        if len(score_outcomes) >= 2:
+            correlation = float(score_outcomes["winner_score"].corr(score_outcomes["net_return"]))
+        else:
+            correlation = np.nan
+        if len(score_outcomes) < 10:
+            corr_severity = "warn"
+            corr_detail = "At least ten settled scored trades are needed for score/outcome correlation."
+        elif len(score_outcomes) >= 20 and pd.notna(correlation) and correlation < -0.25:
+            corr_severity = "severe"
+            corr_detail = ""
+        elif pd.notna(correlation) and correlation < 0.0:
+            corr_severity = "warn"
+            corr_detail = ""
+        else:
+            corr_severity = "ok"
+            corr_detail = ""
+        add_row(
+            "decision_quality",
+            str(paper_portfolio_id),
+            "score_outcome_correlation",
+            corr_severity,
+            correlation,
+            0.0,
+            corr_detail,
+        )
+
+        drift = build_live_score_drift_frame(
+            live_asset_snapshots=live_assets,
+            portfolio_run_id=portfolio_run_id,
+            deployment_variant=deployment_variant,
+            recent_window=self.recent_window,
+            baseline_window=self.baseline_window,
+        )
+        if drift.empty:
+            add_row(
+                "drift",
+                "live_asset_snapshots",
+                "live_score_history",
+                "warn",
+                0,
+                self.recent_window + 1,
+                "No live snapshot history is available for drift analysis yet.",
+            )
+        else:
+            for _, row in drift.iterrows():
+                z_score = row.get("z_score")
+                if pd.isna(z_score):
+                    severity = "warn"
+                    detail = "No prior baseline window is available for this asset metric yet."
+                elif float(z_score) >= 3.0:
+                    severity = "severe"
+                    detail = "Recent value moved more than roughly 3x baseline dispersion."
+                elif float(z_score) >= 2.0:
+                    severity = "warn"
+                    detail = "Recent value moved more than roughly 2x baseline dispersion."
+                else:
+                    severity = "ok"
+                    detail = ""
+                add_row(
+                    "drift",
+                    str(row["asset_symbol"]),
+                    f"{row['metric_name']}_drift_z",
+                    severity,
+                    z_score,
+                    2.0,
+                    detail,
+                )
+
+        winner_distribution = build_winner_distribution_frame(journal, paper_portfolio_id)
+        if not winner_distribution.empty:
+            top_share = float(winner_distribution["decision_count"].iloc[0] / winner_distribution["decision_count"].sum())
+            add_row(
+                "drift",
+                str(winner_distribution["winning_asset"].iloc[0]),
+                "winner_concentration_rate",
+                _severity_from_thresholds(top_share, warn_above=0.75, severe_above=0.90) if decision_count >= 10 else "ok",
+                top_share,
+                0.75,
+                "Winner concentration thresholds activate after at least ten decisions." if decision_count < 10 else "",
+            )
+
+        diagnostics = ensure_performance_diagnostic_frame(pd.DataFrame(rows, columns=PERFORMANCE_DIAGNOSTIC_COLUMNS))
+        if diagnostics.empty:
+            return diagnostics
+        diagnostics["severity_rank"] = diagnostics["severity"].map(PERFORMANCE_SEVERITY_ORDER).fillna(0)
+        diagnostics = diagnostics.sort_values(
+            ["severity_rank", "scope_kind", "scope_key", "metric_name"],
+            ascending=[False, True, True, True],
+        ).drop(columns=["severity_rank"])
+        return diagnostics.reset_index(drop=True)
+
+    def persist_snapshot(
+        self,
+        paper_portfolio_id: str,
+        generated_at: pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        latest = self.evaluate_paper_portfolio(paper_portfolio_id, generated_at=generated_at)
+        snapshot_id = str(latest.iloc[0]["snapshot_id"]) if not latest.empty else ""
+        self.store.save_frame(
+            "model_performance_latest",
+            latest,
+            metadata={"row_count": int(len(latest)), "snapshot_id": snapshot_id},
+        )
+        self.store.append_frame(
+            "model_performance_history",
+            latest,
+            dedupe_on=["snapshot_id", "paper_portfolio_id", "scope_kind", "scope_key", "metric_name"],
+            metadata={"snapshot_id": snapshot_id},
+        )
+        return latest
+
+    def load_latest_for_portfolio(self, paper_portfolio_id: str) -> pd.DataFrame:
+        latest = ensure_performance_diagnostic_frame(self.store.read_frame("model_performance_latest"))
+        filtered = latest.loc[latest["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+        if not filtered.empty:
+            return filtered.reset_index(drop=True)
+        history = ensure_performance_diagnostic_frame(self.store.read_frame("model_performance_history"))
+        filtered = history.loc[history["paper_portfolio_id"].astype(str) == str(paper_portfolio_id)].copy()
+        if filtered.empty:
+            return _empty_performance_diagnostic_frame()
+        latest_snapshot_time = filtered["generated_at"].max()
+        latest_snapshot = filtered.loc[filtered["generated_at"] == latest_snapshot_time].copy()
+        return latest_snapshot.reset_index(drop=True)
+
+    def build_summary(self, paper_portfolio_id: str, diagnostics: pd.DataFrame | None = None) -> dict[str, Any]:
+        diagnostics_frame = (
+            ensure_performance_diagnostic_frame(diagnostics)
+            if diagnostics is not None
+            else self.load_latest_for_portfolio(paper_portfolio_id)
+        )
+        return build_performance_summary(
+            diagnostics=diagnostics_frame,
+            registry=self.store.read_frame("paper_portfolio_registry"),
+            journal=self.store.read_frame("paper_decision_journal"),
+            trades=self.store.read_frame("paper_trade_ledger"),
+            equity=self.store.read_frame("paper_equity_curve"),
+            benchmark=self.store.read_frame("paper_benchmark_curve"),
+            paper_portfolio_id=paper_portfolio_id,
+        )
+

--- a/trump_workbench/scheduler.py
+++ b/trump_workbench/scheduler.py
@@ -18,6 +18,7 @@ from .live_monitor import build_live_portfolio_run_state, validate_live_monitor_
 from .market import MarketDataService
 from .modeling import ModelService
 from .paper_trading import PaperTradingService, paper_config_matches_live
+from .performance import PerformanceObservatoryService
 from .runtime import missing_core_datasets, refresh_datasets
 from .storage import DuckDBStore
 
@@ -106,6 +107,7 @@ def run_scheduler_cycle(
     experiment_store: ExperimentStore,
     model_service: ModelService,
     paper_service: PaperTradingService,
+    performance_service: PerformanceObservatoryService | None = None,
     generated_at: pd.Timestamp | None = None,
 ) -> SchedulerDecision:
     if not decision.should_run:
@@ -149,6 +151,8 @@ def run_scheduler_cycle(
     paper_config = paper_service.load_current_config()
     if paper_config_matches_live(paper_config, live_config):
         paper_service.process_live_history(paper_config, as_of=snapshot_time)
+        if performance_service is not None and paper_config is not None:
+            performance_service.persist_snapshot(paper_config.paper_portfolio_id, generated_at=snapshot_time)
     return decision
 
 
@@ -172,6 +176,7 @@ def run_scheduler_once(settings: AppSettings) -> SchedulerDecision:
         experiment_store = ExperimentStore(store)
         model_service = ModelService()
         paper_service = PaperTradingService(store)
+        performance_service = PerformanceObservatoryService(store)
         return run_scheduler_cycle(
             settings=settings,
             store=store,
@@ -184,6 +189,7 @@ def run_scheduler_once(settings: AppSettings) -> SchedulerDecision:
             experiment_store=experiment_store,
             model_service=model_service,
             paper_service=paper_service,
+            performance_service=performance_service,
         )
     finally:
         release_refresh_lock(settings, lock_fd)

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -69,6 +69,17 @@ from .paper_trading import (
     ensure_paper_trade_ledger_frame,
     paper_config_matches_live,
 )
+from .performance import (
+    PerformanceObservatoryService,
+    build_equity_comparison_frame,
+    build_live_score_drift_frame,
+    build_performance_summary,
+    build_rolling_return_frame,
+    build_score_bucket_outcome_frame,
+    build_score_outcome_frame,
+    build_winner_distribution_frame,
+    ensure_performance_diagnostic_frame,
+)
 from .runtime import (
     append_refresh_history as runtime_append_refresh_history,
     build_source_adapters as runtime_build_source_adapters,
@@ -3474,6 +3485,7 @@ def render_live_monitor(
         return
 
     paper_service = PaperTradingService(store)
+    performance_service = PerformanceObservatoryService(store)
     active_run_rows = joint_portfolio_runs.loc[
         joint_portfolio_runs["run_id"].astype(str) == str(active_config.portfolio_run_id)
     ].copy()
@@ -3532,7 +3544,7 @@ def render_live_monitor(
     winner_row = winner_rows.iloc[0] if not winner_rows.empty else None
     winner_confidence = float(winner_row["confidence"]) if winner_row is not None else 0.0
     display_asset = winner_asset or "FLAT"
-    tabs = st.tabs(["Current Decision", "Why This Asset Won", "History", "Paper Portfolio"])
+    tabs = st.tabs(["Current Decision", "Why This Asset Won", "History", "Paper Portfolio", "Performance Observatory"])
 
     with tabs[0]:
         metric_cols = st.columns(8)
@@ -3925,6 +3937,238 @@ def render_live_monitor(
                     use_container_width=True,
                     hide_index=True,
                 )
+
+    with tabs[4]:
+        st.caption("Warn-only observability for the selected paper portfolio. These diagnostics do not gate live decisions, retrain models, or change trading behavior.")
+        registry = paper_service.list_portfolios()
+        if registry.empty:
+            st.info("Create a paper portfolio before using the Performance Observatory.")
+        else:
+            registry_view = registry.copy()
+            registry_view["status"] = np.where(
+                registry_view["archived_at"].notna(),
+                "archived",
+                np.where(registry_view["enabled"], "active", "disabled"),
+            )
+            option_ids = registry_view["paper_portfolio_id"].astype(str).tolist()
+            current_config = paper_service.load_current_config()
+            default_performance_id = (
+                current_config.paper_portfolio_id
+                if current_config is not None and str(current_config.paper_portfolio_id) in option_ids
+                else option_ids[0]
+            )
+            selected_performance_id = st.selectbox(
+                "Performance portfolio",
+                options=option_ids,
+                index=option_ids.index(default_performance_id) if default_performance_id in option_ids else 0,
+                format_func=lambda paper_id: (
+                    lambda row: f"{paper_id} | {row['status']} | {row['portfolio_run_name']} | {row['deployment_variant'] or 'n/a'}"
+                )(registry_view.loc[registry_view["paper_portfolio_id"].astype(str) == str(paper_id)].iloc[0]),
+                key="performance-observatory-portfolio-select",
+            )
+            selected_performance_row = registry_view.loc[
+                registry_view["paper_portfolio_id"].astype(str) == str(selected_performance_id)
+            ].iloc[0]
+
+            diagnostics = performance_service.load_latest_for_portfolio(selected_performance_id)
+            if diagnostics.empty:
+                diagnostics = performance_service.evaluate_paper_portfolio(
+                    selected_performance_id,
+                    generated_at=board_generated_at,
+                )
+                st.caption("No persisted observability snapshot exists yet, so the dashboard is showing a current in-memory evaluation.")
+            else:
+                latest_generated_at = diagnostics["generated_at"].max()
+                st.caption(
+                    "Showing the latest persisted observability snapshot"
+                    + (f" from {pd.Timestamp(latest_generated_at):%Y-%m-%d %H:%M UTC}." if pd.notna(latest_generated_at) else "."),
+                )
+
+            observatory_registry = ensure_paper_portfolio_registry_frame(store.read_frame("paper_portfolio_registry"))
+            observatory_journal = ensure_paper_decision_journal_frame(store.read_frame("paper_decision_journal"))
+            observatory_trades = ensure_paper_trade_ledger_frame(store.read_frame("paper_trade_ledger"))
+            observatory_equity = ensure_paper_equity_curve_frame(store.read_frame("paper_equity_curve"))
+            observatory_benchmark = ensure_paper_benchmark_curve_frame(store.read_frame("paper_benchmark_curve"))
+            summary = build_performance_summary(
+                diagnostics=diagnostics,
+                registry=observatory_registry,
+                journal=observatory_journal,
+                trades=observatory_trades,
+                equity=observatory_equity,
+                benchmark=observatory_benchmark,
+                paper_portfolio_id=selected_performance_id,
+            )
+
+            def _pct_or_na(value: object) -> str:
+                numeric = pd.to_numeric(value, errors="coerce")
+                return f"{float(numeric):+.2%}" if pd.notna(numeric) else "n/a"
+
+            def _num_or_na(value: object) -> str:
+                numeric = pd.to_numeric(value, errors="coerce")
+                return f"{float(numeric):.2f}" if pd.notna(numeric) else "n/a"
+
+            perf_cols = st.columns(5)
+            perf_cols[0].metric("Overall", str(summary.get("overall_severity", "ok")).upper())
+            perf_cols[1].metric("Total return", _pct_or_na(summary.get("total_return")))
+            perf_cols[2].metric("SPY return", _pct_or_na(summary.get("benchmark_return")))
+            perf_cols[3].metric("Alpha", _pct_or_na(summary.get("alpha")))
+            perf_cols[4].metric("Max drawdown", _pct_or_na(summary.get("max_drawdown")))
+            quality_cols = st.columns(5)
+            quality_cols[0].metric("Win rate", _pct_or_na(summary.get("win_rate")))
+            quality_cols[1].metric("Trade count", f"{int(summary.get('trade_count', 0)):,}")
+            quality_cols[2].metric("Pending decisions", f"{int(summary.get('pending_decisions', 0)):,}")
+            quality_cols[3].metric("Fallback rate", _pct_or_na(summary.get("fallback_rate")))
+            quality_cols[4].metric("Score/outcome corr", _num_or_na(summary.get("score_outcome_correlation")))
+
+            equity_compare = build_equity_comparison_frame(
+                observatory_equity,
+                observatory_benchmark,
+                selected_performance_id,
+            )
+            rolling_returns = build_rolling_return_frame(observatory_trades, selected_performance_id)
+            score_outcomes = build_score_outcome_frame(
+                observatory_journal,
+                observatory_trades,
+                selected_performance_id,
+            )
+            winner_distribution = build_winner_distribution_frame(observatory_journal, selected_performance_id)
+            drift_frame = build_live_score_drift_frame(
+                live_asset_snapshots=store.read_frame("live_asset_snapshots"),
+                portfolio_run_id=str(selected_performance_row.get("portfolio_run_id", "") or ""),
+                deployment_variant=str(selected_performance_row.get("deployment_variant", "") or ""),
+            )
+
+            chart_cols = st.columns(2)
+            with chart_cols[0]:
+                if equity_compare.empty:
+                    st.info("No equity history is available yet.")
+                else:
+                    equity_fig = go.Figure()
+                    equity_fig.add_trace(
+                        go.Scatter(
+                            x=equity_compare["next_session_date"],
+                            y=equity_compare["paper_portfolio_equity"],
+                            mode="lines+markers",
+                            name="Paper portfolio",
+                        ),
+                    )
+                    if "spy_benchmark_equity" in equity_compare.columns:
+                        equity_fig.add_trace(
+                            go.Scatter(
+                                x=equity_compare["next_session_date"],
+                                y=equity_compare["spy_benchmark_equity"],
+                                mode="lines+markers",
+                                name="SPY benchmark",
+                            ),
+                        )
+                    equity_fig.update_layout(title="Equity vs SPY", xaxis_title="Session", yaxis_title="Equity")
+                    st.plotly_chart(equity_fig, use_container_width=True)
+
+            with chart_cols[1]:
+                if rolling_returns.empty:
+                    st.info("No settled trade returns are available yet.")
+                else:
+                    rolling_fig = go.Figure()
+                    rolling_fig.add_trace(
+                        go.Scatter(
+                            x=rolling_returns["next_session_date"],
+                            y=rolling_returns["rolling_net_return"],
+                            mode="lines+markers",
+                            name="Rolling net return",
+                        ),
+                    )
+                    rolling_fig.update_layout(title="Rolling net return", xaxis_title="Session", yaxis_title="Return")
+                    st.plotly_chart(rolling_fig, use_container_width=True)
+
+            calibration_cols = st.columns(2)
+            with calibration_cols[0]:
+                if score_outcomes.empty:
+                    st.info("No score/outcome pairs are available yet.")
+                else:
+                    score_fig = go.Figure()
+                    for asset_symbol, group in score_outcomes.groupby(score_outcomes["winning_asset"].astype(str)):
+                        score_fig.add_trace(
+                            go.Scatter(
+                                x=group["winner_score"],
+                                y=group["net_return"],
+                                mode="markers",
+                                name=str(asset_symbol or "unknown"),
+                            ),
+                        )
+                    score_fig.update_layout(title="Winner score vs realized return", xaxis_title="Winner score", yaxis_title="Net return")
+                    st.plotly_chart(score_fig, use_container_width=True)
+
+            with calibration_cols[1]:
+                if winner_distribution.empty:
+                    st.info("No paper decisions are available yet.")
+                else:
+                    winner_fig = go.Figure(
+                        data=[
+                            go.Bar(
+                                x=winner_distribution["winning_asset"],
+                                y=winner_distribution["decision_count"],
+                                name="Decisions",
+                            ),
+                        ],
+                    )
+                    winner_fig.update_layout(title="Winner asset distribution", xaxis_title="Asset", yaxis_title="Decisions")
+                    st.plotly_chart(winner_fig, use_container_width=True)
+
+            if drift_frame.empty:
+                st.info("No live score drift history is available yet.")
+            else:
+                drift_fig = go.Figure()
+                for metric_name, group in drift_frame.groupby("metric_name", sort=False):
+                    drift_fig.add_trace(
+                        go.Bar(
+                            x=group["asset_symbol"],
+                            y=group["z_score"],
+                            name=str(metric_name),
+                        ),
+                    )
+                drift_fig.update_layout(
+                    title="Live score drift by asset",
+                    xaxis_title="Asset",
+                    yaxis_title="Recent-vs-baseline z score",
+                    barmode="group",
+                )
+                st.plotly_chart(drift_fig, use_container_width=True)
+                st.dataframe(drift_frame, use_container_width=True, hide_index=True)
+
+            score_buckets = build_score_bucket_outcome_frame(
+                observatory_journal,
+                observatory_trades,
+                selected_performance_id,
+            )
+            if not score_buckets.empty:
+                st.markdown("**Score bucket outcomes**")
+                st.dataframe(score_buckets, use_container_width=True, hide_index=True)
+
+            st.markdown("**Latest diagnostics**")
+            normalized_diagnostics = ensure_performance_diagnostic_frame(diagnostics)
+            if normalized_diagnostics.empty:
+                st.info("No diagnostics are available for this portfolio yet.")
+            else:
+                severity_options = ["ok", "warn", "severe"]
+                selected_severities = st.multiselect(
+                    "Severity filter",
+                    options=severity_options,
+                    default=["warn", "severe"],
+                    key="performance-observatory-severity-filter",
+                )
+                scope_options = sorted(normalized_diagnostics["scope_kind"].dropna().astype(str).unique().tolist())
+                selected_scopes = st.multiselect(
+                    "Scope filter",
+                    options=scope_options,
+                    default=scope_options,
+                    key="performance-observatory-scope-filter",
+                )
+                diagnostics_view = normalized_diagnostics.copy()
+                if selected_severities:
+                    diagnostics_view = diagnostics_view.loc[diagnostics_view["severity"].isin(selected_severities)].copy()
+                if selected_scopes:
+                    diagnostics_view = diagnostics_view.loc[diagnostics_view["scope_kind"].astype(str).isin(selected_scopes)].copy()
+                st.dataframe(diagnostics_view, use_container_width=True, hide_index=True)
 
 
 def render_historical_replay_view(


### PR DESCRIPTION
## Summary
- add a PerformanceObservatoryService that computes warn-only portfolio outcome, decision-quality, and live drift diagnostics from existing live/paper datasets
- persist model_performance_latest and model_performance_history from scheduler cycles after paper trading processing
- add a Live Monitor Performance Observatory tab with summary metrics, equity/return/calibration/distribution/drift charts, and filtered diagnostic rows
- document the new observatory behavior and add unit, integration, scheduler, and UI source-inspection coverage

## Validation
- bash scripts/ci.sh