### PR TITLE
Add frontend UI testing baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - name: Check out repository
@@ -45,6 +45,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
+
+      - name: Install Playwright system dependencies
+        run: npx --prefix frontend playwright install-deps chromium
 
       - name: Run shared CI entrypoint
         run: bash scripts/ci.sh

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   health-check:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - name: Check out repository
@@ -41,6 +41,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
+
+      - name: Install Playwright system dependencies
+        run: npx --prefix frontend playwright install-deps chromium
 
       - name: Run shared CI entrypoint
         run: bash scripts/ci.sh

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ htmlcov/
 docker-state/
 frontend/dist/
 frontend/node_modules/
+frontend/playwright-report/
+frontend/test-results/
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Optional frontend env var:
 
 The FastAPI surface is intentionally read-only in this slice. Admin mutations, model training, and refresh workflows still live in Streamlit until they are moved behind explicit job APIs.
 
+Run browser UI tests for the React shell:
+
+```bash
+npm exec --prefix frontend playwright install chromium
+npm run test:ui --prefix frontend
+```
+
 On the first launch, the app may take a little longer because it can bootstrap local working datasets automatically.
 
 The app opens as a multi-page Streamlit workbench with these sections:
@@ -479,6 +486,8 @@ The code is organized as a modular monolith under `trump_workbench/`:
 - `experiments.py` for saved runs and artifacts
 - `research.py` for descriptive visualization helpers
 - `ui.py` for the Streamlit app shell
+- `api.py` for the read-only FastAPI migration surface
+- `frontend/` for the React + TypeScript web shell
 
 ## Testing
 
@@ -499,4 +508,17 @@ Run the configured coverage report:
 ```bash
 python -m coverage run -m unittest discover -s tests
 python -m coverage report -m
+```
+
+Run the React browser UI tests:
+
+```bash
+npm exec --prefix frontend playwright install chromium
+npm run test:ui --prefix frontend
+```
+
+Run the same checks as GitHub Actions:
+
+```bash
+bash scripts/ci.sh
 ```

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -1,0 +1,218 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const statusPayload = {
+  title: "Trump Social Trading Research Workbench",
+  mode: "private",
+  state_root: "/tmp/allcaps-test-state",
+  db_path: "/tmp/allcaps-test-state/.workbench/workbench.duckdb",
+  source_mode: {
+    mode: "truth_only",
+    truth_post_count: 42,
+    x_post_count: 0,
+  },
+  missing_core_datasets: [],
+  dataset_count: 9,
+};
+
+const healthPayload = {
+  summary: {
+    overall_severity: "warn",
+    severe_count: 0,
+    warn_count: 1,
+    last_refresh_status: "success",
+  },
+  latest: [
+    {
+      scope_kind: "dataset",
+      scope_key: "asset_intraday",
+      check_name: "freshness_hours",
+      severity: "warn",
+      observed_value: 7.5,
+      detail: "Latest intraday row is stale.",
+    },
+    {
+      scope_kind: "dataset",
+      scope_key: "normalized_posts",
+      check_name: "dataset_presence",
+      severity: "ok",
+      observed_value: 42,
+      detail: "",
+    },
+  ],
+  trend: [],
+  refresh_history: [
+    {
+      refresh_mode: "incremental",
+      status: "success",
+    },
+  ],
+  registry: [
+    {
+      dataset_name: "normalized_posts",
+      row_count: 42,
+      updated_at: "2026-04-20T12:00:00Z",
+    },
+  ],
+};
+
+const runsPayload = {
+  count: 1,
+  runs: [
+    {
+      run_id: "run-portfolio-1",
+      run_name: "Portfolio Alpha",
+      run_type: "portfolio_allocator",
+      allocator_mode: "joint_model",
+      target_asset: "PORTFOLIO",
+    },
+  ],
+};
+
+const livePayload = {
+  configured: true,
+  errors: [],
+  warnings: [],
+  decision: {
+    winning_asset: "QQQ",
+    decision_source: "eligible",
+    winner_score: 0.024,
+    eligible_asset_count: 2,
+  },
+  board: [
+    {
+      asset_symbol: "QQQ",
+      expected_return_score: 0.024,
+      confidence: 0.71,
+      qualifies: true,
+      is_winner: true,
+    },
+    {
+      asset_symbol: "SPY",
+      expected_return_score: 0.012,
+      confidence: 0.62,
+      qualifies: true,
+      is_winner: false,
+    },
+  ],
+};
+
+const portfoliosPayload = {
+  current_config: {
+    paper_portfolio_id: "paper-1",
+  },
+  portfolios: [
+    {
+      paper_portfolio_id: "paper-1",
+      portfolio_run_name: "Portfolio Alpha",
+      deployment_variant: "per_asset",
+      enabled: true,
+    },
+  ],
+};
+
+const performancePayload = {
+  persisted: true,
+  summary: {
+    overall_severity: "warn",
+    total_return: 0.031,
+    alpha: 0.014,
+    fallback_rate: 0.125,
+  },
+  diagnostics: [
+    {
+      scope_kind: "decision_quality",
+      scope_key: "paper-1",
+      metric_name: "score_outcome_correlation",
+      severity: "warn",
+      observed_value: -0.1,
+      detail: "Correlation is below zero.",
+    },
+    {
+      scope_kind: "portfolio",
+      scope_key: "paper-1",
+      metric_name: "win_rate",
+      severity: "ok",
+      observed_value: 0.6,
+      detail: "",
+    },
+  ],
+  equity_comparison: [],
+  rolling_returns: [],
+  score_outcomes: [],
+  score_buckets: [],
+  winner_distribution: [
+    {
+      winning_asset: "QQQ",
+      decision_count: 7,
+    },
+    {
+      winning_asset: "SPY",
+      decision_count: 3,
+    },
+  ],
+  drift: [],
+};
+
+async function fulfillJson(page: Page, path: string, payload: unknown) {
+  await page.route(`**${path}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(payload),
+    });
+  });
+}
+
+async function mockApi(page: Page) {
+  await fulfillJson(page, "/api/status", statusPayload);
+  await fulfillJson(page, "/api/datasets/health", healthPayload);
+  await fulfillJson(page, "/api/runs", runsPayload);
+  await fulfillJson(page, "/api/live/current", livePayload);
+  await fulfillJson(page, "/api/paper/portfolios", portfoliosPayload);
+  await fulfillJson(page, "/api/performance/paper-1", performancePayload);
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("renders the overview shell from API-backed data", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Web-first decision workbench" })).toBeVisible();
+  await expect(page.getByText("API base")).toBeVisible();
+  await expect(page.getByText("truth_only (42 Truth, 0 X)")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Recent saved runs" })).toBeVisible();
+  await expect(page.getByText("Portfolio Alpha")).toBeVisible();
+});
+
+test("shows data health warnings and registry rows", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /Data Health/ }).click();
+
+  await expect(page.getByRole("heading", { name: "Freshness, completeness, and anomalies" })).toBeVisible();
+  await expect(page.getByText("asset_intraday")).toBeVisible();
+  await expect(page.getByText("freshness_hours")).toBeVisible();
+  await expect(page.getByText("normalized_posts")).toBeVisible();
+});
+
+test("shows the current live decision and candidate board", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /Live Decision/ }).click();
+
+  await expect(page.getByRole("cell", { name: "QQQ" })).toBeVisible();
+  await expect(page.getByText("eligible", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Current ranked board" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "SPY" })).toBeVisible();
+});
+
+test("shows paper performance diagnostics and winner distribution", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /Paper \+ Performance/ }).click();
+
+  await expect(page.getByRole("heading", { name: "Portfolio selector" })).toBeVisible();
+  await expect(page.getByRole("combobox")).toContainText("paper-1 - Portfolio Alpha");
+  await expect(page.getByText("score_outcome_correlation")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Winner distribution" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "decision count" })).toBeVisible();
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
@@ -413,6 +414,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1327,6 +1344,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc -b && vite build",
-    "preview": "vite preview --host 127.0.0.1"
+    "preview": "vite preview --host 127.0.0.1",
+    "test:ui": "playwright test",
+    "test:ui:headed": "playwright test --headed"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.12",
@@ -14,6 +16,7 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "on-first-retry",
+    serviceWorkers: "block",
+  },
+  webServer: {
+    command: "npm run dev -- --port 5173",
+    url: "http://127.0.0.1:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -35,6 +35,9 @@ if [[ -f "$ROOT_DIR/frontend/package.json" ]]; then
     echo "==> Frontend build"
     npm ci --prefix "$ROOT_DIR/frontend"
     npm run build --prefix "$ROOT_DIR/frontend"
+    echo "==> Frontend UI tests"
+    npm exec --prefix "$ROOT_DIR/frontend" playwright install chromium
+    npm run test:ui --prefix "$ROOT_DIR/frontend"
   else
     echo "npm is required for the frontend build but was not found on PATH." >&2
     exit 1


### PR DESCRIPTION
## Summary
- add Playwright browser UI tests for the React/Vite frontend shell with mocked FastAPI responses
- cover Overview, Data Health, Live Decision, and Paper + Performance pages
- run Playwright from the shared CI path after the frontend build
- install Playwright system deps in CI/weekly-health and document local UI test commands

## GitHub Practice
- Closes #45
- feature branch: codex/frontend-ui-tests
- ready for review because local CI passes

## Validation
- npm run build --prefix frontend
- npm run test:ui --prefix frontend
- bash scripts/ci.sh