### PR TITLE
Migrate Research Asset Lab to React and FastAPI

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -345,6 +345,118 @@ const researchPayload = {
   export_filename: "research-pack-20250120-20260420.zip",
 };
 
+const researchAssetPayload = {
+  ready: true,
+  message: "",
+  source_mode: {
+    mode: "truth_only",
+    truth_post_count: 42,
+    x_post_count: 0,
+  },
+  filters: researchPayload.filters,
+  controls: {
+    selected_asset: "NVDA",
+    comparison_mode: "normalized",
+    benchmark_symbol: "QQQ",
+    pre_sessions: 3,
+    post_sessions: 5,
+    intraday_session_date: "2026-04-17",
+    intraday_anchor_post_id: "truth-asset-1",
+    before_minutes: 120,
+    after_minutes: 240,
+  },
+  asset_options: [
+    {
+      symbol: "NVDA",
+      label: "NVDA - NVIDIA",
+      source: "watchlist",
+      is_watchlist: true,
+      has_daily: true,
+    },
+    {
+      symbol: "QQQ",
+      label: "QQQ - Invesco QQQ Trust",
+      source: "etf_starter",
+      is_watchlist: false,
+      has_daily: true,
+    },
+  ],
+  benchmark_options: ["None", "QQQ", "XLK"],
+  headline_metrics: {
+    sessions_in_range: 12,
+    asset_move: 0.06,
+    mapped_post_count: 4,
+    intraday_bars: 18,
+  },
+  charts: {
+    asset_comparison: {
+      data: [{ type: "scatter", mode: "lines", x: ["2026-04-17"], y: [1.04], name: "NVDA" }],
+      layout: { title: { text: "SPY vs. selected asset" } },
+    },
+    event_study: {
+      data: [{ type: "scatter", mode: "lines+markers", x: [-1, 0, 1], y: [-0.01, 0, 0.02], name: "NVDA" }],
+      layout: { title: { text: "Event study around mapped posts" } },
+    },
+    intraday_reaction: {
+      data: [{ type: "scatter", mode: "lines", x: ["2026-04-17T13:35:00Z"], y: [0.01], name: "NVDA" }],
+      layout: { title: { text: "Intraday reaction around selected post" } },
+    },
+  },
+  asset_session_rows: [
+    {
+      trade_date: "2026-04-17",
+      post_count: 3,
+      next_session_return: 0.014,
+    },
+  ],
+  asset_mapping_rows: [
+    {
+      asset_symbol: "NVDA",
+      session_date: "2026-04-17",
+      author_handle: "realDonaldTrump",
+      match_reasons: "semantic_primary_asset",
+      post_text: "The economy is strong.",
+    },
+  ],
+  comparison_rows: [
+    {
+      trade_date: "2026-04-17",
+      spy_close: 6800,
+      asset_close: 920,
+      asset_normalized_return: 0.04,
+    },
+  ],
+  event_study_rows: [
+    {
+      symbol: "NVDA",
+      relative_session: 0,
+      avg_relative_return: 0,
+      event_count: 4,
+    },
+  ],
+  intraday_anchor_options: [
+    {
+      anchor_id: "truth-asset-1",
+      session_date: "2026-04-17",
+      label: "2026-04-17 09:35 ET | @realDonaldTrump | The economy is strong.",
+      post_timestamp: "2026-04-17T13:35:00Z",
+    },
+  ],
+  intraday_coverage: [
+    { symbol: "SPY", bars: 9 },
+    { symbol: "NVDA", bars: 9 },
+    { symbol: "QQQ", bars: 9 },
+  ],
+  intraday_rows: [
+    {
+      symbol: "NVDA",
+      timestamp: "2026-04-17T13:35:00Z",
+      normalized_return: 0.01,
+    },
+  ],
+  intraday_message: "",
+};
+
 const livePayload = {
   configured: true,
   errors: [],
@@ -447,6 +559,7 @@ async function mockApi(page: Page) {
   await fulfillJson(page, "/api/runs/run-portfolio-1**", runDetailPayload);
   await fulfillJson(page, "/api/runs/compare**", runComparisonPayload);
   await fulfillJson(page, "/api/research**", researchPayload);
+  await fulfillJson(page, "/api/research/assets**", researchAssetPayload);
   await fulfillJson(page, "/api/live/current", livePayload);
   await fulfillJson(page, "/api/paper/portfolios", portfoliosPayload);
   await fulfillJson(page, "/api/performance/paper-1", performancePayload);
@@ -491,6 +604,18 @@ test("shows the migrated research workspace with narratives and export", async (
   await expect(page.getByRole("heading", { name: "Structured narrative inspection" })).toBeVisible();
   await expect(page.getByRole("cell", { name: "markets" }).first()).toBeVisible();
   await expect(page.getByText("heuristic-fallback")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Multi-asset comparison, event study, and intraday reaction" })).toBeVisible();
+  await expect(page.locator("label", { hasText: "Selected asset" }).locator("select")).toHaveValue("NVDA");
+  await expect(page.getByLabel("ETF baseline")).toHaveValue("QQQ");
+  await expect(page.getByText("Mapped posts", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "SPY vs. selected asset" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Event study", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Intraday reaction", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Mapped posts for selected asset" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "realDonaldTrump" }).first()).toBeVisible();
+  await expect(page.getByRole("cell", { name: "semantic_primary_asset" }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Intraday coverage" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "NVDA" }).first()).toBeVisible();
 });
 
 test("shows the migrated run explorer with detail and comparison tables", async ({ page }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import createPlotlyComponentModule from "react-plotly.js/factory";
 import Plotly from "plotly.js-dist-min";
 import type { Data, Frame, Layout } from "plotly.js";
-import { api, type PlotlyFigure, type RecordRow, type ResearchFilters } from "./api";
+import { api, type PlotlyFigure, type RecordRow, type ResearchAssetFilters, type ResearchFilters } from "./api";
 
 type PlotComponentFactory = (plotly: unknown) => ComponentType<Record<string, unknown>>;
 const createPlotlyComponent = (
@@ -126,12 +126,30 @@ function DataTable({ rows, emptyLabel = "No rows returned yet." }: { rows: Recor
 
 function ResearchPage() {
   const [filters, setFilters] = useState<ResearchFilters>({});
+  const [assetFilters, setAssetFilters] = useState<ResearchAssetFilters>({});
   const research = useQuery({ queryKey: ["research", filters], queryFn: () => api.research(filters) });
 
   const payload = research.data;
   const currentFilters = { ...(payload?.filters ?? {}), ...filters };
+  const assetQueryFilters: ResearchAssetFilters = {
+    date_start: currentFilters.date_start,
+    date_end: currentFilters.date_end,
+    platforms: currentFilters.platforms,
+    include_reshares: currentFilters.include_reshares,
+    tracked_only: currentFilters.tracked_only,
+    trump_authored_only: currentFilters.trump_authored_only,
+    keyword: currentFilters.keyword,
+    ...assetFilters,
+  };
+  const assetLab = useQuery({
+    queryKey: ["research-assets", assetQueryFilters],
+    queryFn: () => api.researchAssets(assetQueryFilters),
+  });
+  const assetPayload = assetLab.data;
+  const currentAssetControls = { ...(assetPayload?.controls ?? {}), ...assetFilters };
   const options = payload?.narrative_filter_options ?? {};
   const updateFilters = (next: ResearchFilters) => setFilters((previous) => ({ ...previous, ...next }));
+  const updateAssetFilters = (next: ResearchAssetFilters) => setAssetFilters((previous) => ({ ...previous, ...next }));
 
   if (research.isLoading) {
     return <LoadingBlock label="Loading research workspace..." />;
@@ -405,6 +423,173 @@ function ResearchPage() {
           <h2>Provider and cache indicators</h2>
         </div>
         <DataTable rows={payload?.provider_summary ?? []} />
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <div>
+            <p className="eyebrow">Asset Lab</p>
+            <h2>Multi-asset comparison, event study, and intraday reaction</h2>
+          </div>
+          <StatusPill label={assetPayload?.ready ? "Stored data" : "Setup needed"} tone={assetPayload?.ready ? "ok" : "warn"} />
+        </div>
+        {assetLab.isLoading ? <LoadingBlock label="Loading asset lab..." /> : null}
+        {assetLab.error ? <ErrorBlock error={assetLab.error} /> : null}
+        {assetPayload && !assetPayload.ready ? <div className="empty-state">{assetPayload.message}</div> : null}
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Selected asset
+            <select
+              value={String(currentAssetControls.selected_asset ?? "")}
+              onChange={(event) => {
+                updateAssetFilters({
+                  selected_asset: event.target.value,
+                  benchmark_symbol: "None",
+                  intraday_session_date: "",
+                  intraday_anchor_post_id: "",
+                });
+              }}
+            >
+              {(assetPayload?.asset_options ?? []).map((option) => (
+                <option key={option.symbol} value={option.symbol}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Comparison mode
+            <select
+              value={String(currentAssetControls.comparison_mode ?? "normalized")}
+              onChange={(event) => updateAssetFilters({ comparison_mode: event.target.value as "price" | "normalized" })}
+            >
+              <option value="normalized">Normalized returns</option>
+              <option value="price">Price overlay</option>
+            </select>
+          </label>
+          <label>
+            ETF baseline
+            <select
+              value={String(currentAssetControls.benchmark_symbol ?? "None")}
+              onChange={(event) => updateAssetFilters({ benchmark_symbol: event.target.value, intraday_anchor_post_id: "" })}
+            >
+              {(assetPayload?.benchmark_options ?? ["None"]).map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Intraday anchor
+            <select
+              value={String(currentAssetControls.intraday_anchor_post_id ?? "")}
+              onChange={(event) => {
+                const option = assetPayload?.intraday_anchor_options.find((item) => item.anchor_id === event.target.value);
+                updateAssetFilters({
+                  intraday_anchor_post_id: event.target.value,
+                  intraday_session_date: option?.session_date ?? "",
+                });
+              }}
+            >
+              <option value="">Latest eligible anchor</option>
+              {(assetPayload?.intraday_anchor_options ?? []).map((option) => (
+                <option key={option.anchor_id} value={option.anchor_id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Sessions before
+            <input
+              type="number"
+              min={1}
+              max={10}
+              value={Number(currentAssetControls.pre_sessions ?? 3)}
+              onChange={(event) => updateAssetFilters({ pre_sessions: Number(event.target.value) })}
+            />
+          </label>
+          <label>
+            Sessions after
+            <input
+              type="number"
+              min={1}
+              max={10}
+              value={Number(currentAssetControls.post_sessions ?? 5)}
+              onChange={(event) => updateAssetFilters({ post_sessions: Number(event.target.value) })}
+            />
+          </label>
+          <label>
+            Minutes before
+            <input
+              type="number"
+              min={30}
+              max={390}
+              step={30}
+              value={Number(currentAssetControls.before_minutes ?? 120)}
+              onChange={(event) => updateAssetFilters({ before_minutes: Number(event.target.value) })}
+            />
+          </label>
+          <label>
+            Minutes after
+            <input
+              type="number"
+              min={30}
+              max={780}
+              step={30}
+              value={Number(currentAssetControls.after_minutes ?? 240)}
+              onChange={(event) => updateAssetFilters({ after_minutes: Number(event.target.value) })}
+            />
+          </label>
+        </div>
+        <div className="metric-grid metric-grid--small">
+          <MetricCard label="Sessions" value={assetPayload?.headline_metrics.sessions_in_range ?? 0} />
+          <MetricCard label="Asset move" value={assetPayload?.headline_metrics.asset_move ?? null} />
+          <MetricCard label="Mapped posts" value={assetPayload?.headline_metrics.mapped_post_count ?? 0} />
+          <MetricCard label="Intraday bars" value={assetPayload?.headline_metrics.intraday_bars ?? 0} />
+        </div>
+      </article>
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>SPY vs. selected asset</h2>
+          <PlotlyChart figure={assetPayload?.charts.asset_comparison} title="SPY vs. selected asset" />
+        </div>
+        <div>
+          <h2>Event study</h2>
+          <PlotlyChart figure={assetPayload?.charts.event_study} title="Asset event study" />
+        </div>
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Intraday reaction</h2>
+        </div>
+        {assetPayload?.intraday_message ? <div className="empty-state">{assetPayload.intraday_message}</div> : null}
+        <PlotlyChart figure={assetPayload?.charts.intraday_reaction} title="Intraday reaction" />
+      </article>
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>Asset session summary</h2>
+          <DataTable rows={assetPayload?.asset_session_rows ?? []} />
+        </div>
+        <div>
+          <h2>Mapped posts for selected asset</h2>
+          <DataTable rows={assetPayload?.asset_mapping_rows ?? []} />
+        </div>
+      </article>
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>Event-study rows</h2>
+          <DataTable rows={assetPayload?.event_study_rows ?? []} />
+        </div>
+        <div>
+          <h2>Intraday coverage</h2>
+          <DataTable rows={assetPayload?.intraday_coverage ?? []} />
+        </div>
       </article>
     </section>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -181,6 +181,66 @@ export type ResearchPayload = {
   export_filename: string;
 };
 
+export type ResearchAssetFilters = Pick<
+  ResearchFilters,
+  "date_start" | "date_end" | "platforms" | "include_reshares" | "tracked_only" | "trump_authored_only" | "keyword"
+> & {
+  selected_asset?: string;
+  comparison_mode?: "price" | "normalized";
+  benchmark_symbol?: string;
+  pre_sessions?: number;
+  post_sessions?: number;
+  intraday_session_date?: string;
+  intraday_anchor_post_id?: string;
+  before_minutes?: number;
+  after_minutes?: number;
+};
+
+export type ResearchAssetPayload = {
+  ready: boolean;
+  message: string;
+  source_mode: StatusPayload["source_mode"];
+  filters: ResearchPayload["filters"];
+  controls: {
+    selected_asset: string;
+    comparison_mode: "price" | "normalized";
+    benchmark_symbol: string;
+    pre_sessions: number;
+    post_sessions: number;
+    before_minutes: number;
+    after_minutes: number;
+    intraday_session_date: string;
+    intraday_anchor_post_id: string;
+  };
+  asset_options: Array<{
+    symbol: string;
+    label: string;
+    source: string;
+    is_watchlist: boolean;
+    has_daily: boolean;
+  }>;
+  benchmark_options: string[];
+  headline_metrics: RecordRow;
+  charts: {
+    asset_comparison?: PlotlyFigure;
+    event_study?: PlotlyFigure;
+    intraday_reaction?: PlotlyFigure;
+  };
+  asset_session_rows: RecordRow[];
+  asset_mapping_rows: RecordRow[];
+  comparison_rows: RecordRow[];
+  event_study_rows: RecordRow[];
+  intraday_anchor_options: Array<{
+    anchor_id: string;
+    session_date: string;
+    label: string;
+    post_timestamp: string;
+  }>;
+  intraday_coverage: RecordRow[];
+  intraday_rows: RecordRow[];
+  intraday_message: string;
+};
+
 function researchQuery(filters: ResearchFilters = {}): string {
   const params = new URLSearchParams();
   Object.entries(filters).forEach(([key, value]) => {
@@ -235,6 +295,7 @@ export const api = {
     return getJson<RunComparisonPayload>(`/api/runs/compare${query ? `?${query}` : ""}`);
   },
   research: (filters?: ResearchFilters) => getJson<ResearchPayload>(`/api/research${researchQuery(filters)}`),
+  researchAssets: (filters?: ResearchAssetFilters) => getJson<ResearchAssetPayload>(`/api/research/assets${researchQuery(filters)}`),
   researchExportUrl: (filters?: ResearchFilters) => `${API_BASE_URL}/api/research/export${researchQuery(filters)}`,
   live: () => getJson<LivePayload>("/api/live/current"),
   paperPortfolios: () => getJson<PaperPortfoliosPayload>("/api/paper/portfolios"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,6 +125,118 @@ class ApiContractTests(unittest.TestCase):
             ),
         )
 
+    def _save_asset_lab_frames(self, include_intraday: bool = True) -> None:
+        self._save_research_frames(include_x=True)
+        self.store.save_frame(
+            "asset_daily",
+            pd.DataFrame(
+                [
+                    {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-03"), "open": 100.0, "high": 102.0, "low": 99.0, "close": 100.0, "volume": 1000},
+                    {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-04"), "open": 100.5, "high": 103.0, "low": 100.0, "close": 101.0, "volume": 1100},
+                    {"symbol": "SPY", "trade_date": pd.Timestamp("2025-02-05"), "open": 101.0, "high": 102.0, "low": 98.0, "close": 99.0, "volume": 1200},
+                    {"symbol": "NVDA", "trade_date": pd.Timestamp("2025-02-03"), "open": 200.0, "high": 205.0, "low": 198.0, "close": 200.0, "volume": 2000},
+                    {"symbol": "NVDA", "trade_date": pd.Timestamp("2025-02-04"), "open": 203.0, "high": 211.0, "low": 202.0, "close": 210.0, "volume": 2200},
+                    {"symbol": "NVDA", "trade_date": pd.Timestamp("2025-02-05"), "open": 210.0, "high": 212.0, "low": 205.0, "close": 208.0, "volume": 2100},
+                    {"symbol": "QQQ", "trade_date": pd.Timestamp("2025-02-03"), "open": 300.0, "high": 303.0, "low": 298.0, "close": 300.0, "volume": 3000},
+                    {"symbol": "QQQ", "trade_date": pd.Timestamp("2025-02-04"), "open": 301.0, "high": 306.0, "low": 300.0, "close": 303.0, "volume": 3100},
+                    {"symbol": "QQQ", "trade_date": pd.Timestamp("2025-02-05"), "open": 303.0, "high": 304.0, "low": 299.0, "close": 301.0, "volume": 3200},
+                ],
+            ),
+        )
+        self.store.save_frame(
+            "asset_session_features",
+            pd.DataFrame(
+                [
+                    {
+                        "asset_symbol": "NVDA",
+                        "signal_session_date": pd.Timestamp("2025-02-03"),
+                        "post_count": 2,
+                        "rule_matched_post_count": 1,
+                        "semantic_matched_post_count": 1,
+                        "primary_match_post_count": 1,
+                        "asset_relevance_score_avg": 0.8,
+                        "sentiment_avg": 0.15,
+                        "target_next_session_return": 0.05,
+                        "target_available": True,
+                    },
+                    {
+                        "asset_symbol": "NVDA",
+                        "signal_session_date": pd.Timestamp("2025-02-04"),
+                        "post_count": 1,
+                        "rule_matched_post_count": 1,
+                        "semantic_matched_post_count": 0,
+                        "primary_match_post_count": 1,
+                        "asset_relevance_score_avg": 0.6,
+                        "sentiment_avg": 0.4,
+                        "target_next_session_return": -0.01,
+                        "target_available": True,
+                    },
+                ],
+            ),
+        )
+        self.store.save_frame(
+            "asset_post_mappings",
+            pd.DataFrame(
+                [
+                    {
+                        "asset_symbol": "NVDA",
+                        "session_date": pd.Timestamp("2025-02-03"),
+                        "post_id": "truth-1",
+                        "post_timestamp": pd.Timestamp("2025-02-03 08:00:00", tz="America/New_York"),
+                        "reaction_anchor_ts": pd.Timestamp("2025-02-03 09:35:00", tz="America/New_York"),
+                        "author_handle": "realDonaldTrump",
+                        "author_display_name": "Donald Trump",
+                        "source_platform": "Truth Social",
+                        "author_is_trump": True,
+                        "is_active_tracked_account": False,
+                        "asset_relevance_score": 0.9,
+                        "rule_match_score": 1.0,
+                        "semantic_match_score": 0.8,
+                        "match_rank": 1,
+                        "is_primary_asset": True,
+                        "match_reasons": "semantic_primary_asset",
+                        "cleaned_text": "The stock market and economy are looking strong.",
+                    },
+                    {
+                        "asset_symbol": "NVDA",
+                        "session_date": pd.Timestamp("2025-02-03"),
+                        "post_id": "x-1",
+                        "post_timestamp": pd.Timestamp("2025-02-03 10:00:00", tz="America/New_York"),
+                        "reaction_anchor_ts": pd.Timestamp("2025-02-03 10:00:00", tz="America/New_York"),
+                        "author_handle": "macroalpha",
+                        "author_display_name": "Macro Alpha",
+                        "source_platform": "X",
+                        "author_is_trump": False,
+                        "is_active_tracked_account": False,
+                        "asset_relevance_score": 0.7,
+                        "rule_match_score": 0.8,
+                        "semantic_match_score": 0.6,
+                        "match_rank": 2,
+                        "is_primary_asset": False,
+                        "match_reasons": "keyword",
+                        "cleaned_text": "Trump tariff headlines could pressure semiconductors.",
+                    },
+                ],
+            ),
+        )
+        intraday_rows = []
+        if include_intraday:
+            for symbol, base in [("SPY", 100.0), ("NVDA", 200.0), ("QQQ", 300.0)]:
+                for index, minute in enumerate([0, 5, 10, 15, 20, 25, 30]):
+                    intraday_rows.append(
+                        {
+                            "symbol": symbol,
+                            "timestamp": pd.Timestamp("2025-02-03 09:30:00", tz="America/New_York") + pd.Timedelta(minutes=minute),
+                            "open": base + index,
+                            "high": base + index + 1,
+                            "low": base + index - 1,
+                            "close": base + index,
+                            "volume": 100 + index,
+                            "interval": "5m",
+                        },
+                    )
+        self.store.save_frame("asset_intraday", pd.DataFrame(intraday_rows))
+
     def _save_run_record(self) -> None:
         self.store.save_run_record(
             run_id="run-1",
@@ -624,6 +736,95 @@ class ApiContractTests(unittest.TestCase):
             self.assertEqual(manifest["source_mode"]["mode"], "truth_only")
             self.assertTrue(manifest["filters"]["trump_authored_only"])
             self.assertEqual(manifest["headline_metrics"]["posts_in_view"], 1)
+
+    def test_research_asset_lab_returns_empty_state_without_asset_data(self) -> None:
+        response = self.client.get("/api/research/assets")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["ready"])
+        self.assertEqual(payload["asset_options"], [])
+        self.assertIn("Refresh datasets", payload["message"])
+        self.assertIn("asset_comparison", payload["charts"])
+
+    def test_research_asset_lab_uses_watchlist_default_and_filters_mapped_posts(self) -> None:
+        self._save_asset_lab_frames()
+
+        response = self.client.get(
+            "/api/research/assets",
+            params=[
+                ("date_start", "2025-02-03"),
+                ("date_end", "2025-02-05"),
+                ("platforms", "Truth Social"),
+                ("trump_authored_only", "true"),
+                ("comparison_mode", "price"),
+                ("benchmark_symbol", "QQQ"),
+                ("pre_sessions", "2"),
+                ("post_sessions", "4"),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ready"])
+        self.assertEqual(payload["controls"]["selected_asset"], "NVDA")
+        self.assertEqual(payload["controls"]["comparison_mode"], "price")
+        self.assertEqual(payload["controls"]["benchmark_symbol"], "QQQ")
+        self.assertEqual(payload["filters"]["platforms"], ["Truth Social"])
+        self.assertEqual(payload["headline_metrics"]["mapped_post_count"], 1)
+        self.assertEqual(len(payload["asset_mapping_rows"]), 1)
+        self.assertEqual(payload["asset_mapping_rows"][0]["author_handle"], "realDonaldTrump")
+        self.assertGreaterEqual(len(payload["comparison_rows"]), 3)
+        self.assertGreaterEqual(len(payload["event_study_rows"]), 1)
+        self.assertIn("asset_comparison", payload["charts"])
+        self.assertIn("event_study", payload["charts"])
+
+    def test_research_asset_lab_returns_intraday_window_and_coverage(self) -> None:
+        self._save_asset_lab_frames()
+
+        response = self.client.get(
+            "/api/research/assets",
+            params=[
+                ("date_start", "2025-02-03"),
+                ("date_end", "2025-02-05"),
+                ("selected_asset", "NVDA"),
+                ("benchmark_symbol", "QQQ"),
+                ("before_minutes", "30"),
+                ("after_minutes", "60"),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ready"])
+        self.assertGreaterEqual(len(payload["intraday_anchor_options"]), 1)
+        self.assertEqual(payload["controls"]["intraday_anchor_post_id"], "truth-1")
+        self.assertGreaterEqual(len(payload["intraday_rows"]), 1)
+        self.assertSetEqual(
+            {row["symbol"] for row in payload["intraday_coverage"]},
+            {"SPY", "NVDA", "QQQ"},
+        )
+        self.assertEqual(payload["intraday_message"], "")
+        self.assertIn("intraday_reaction", payload["charts"])
+
+    def test_research_asset_lab_reports_missing_intraday_coverage_without_failing(self) -> None:
+        self._save_asset_lab_frames(include_intraday=False)
+
+        response = self.client.get(
+            "/api/research/assets",
+            params=[
+                ("date_start", "2025-02-03"),
+                ("date_end", "2025-02-05"),
+                ("selected_asset", "NVDA"),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ready"])
+        self.assertEqual(payload["intraday_anchor_options"], [])
+        self.assertEqual(payload["intraday_rows"], [])
+        self.assertIn("No stored intraday data", payload["intraday_message"])
 
     def test_dataset_health_returns_summary_rows_and_registry(self) -> None:
         self._save_truth_posts()

--- a/trump_workbench/api.py
+++ b/trump_workbench/api.py
@@ -32,6 +32,7 @@ from .performance import (
     build_winner_distribution_frame,
 )
 from .runtime import missing_core_datasets
+from .research_asset_lab import build_research_asset_lab
 from .research_workspace import build_research_workspace, detect_source_mode
 from .run_explorer import build_run_comparison_payload, build_run_detail_payload
 from .storage import DuckDBStore
@@ -192,6 +193,48 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
             content=result.export_bundle,
             media_type="application/zip",
             headers={"Content-Disposition": f'attachment; filename="{result.export_filename}"'},
+        )
+
+    @app.get("/api/research/assets")
+    def research_assets(
+        date_start: str | None = None,
+        date_end: str | None = None,
+        platforms: list[str] | None = Query(default=None),
+        include_reshares: bool | None = None,
+        tracked_only: bool | None = None,
+        trump_authored_only: bool | None = None,
+        keyword: str | None = None,
+        selected_asset: str | None = None,
+        comparison_mode: str | None = None,
+        benchmark_symbol: str | None = None,
+        pre_sessions: int | None = None,
+        post_sessions: int | None = None,
+        intraday_session_date: str | None = None,
+        intraday_anchor_post_id: str | None = None,
+        before_minutes: int | None = None,
+        after_minutes: int | None = None,
+    ) -> dict[str, Any]:
+        return _json_safe(
+            build_research_asset_lab(
+                settings=settings,
+                store=store,
+                date_start=date_start,
+                date_end=date_end,
+                platforms=platforms,
+                include_reshares=include_reshares,
+                tracked_only=tracked_only,
+                trump_authored_only=trump_authored_only,
+                keyword=keyword,
+                selected_asset=selected_asset,
+                comparison_mode=comparison_mode,
+                benchmark_symbol=benchmark_symbol,
+                pre_sessions=pre_sessions,
+                post_sessions=post_sessions,
+                intraday_session_date=intraday_session_date,
+                intraday_anchor_post_id=intraday_anchor_post_id,
+                before_minutes=before_minutes,
+                after_minutes=after_minutes,
+            ),
         )
 
     @app.get("/api/datasets/health")

--- a/trump_workbench/research_asset_lab.py
+++ b/trump_workbench/research_asset_lab.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import pandas as pd
+
+from .config import AppSettings, DEFAULT_ETF_SYMBOLS
+from .market import ASSET_INTRADAY_COLUMNS
+from .research import (
+    build_asset_comparison_chart,
+    build_asset_comparison_frame,
+    build_event_study_chart,
+    build_event_study_frame,
+    build_intraday_comparison_chart,
+    build_intraday_comparison_frame,
+    filter_posts,
+    make_asset_mapping_table,
+    make_asset_session_table,
+    truncate_text,
+)
+from .research_workspace import (
+    _figure_json,
+    _frame_records,
+    _public_filter_payload,
+    _resolve_filters,
+    detect_source_mode,
+)
+from .storage import DuckDBStore
+
+TABLE_LIMIT = 250
+DEFAULT_INTRADAY_BEFORE_MINUTES = 120
+DEFAULT_INTRADAY_AFTER_MINUTES = 240
+
+
+def _to_records(frame: pd.DataFrame, limit: int | None = TABLE_LIMIT) -> list[dict[str, Any]]:
+    if frame.empty:
+        return []
+    return _frame_records(frame.head(limit) if limit is not None else frame)
+
+
+def _normalize_mode(value: str | None) -> str:
+    return "price" if str(value or "").strip().lower() == "price" else "normalized"
+
+
+def _coerce_positive_int(value: int | None, default: int, minimum: int = 1, maximum: int = 390) -> int:
+    try:
+        parsed = int(value if value is not None else default)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _asset_options(asset_universe: pd.DataFrame, asset_daily: pd.DataFrame) -> list[dict[str, Any]]:
+    daily_symbols = (
+        set(asset_daily["symbol"].dropna().astype(str).str.upper().tolist())
+        if not asset_daily.empty and "symbol" in asset_daily.columns
+        else set()
+    )
+    options: list[dict[str, Any]] = []
+    if not asset_universe.empty and "symbol" in asset_universe.columns:
+        universe = asset_universe.copy()
+        universe["symbol"] = universe["symbol"].astype(str).str.upper()
+        universe = universe.loc[universe["symbol"] != "SPY"].copy()
+        for _, row in universe.iterrows():
+            symbol = str(row.get("symbol", "") or "").upper()
+            if not symbol:
+                continue
+            source = str(row.get("source", "") or "")
+            is_watchlist = bool(row.get("is_watchlist", False)) or source == "watchlist"
+            display_name = str(row.get("display_name", "") or symbol)
+            options.append(
+                {
+                    "symbol": symbol,
+                    "label": f"{symbol} - {display_name}",
+                    "source": source,
+                    "is_watchlist": is_watchlist,
+                    "has_daily": symbol in daily_symbols if daily_symbols else True,
+                },
+            )
+    elif daily_symbols:
+        for symbol in sorted(symbol for symbol in daily_symbols if symbol != "SPY"):
+            options.append(
+                {
+                    "symbol": symbol,
+                    "label": symbol,
+                    "source": "asset_daily",
+                    "is_watchlist": False,
+                    "has_daily": True,
+                },
+            )
+    return sorted(options, key=lambda item: (not bool(item["is_watchlist"]), str(item["symbol"])))
+
+
+def _select_asset(asset_options: list[dict[str, Any]], selected_asset: str | None) -> str:
+    symbols = [str(option["symbol"]).upper() for option in asset_options]
+    requested = str(selected_asset or "").strip().upper()
+    if requested in symbols:
+        return requested
+    for option in asset_options:
+        if bool(option.get("is_watchlist")):
+            return str(option["symbol"]).upper()
+    return symbols[0] if symbols else ""
+
+
+def _benchmark_options(selected_asset: str) -> list[str]:
+    selected = str(selected_asset).upper()
+    return ["None", *[symbol for symbol in DEFAULT_ETF_SYMBOLS if symbol not in {"SPY", selected}]]
+
+
+def _select_benchmark(selected_asset: str, benchmark_symbol: str | None) -> str:
+    requested = str(benchmark_symbol or "").strip().upper()
+    if requested in {"", "NONE", "NULL"}:
+        return "None"
+    options = _benchmark_options(selected_asset)
+    return requested if requested in options else "None"
+
+
+def _normalize_daily_market(asset_daily: pd.DataFrame, date_start: pd.Timestamp, date_end: pd.Timestamp) -> pd.DataFrame:
+    if asset_daily.empty:
+        return asset_daily.copy()
+    if not {"symbol", "trade_date"}.issubset(asset_daily.columns):
+        return asset_daily.head(0).copy()
+    frame = asset_daily.copy()
+    frame["symbol"] = frame["symbol"].astype(str).str.upper()
+    frame["trade_date"] = pd.to_datetime(frame["trade_date"], errors="coerce").dt.normalize()
+    return frame.loc[
+        (frame["trade_date"] >= pd.Timestamp(date_start).normalize())
+        & (frame["trade_date"] <= pd.Timestamp(date_end).normalize())
+    ].copy()
+
+
+def _normalize_asset_features(
+    asset_session_features: pd.DataFrame,
+    selected_asset: str,
+    date_start: pd.Timestamp,
+    date_end: pd.Timestamp,
+    allowed_sessions: set[pd.Timestamp] | None = None,
+) -> pd.DataFrame:
+    if asset_session_features.empty:
+        return asset_session_features.copy()
+    if not {"asset_symbol", "signal_session_date"}.issubset(asset_session_features.columns):
+        return asset_session_features.head(0).copy()
+    frame = asset_session_features.copy()
+    frame["asset_symbol"] = frame["asset_symbol"].astype(str).str.upper()
+    frame["signal_session_date"] = pd.to_datetime(frame["signal_session_date"], errors="coerce").dt.normalize()
+    frame = frame.loc[
+        (frame["asset_symbol"] == str(selected_asset).upper())
+        & (frame["signal_session_date"] >= pd.Timestamp(date_start).normalize())
+        & (frame["signal_session_date"] <= pd.Timestamp(date_end).normalize())
+    ].copy()
+    if allowed_sessions is not None:
+        frame = frame.loc[frame["signal_session_date"].isin(allowed_sessions)].copy()
+    return frame
+
+
+def _filter_asset_mappings(
+    asset_post_mappings: pd.DataFrame,
+    filtered_posts: pd.DataFrame,
+    selected_asset: str,
+    date_start: pd.Timestamp,
+    date_end: pd.Timestamp,
+) -> pd.DataFrame:
+    if asset_post_mappings.empty:
+        return asset_post_mappings.copy()
+    if not {"asset_symbol", "session_date"}.issubset(asset_post_mappings.columns):
+        return asset_post_mappings.head(0).copy()
+    frame = asset_post_mappings.copy()
+    frame["asset_symbol"] = frame["asset_symbol"].astype(str).str.upper()
+    frame["session_date"] = pd.to_datetime(frame["session_date"], errors="coerce").dt.normalize()
+    frame = frame.loc[
+        (frame["asset_symbol"] == str(selected_asset).upper())
+        & (frame["session_date"] >= pd.Timestamp(date_start).normalize())
+        & (frame["session_date"] <= pd.Timestamp(date_end).normalize())
+    ].copy()
+    if "post_id" in frame.columns and "post_id" in filtered_posts.columns:
+        allowed_post_ids = set(filtered_posts["post_id"].dropna().astype(str).tolist())
+        frame = frame.loc[frame["post_id"].astype(str).isin(allowed_post_ids)].copy()
+    if "reaction_anchor_ts" not in frame.columns and "post_timestamp" in frame.columns:
+        frame["reaction_anchor_ts"] = frame["post_timestamp"]
+    return frame
+
+
+def _normalize_intraday_frame(intraday: pd.DataFrame, timezone: str) -> pd.DataFrame:
+    if intraday.empty:
+        return pd.DataFrame(columns=ASSET_INTRADAY_COLUMNS)
+    if not {"symbol", "timestamp"}.issubset(intraday.columns):
+        return pd.DataFrame(columns=ASSET_INTRADAY_COLUMNS)
+    frame = intraday.copy()
+    frame["symbol"] = frame["symbol"].astype(str).str.upper()
+    timestamps = pd.to_datetime(frame["timestamp"], errors="coerce")
+    if getattr(timestamps.dt, "tz", None) is None:
+        timestamps = timestamps.dt.tz_localize(timezone, nonexistent="NaT", ambiguous="NaT")
+    else:
+        timestamps = timestamps.dt.tz_convert(timezone)
+    frame["timestamp"] = timestamps
+    return frame.dropna(subset=["timestamp"]).copy()
+
+
+def _anchor_timestamp(value: Any, timezone: str) -> pd.Timestamp | None:
+    timestamp = pd.to_datetime(value, errors="coerce")
+    if pd.isna(timestamp):
+        return None
+    if getattr(timestamp, "tzinfo", None) is None:
+        timestamp = timestamp.tz_localize(timezone, nonexistent="NaT", ambiguous="NaT")
+    else:
+        timestamp = timestamp.tz_convert(timezone)
+    return None if pd.isna(timestamp) else pd.Timestamp(timestamp)
+
+
+def _intraday_coverage(intraday: pd.DataFrame, required_symbols: set[str]) -> pd.DataFrame:
+    if intraday.empty:
+        return pd.DataFrame(columns=["symbol", "bars", "first_timestamp", "last_timestamp", "covered_dates"])
+    frame = intraday.loc[intraday["symbol"].isin(required_symbols)].copy()
+    if frame.empty:
+        return pd.DataFrame(columns=["symbol", "bars", "first_timestamp", "last_timestamp", "covered_dates"])
+    frame["session_date"] = frame["timestamp"].dt.date
+    return (
+        frame.groupby("symbol", as_index=False)
+        .agg(
+            bars=("timestamp", "size"),
+            first_timestamp=("timestamp", "min"),
+            last_timestamp=("timestamp", "max"),
+            covered_dates=("session_date", lambda values: ", ".join(sorted({str(value) for value in values}))),
+        )
+        .sort_values("symbol")
+        .reset_index(drop=True)
+    )
+
+
+def _intraday_anchor_options(
+    mappings: pd.DataFrame,
+    intraday: pd.DataFrame,
+    required_symbols: set[str],
+    timezone: str,
+) -> tuple[list[dict[str, Any]], pd.DataFrame, str]:
+    if mappings.empty:
+        return [], mappings.head(0).copy(), "No mapped posts are available for the selected asset and filters."
+    if intraday.empty:
+        return [], mappings.head(0).copy(), "No stored intraday data is available yet."
+
+    intraday_dates = {
+        symbol: set(
+            intraday.loc[intraday["symbol"] == symbol, "timestamp"]
+            .dropna()
+            .dt.date
+            .tolist()
+        )
+        for symbol in required_symbols
+    }
+    eligible_sessions = {
+        session_date
+        for session_date in pd.to_datetime(mappings["session_date"], errors="coerce").dt.date.dropna().unique().tolist()
+        if all(session_date in intraday_dates.get(symbol, set()) for symbol in required_symbols)
+    }
+    if not eligible_sessions:
+        return [], mappings.head(0).copy(), (
+            "No recent intraday coverage overlaps mapped sessions for "
+            f"{', '.join(sorted(required_symbols))}."
+        )
+
+    eligible = mappings.loc[
+        pd.to_datetime(mappings["session_date"], errors="coerce").dt.date.isin(eligible_sessions)
+    ].copy()
+    eligible = eligible.sort_values(["session_date", "post_timestamp"], ascending=[False, True]).reset_index(drop=True)
+    options: list[dict[str, Any]] = []
+    for index, row in eligible.iterrows():
+        anchor_id = str(row.get("post_id", "") or f"row-{index}")
+        timestamp = _anchor_timestamp(row.get("reaction_anchor_ts", row.get("post_timestamp")), timezone)
+        if timestamp is None:
+            continue
+        author = str(row.get("author_handle", "") or row.get("author_display_name", "") or "unknown")
+        text = truncate_text(str(row.get("cleaned_text", "") or ""), max_chars=96)
+        session_date = pd.Timestamp(row["session_date"]).date().isoformat()
+        options.append(
+            {
+                "anchor_id": anchor_id,
+                "session_date": session_date,
+                "label": f"{timestamp:%Y-%m-%d %H:%M} ET | @{author} | {text}",
+                "post_timestamp": timestamp.isoformat(),
+            },
+        )
+    return options, eligible, "" if options else "Mapped posts exist, but none have a usable intraday anchor timestamp."
+
+
+def _select_anchor(
+    eligible_mappings: pd.DataFrame,
+    anchor_options: list[dict[str, Any]],
+    intraday_session_date: str | None,
+    intraday_anchor_post_id: str | None,
+) -> tuple[dict[str, Any] | None, pd.Series | None]:
+    if eligible_mappings.empty or not anchor_options:
+        return None, None
+    option_lookup = {str(option["anchor_id"]): option for option in anchor_options}
+    requested_anchor = str(intraday_anchor_post_id or "").strip()
+    requested_session = str(intraday_session_date or "").strip()
+    selected_option = option_lookup.get(requested_anchor)
+    if selected_option is None and requested_session:
+        selected_option = next((option for option in anchor_options if str(option["session_date"]) == requested_session), None)
+    selected_option = selected_option or anchor_options[0]
+    selected_anchor_id = str(selected_option["anchor_id"])
+    for _, row in eligible_mappings.iterrows():
+        row_anchor_id = str(row.get("post_id", "") or "")
+        if row_anchor_id == selected_anchor_id:
+            return selected_option, row
+    try:
+        fallback_index = int(selected_anchor_id.replace("row-", ""))
+        if fallback_index in eligible_mappings.index:
+            return selected_option, eligible_mappings.loc[fallback_index]
+    except ValueError:
+        pass
+    return selected_option, eligible_mappings.iloc[0]
+
+
+def build_research_asset_lab(
+    *,
+    settings: AppSettings,
+    store: DuckDBStore,
+    date_start: str | None = None,
+    date_end: str | None = None,
+    platforms: Iterable[str] | None = None,
+    include_reshares: bool | None = None,
+    tracked_only: bool | None = None,
+    trump_authored_only: bool | None = None,
+    keyword: str | None = None,
+    selected_asset: str | None = None,
+    comparison_mode: str | None = None,
+    benchmark_symbol: str | None = None,
+    pre_sessions: int | None = None,
+    post_sessions: int | None = None,
+    intraday_session_date: str | None = None,
+    intraday_anchor_post_id: str | None = None,
+    before_minutes: int | None = None,
+    after_minutes: int | None = None,
+) -> dict[str, Any]:
+    posts = store.read_frame("normalized_posts")
+    asset_universe = store.read_frame("asset_universe")
+    asset_daily = store.read_frame("asset_daily")
+    asset_intraday = store.read_frame("asset_intraday")
+    asset_post_mappings = store.read_frame("asset_post_mappings")
+    asset_session_features = store.read_frame("asset_session_features")
+
+    source_mode = detect_source_mode(posts)
+    filters = _resolve_filters(
+        settings,
+        posts,
+        date_start=date_start,
+        date_end=date_end,
+        platforms=platforms,
+        include_reshares=include_reshares,
+        tracked_only=tracked_only,
+        trump_authored_only=trump_authored_only,
+        keyword=keyword,
+    )
+    public_filters = _public_filter_payload(filters)
+    options = _asset_options(asset_universe, asset_daily)
+    resolved_asset = _select_asset(options, selected_asset)
+    mode = _normalize_mode(comparison_mode)
+    resolved_benchmark = _select_benchmark(resolved_asset, benchmark_symbol)
+    benchmark_value = None if resolved_benchmark == "None" else resolved_benchmark
+    resolved_pre_sessions = _coerce_positive_int(pre_sessions, 3, minimum=1, maximum=10)
+    resolved_post_sessions = _coerce_positive_int(post_sessions, 5, minimum=1, maximum=10)
+    resolved_before_minutes = _coerce_positive_int(before_minutes, DEFAULT_INTRADAY_BEFORE_MINUTES, minimum=30, maximum=390)
+    resolved_after_minutes = _coerce_positive_int(after_minutes, DEFAULT_INTRADAY_AFTER_MINUTES, minimum=30, maximum=780)
+
+    empty_comparison = build_asset_comparison_chart(pd.DataFrame(), resolved_asset or "asset", mode)
+    empty_event = build_event_study_chart(pd.DataFrame(), resolved_asset or "asset")
+    empty_intraday = build_intraday_comparison_chart(pd.DataFrame(), resolved_asset or "asset", pd.Timestamp.now(tz=settings.timezone))
+    if not resolved_asset or asset_daily.empty:
+        message = "Refresh datasets and add at least one non-SPY tracked asset to use the Asset Lab."
+        return {
+            "ready": False,
+            "message": message,
+            "source_mode": source_mode,
+            "filters": public_filters,
+            "controls": {
+                "selected_asset": resolved_asset,
+                "comparison_mode": mode,
+                "benchmark_symbol": resolved_benchmark,
+                "pre_sessions": resolved_pre_sessions,
+                "post_sessions": resolved_post_sessions,
+                "before_minutes": resolved_before_minutes,
+                "after_minutes": resolved_after_minutes,
+                "intraday_session_date": intraday_session_date or "",
+                "intraday_anchor_post_id": intraday_anchor_post_id or "",
+            },
+            "asset_options": options,
+            "benchmark_options": _benchmark_options(resolved_asset),
+            "headline_metrics": {},
+            "charts": {
+                "asset_comparison": _figure_json(empty_comparison),
+                "event_study": _figure_json(empty_event),
+                "intraday_reaction": _figure_json(empty_intraday),
+            },
+            "asset_session_rows": [],
+            "asset_mapping_rows": [],
+            "comparison_rows": [],
+            "event_study_rows": [],
+            "intraday_anchor_options": [],
+            "intraday_coverage": [],
+            "intraday_rows": [],
+            "intraday_message": message,
+        }
+
+    filtered_posts = filter_posts(
+        posts=posts,
+        date_start=filters["date_start"],
+        date_end=filters["date_end"],
+        include_reshares=filters["include_reshares"],
+        platforms=filters["platforms"],
+        keyword=filters["keyword"],
+        tracked_only=filters["tracked_only"],
+        trump_authored_only=filters["trump_authored_only"],
+    )
+    daily_market = _normalize_daily_market(asset_daily, filters["date_start"], filters["date_end"])
+    selected_mappings = _filter_asset_mappings(
+        asset_post_mappings,
+        filtered_posts,
+        resolved_asset,
+        filters["date_start"],
+        filters["date_end"],
+    )
+    allowed_sessions = (
+        set(pd.to_datetime(selected_mappings["session_date"], errors="coerce").dropna().dt.normalize().tolist())
+        if not selected_mappings.empty and "session_date" in selected_mappings.columns
+        else None
+    )
+    selected_features = _normalize_asset_features(
+        asset_session_features,
+        resolved_asset,
+        filters["date_start"],
+        filters["date_end"],
+        allowed_sessions=allowed_sessions,
+    )
+    comparison = build_asset_comparison_frame(
+        asset_market=daily_market,
+        selected_symbol=resolved_asset,
+        benchmark_symbol=benchmark_value,
+        date_start=filters["date_start"],
+        date_end=filters["date_end"],
+    )
+    event_study = build_event_study_frame(
+        asset_market=daily_market,
+        asset_session_features=selected_features,
+        selected_symbol=resolved_asset,
+        benchmark_symbol=benchmark_value,
+        pre_sessions=resolved_pre_sessions,
+        post_sessions=resolved_post_sessions,
+    )
+    comparison_chart = build_asset_comparison_chart(comparison, resolved_asset, mode)
+    event_chart = build_event_study_chart(event_study, resolved_asset)
+    asset_session_table = make_asset_session_table(selected_features, resolved_asset)
+    asset_mapping_table = make_asset_mapping_table(selected_mappings, resolved_asset)
+
+    intraday_frame = _normalize_intraday_frame(asset_intraday, settings.timezone)
+    required_intraday_symbols = {"SPY", resolved_asset}
+    if benchmark_value:
+        required_intraday_symbols.add(benchmark_value)
+    anchor_options, eligible_mappings, intraday_message = _intraday_anchor_options(
+        selected_mappings,
+        intraday_frame,
+        required_intraday_symbols,
+        settings.timezone,
+    )
+    selected_anchor, selected_anchor_row = _select_anchor(
+        eligible_mappings,
+        anchor_options,
+        intraday_session_date,
+        intraday_anchor_post_id,
+    )
+    intraday_comparison = pd.DataFrame()
+    intraday_chart = empty_intraday
+    if selected_anchor_row is not None:
+        anchor_ts = _anchor_timestamp(
+            selected_anchor_row.get("reaction_anchor_ts", selected_anchor_row.get("post_timestamp")),
+            settings.timezone,
+        )
+        if anchor_ts is not None:
+            intraday_comparison = build_intraday_comparison_frame(
+                intraday_frame=intraday_frame,
+                selected_symbol=resolved_asset,
+                anchor_ts=anchor_ts,
+                before_minutes=resolved_before_minutes,
+                after_minutes=resolved_after_minutes,
+                benchmark_symbol=benchmark_value,
+            )
+            intraday_chart = build_intraday_comparison_chart(intraday_comparison, resolved_asset, anchor_ts)
+            if intraday_comparison.empty and not intraday_message:
+                intraday_message = "No intraday comparison rows were returned for the selected window."
+    coverage = _intraday_coverage(intraday_frame, required_intraday_symbols)
+
+    sessions_in_range = int(len(comparison))
+    spy_move = float(comparison["spy_normalized_return"].iloc[-1]) if not comparison.empty and "spy_normalized_return" in comparison.columns else None
+    asset_move = float(comparison["asset_normalized_return"].iloc[-1]) if not comparison.empty and "asset_normalized_return" in comparison.columns else None
+    headline_metrics = {
+        "sessions_in_range": sessions_in_range,
+        "spy_move": spy_move,
+        "asset_move": asset_move,
+        "asset_vs_spy_spread": float(asset_move - spy_move) if asset_move is not None and spy_move is not None else None,
+        "mapped_post_count": int(len(selected_mappings)),
+        "asset_session_count": int(len(selected_features)),
+        "event_count": int(event_study["event_count"].max()) if not event_study.empty and "event_count" in event_study.columns else 0,
+        "intraday_bars": int(len(intraday_comparison)),
+    }
+
+    return {
+        "ready": True,
+        "message": "",
+        "source_mode": source_mode,
+        "filters": public_filters,
+        "controls": {
+            "selected_asset": resolved_asset,
+            "comparison_mode": mode,
+            "benchmark_symbol": resolved_benchmark,
+            "pre_sessions": resolved_pre_sessions,
+            "post_sessions": resolved_post_sessions,
+            "before_minutes": resolved_before_minutes,
+            "after_minutes": resolved_after_minutes,
+            "intraday_session_date": selected_anchor.get("session_date", "") if selected_anchor else "",
+            "intraday_anchor_post_id": selected_anchor.get("anchor_id", "") if selected_anchor else "",
+        },
+        "asset_options": options,
+        "benchmark_options": _benchmark_options(resolved_asset),
+        "headline_metrics": headline_metrics,
+        "charts": {
+            "asset_comparison": _figure_json(comparison_chart),
+            "event_study": _figure_json(event_chart),
+            "intraday_reaction": _figure_json(intraday_chart),
+        },
+        "asset_session_rows": _to_records(asset_session_table.sort_values("trade_date", ascending=False) if not asset_session_table.empty else asset_session_table),
+        "asset_mapping_rows": _to_records(asset_mapping_table),
+        "comparison_rows": _to_records(comparison, limit=TABLE_LIMIT),
+        "event_study_rows": _to_records(event_study, limit=TABLE_LIMIT),
+        "intraday_anchor_options": anchor_options[:TABLE_LIMIT],
+        "intraday_coverage": _to_records(coverage, limit=None),
+        "intraday_rows": _to_records(intraday_comparison, limit=TABLE_LIMIT),
+        "intraday_message": intraday_message,
+    }


### PR DESCRIPTION
## Summary
- Add a read-only Research Asset Lab backend builder and `/api/research/assets` endpoint for asset overlays, event-study rows, mapped posts, and stored intraday reaction windows.
- Extend the React Research tab with Asset Lab controls, metric cards, Plotly charts, mapped-post/event/intraday tables, and safe empty states.
- Add backend API tests and Playwright coverage for the migrated Asset Lab workflow.

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `npm run build --prefix frontend`
- `npm run test:ui --prefix frontend`
- `bash scripts/ci.sh`

Closes #51

Note: this PR is stacked on `codex/react-run-explorer` / PR #50 because the plan starts after that migration slice lands.