### PR TITLE
Migrate Discovery Workspace to React and FastAPI

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -345,6 +345,102 @@ const researchPayload = {
   export_filename: "research-pack-20250120-20260420.zip",
 };
 
+const discoveryPayload = {
+  ready: true,
+  message: "Discovery ranks non-Trump X accounts that mention Trump.",
+  source_mode: {
+    mode: "truth_plus_x",
+    truth_post_count: 42,
+    x_post_count: 12,
+  },
+  latest_ranked_at: "2026-04-17T00:00:00",
+  summary: {
+    post_count: 54,
+    x_candidate_post_count: 12,
+    active_account_count: 2,
+    latest_ranking_count: 3,
+    selected_account_count: 2,
+    pinned_account_count: 1,
+    suppressed_latest_count: 1,
+    override_count: 2,
+    pin_override_count: 1,
+    suppress_override_count: 1,
+  },
+  charts: {
+    top_discovered_accounts: {
+      data: [{ type: "bar", orientation: "h", x: [12, 9], y: ["macroalpha", "policywatch"], name: "Discovery score" }],
+      layout: { title: { text: "Top discovered accounts" } },
+    },
+    ranking_history: {
+      data: [{ type: "scatter", mode: "lines+markers", x: ["2026-04-17"], y: [3], name: "Ranked accounts" }],
+      layout: { title: { text: "Discovery ranking history" } },
+    },
+  },
+  active_accounts: [
+    {
+      handle: "macroalpha",
+      display_name: "Macro Alpha",
+      status: "active",
+      discovery_score: 12,
+      mention_count: 3,
+      provenance: "discovery_auto_include",
+    },
+    {
+      handle: "policywatch",
+      display_name: "Policy Watch",
+      status: "pinned",
+      discovery_score: 9,
+      mention_count: 1,
+      provenance: "manual_override:pin",
+    },
+  ],
+  latest_rankings: [
+    {
+      author_handle: "macroalpha",
+      author_display_name: "Macro Alpha",
+      discovery_score: 12,
+      mention_count: 3,
+      selected_status: "active",
+      suppressed_by_override: false,
+    },
+    {
+      author_handle: "policywatch",
+      author_display_name: "Policy Watch",
+      discovery_score: 9,
+      mention_count: 1,
+      selected_status: "pinned",
+      suppressed_by_override: false,
+    },
+    {
+      author_handle: "muted",
+      author_display_name: "Muted Account",
+      discovery_score: 3,
+      mention_count: 1,
+      selected_status: "excluded",
+      suppressed_by_override: true,
+    },
+  ],
+  override_history: [
+    {
+      handle: "policywatch",
+      action: "pin",
+      note: "Always inspect",
+    },
+    {
+      handle: "muted",
+      action: "suppress",
+      note: "Low quality",
+    },
+  ],
+  recent_ranking_history: [
+    {
+      ranked_at: "2026-04-17T00:00:00",
+      author_handle: "macroalpha",
+      discovery_score: 12,
+    },
+  ],
+};
+
 const livePayload = {
   configured: true,
   errors: [],
@@ -447,6 +543,7 @@ async function mockApi(page: Page) {
   await fulfillJson(page, "/api/runs/run-portfolio-1**", runDetailPayload);
   await fulfillJson(page, "/api/runs/compare**", runComparisonPayload);
   await fulfillJson(page, "/api/research**", researchPayload);
+  await fulfillJson(page, "/api/discovery", discoveryPayload);
   await fulfillJson(page, "/api/live/current", livePayload);
   await fulfillJson(page, "/api/paper/portfolios", portfoliosPayload);
   await fulfillJson(page, "/api/performance/paper-1", performancePayload);
@@ -491,6 +588,25 @@ test("shows the migrated research workspace with narratives and export", async (
   await expect(page.getByRole("heading", { name: "Structured narrative inspection" })).toBeVisible();
   await expect(page.getByRole("cell", { name: "markets" }).first()).toBeVisible();
   await expect(page.getByText("heuristic-fallback")).toBeVisible();
+});
+
+test("shows the migrated discovery workspace with rankings and overrides", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /Discovery/ }).click();
+
+  await expect(page.getByRole("heading", { name: "Tracked account ranking workspace" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Discovery workspace" })).toBeVisible();
+  await expect(page.getByText("Manual pin/suppress override writes remain in Streamlit")).toBeVisible();
+  await expect(page.getByText("Discovery ranks non-Trump X accounts that mention Trump.", { exact: true })).toBeVisible();
+  await expect(page.getByText("X candidate posts")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Top discovered accounts" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Active tracked accounts" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "macroalpha" }).first()).toBeVisible();
+  await expect(page.getByRole("cell", { name: "policywatch" }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Latest ranking snapshot" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "suppressed by override" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Override history" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "suppress" })).toBeVisible();
 });
 
 test("shows the migrated run explorer with detail and comparison tables", async ({ page }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,11 +12,12 @@ const createPlotlyComponent = (
 ) as PlotComponentFactory;
 const Plot = createPlotlyComponent(Plotly);
 
-type PageKey = "overview" | "research" | "runs" | "data" | "live" | "paper";
+type PageKey = "overview" | "research" | "discovery" | "runs" | "data" | "live" | "paper";
 
 const pages: Array<{ key: PageKey; label: string; deck: string }> = [
   { key: "overview", label: "Overview", deck: "API status and migration posture" },
   { key: "research", label: "Research", deck: "Sentiment, narratives, and export pack" },
+  { key: "discovery", label: "Discovery", deck: "Tracked account ranking workspace" },
   { key: "runs", label: "Run Explorer", deck: "Saved model results and comparisons" },
   { key: "data", label: "Data Health", deck: "Freshness, completeness, and anomalies" },
   { key: "live", label: "Live Decision", deck: "Current portfolio board" },
@@ -405,6 +406,83 @@ function ResearchPage() {
           <h2>Provider and cache indicators</h2>
         </div>
         <DataTable rows={payload?.provider_summary ?? []} />
+      </article>
+    </section>
+  );
+}
+
+function DiscoveryPage() {
+  const discovery = useQuery({ queryKey: ["discovery"], queryFn: api.discovery });
+
+  if (discovery.isLoading) {
+    return <LoadingBlock label="Loading discovery workspace..." />;
+  }
+  if (discovery.error) {
+    return <ErrorBlock error={discovery.error} />;
+  }
+
+  const payload = discovery.data;
+  const summary = payload?.summary ?? {};
+  return (
+    <section className="page-grid">
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <div>
+            <p className="eyebrow">Read-only migration slice</p>
+            <h2>Discovery workspace</h2>
+          </div>
+          <StatusPill label={payload?.ready ? "Rankings available" : "Guidance"} tone={payload?.ready ? "ok" : "warn"} />
+        </div>
+        <p>
+          Discovery ranks non-Trump X accounts that mention Trump. Manual pin/suppress override writes remain in Streamlit
+          for this migration slice.
+        </p>
+        {payload?.message ? <div className="empty-state">{payload.message}</div> : null}
+      </article>
+
+      <div className="metric-grid">
+        <MetricCard label="X candidate posts" value={summary.x_candidate_post_count ?? 0} />
+        <MetricCard label="Active accounts" value={summary.active_account_count ?? 0} />
+        <MetricCard label="Latest rankings" value={summary.latest_ranking_count ?? 0} />
+        <MetricCard label="Overrides" value={summary.override_count ?? 0} />
+      </div>
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>Top discovered accounts</h2>
+          <PlotlyChart figure={payload?.charts.top_discovered_accounts} title="Top discovered accounts" />
+        </div>
+        <div>
+          <h2>Ranking history</h2>
+          <PlotlyChart figure={payload?.charts.ranking_history} title="Discovery ranking history" />
+        </div>
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Active tracked accounts</h2>
+          <StatusPill label={`${summary.active_account_count ?? 0} active`} />
+        </div>
+        <DataTable rows={payload?.active_accounts ?? []} />
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Latest ranking snapshot</h2>
+          <StatusPill label={payload?.latest_ranked_at ? `Ranked ${payload.latest_ranked_at}` : "No snapshot"} />
+        </div>
+        <DataTable rows={payload?.latest_rankings ?? []} />
+      </article>
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>Override history</h2>
+          <DataTable rows={payload?.override_history ?? []} />
+        </div>
+        <div>
+          <h2>Recent ranking history</h2>
+          <DataTable rows={payload?.recent_ranking_history ?? []} />
+        </div>
       </article>
     </section>
   );
@@ -1006,6 +1084,7 @@ export function App() {
 
       {activePage === "overview" ? <OverviewPage /> : null}
       {activePage === "research" ? <ResearchPage /> : null}
+      {activePage === "discovery" ? <DiscoveryPage /> : null}
       {activePage === "runs" ? <RunExplorerPage /> : null}
       {activePage === "data" ? <DataHealthPage /> : null}
       {activePage === "live" ? <LiveDecisionPage /> : null}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -181,6 +181,22 @@ export type ResearchPayload = {
   export_filename: string;
 };
 
+export type DiscoveryPayload = {
+  ready: boolean;
+  message: string;
+  source_mode: StatusPayload["source_mode"];
+  latest_ranked_at: string | null;
+  summary: RecordRow;
+  charts: {
+    top_discovered_accounts?: PlotlyFigure;
+    ranking_history?: PlotlyFigure;
+  };
+  active_accounts: RecordRow[];
+  latest_rankings: RecordRow[];
+  override_history: RecordRow[];
+  recent_ranking_history: RecordRow[];
+};
+
 function researchQuery(filters: ResearchFilters = {}): string {
   const params = new URLSearchParams();
   Object.entries(filters).forEach(([key, value]) => {
@@ -236,6 +252,7 @@ export const api = {
   },
   research: (filters?: ResearchFilters) => getJson<ResearchPayload>(`/api/research${researchQuery(filters)}`),
   researchExportUrl: (filters?: ResearchFilters) => `${API_BASE_URL}/api/research/export${researchQuery(filters)}`,
+  discovery: () => getJson<DiscoveryPayload>("/api/discovery"),
   live: () => getJson<LivePayload>("/api/live/current"),
   paperPortfolios: () => getJson<PaperPortfoliosPayload>("/api/paper/portfolios"),
   performance: (paperPortfolioId: string) => getJson<PerformancePayload>(`/api/performance/${paperPortfolioId}`),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from trump_workbench.api import create_app
 from trump_workbench.config import AppSettings
-from trump_workbench.contracts import BacktestRun
+from trump_workbench.contracts import BacktestRun, MANUAL_OVERRIDE_COLUMNS, RANKING_HISTORY_COLUMNS, TRACKED_ACCOUNT_COLUMNS
 from trump_workbench.experiments import ExperimentStore
 from trump_workbench.paper_trading import (
     PAPER_BENCHMARK_CURVE_COLUMNS,
@@ -122,6 +122,157 @@ class ApiContractTests(unittest.TestCase):
                     {"symbol": "QQQ", "display_name": "Invesco QQQ Trust", "asset_type": "etf", "source": "core_etf"},
                     {"symbol": "NVDA", "display_name": "NVIDIA", "asset_type": "equity", "source": "watchlist"},
                 ],
+            ),
+        )
+
+    def _save_discovery_frames(self) -> None:
+        self._save_research_frames(include_x=True)
+        self.store.save_frame(
+            "tracked_accounts",
+            pd.DataFrame(
+                [
+                    {
+                        "version_id": "acct-macro-v1",
+                        "account_id": "acct-macro",
+                        "handle": "macroalpha",
+                        "display_name": "Macro Alpha",
+                        "source_platform": "X",
+                        "discovery_score": 12.0,
+                        "status": "active",
+                        "first_seen_at": pd.Timestamp("2025-02-03 10:00:00", tz="America/New_York"),
+                        "last_seen_at": pd.Timestamp("2025-02-03 10:00:00", tz="America/New_York"),
+                        "effective_from": pd.Timestamp("2025-02-03"),
+                        "effective_to": pd.NaT,
+                        "auto_included": True,
+                        "provenance": "discovery_auto_include",
+                        "mention_count": 3,
+                        "engagement_mean": 45.0,
+                        "active_days": 1,
+                    },
+                    {
+                        "version_id": "acct-policy-v1",
+                        "account_id": "acct-policy",
+                        "handle": "policywatch",
+                        "display_name": "Policy Watch",
+                        "source_platform": "X",
+                        "discovery_score": 9.0,
+                        "status": "pinned",
+                        "first_seen_at": pd.Timestamp("2025-02-01 10:00:00", tz="America/New_York"),
+                        "last_seen_at": pd.Timestamp("2025-02-03 10:00:00", tz="America/New_York"),
+                        "effective_from": pd.Timestamp("2025-02-01"),
+                        "effective_to": pd.NaT,
+                        "auto_included": False,
+                        "provenance": "manual_override:pin",
+                        "mention_count": 1,
+                        "engagement_mean": 10.0,
+                        "active_days": 1,
+                    },
+                ],
+                columns=TRACKED_ACCOUNT_COLUMNS,
+            ),
+        )
+        self.store.save_frame(
+            "account_rankings",
+            pd.DataFrame(
+                [
+                    {
+                        "author_account_id": "acct-macro",
+                        "author_handle": "macroalpha",
+                        "author_display_name": "Macro Alpha",
+                        "source_platform": "X",
+                        "discovery_score": 10.0,
+                        "mention_count": 2,
+                        "engagement_mean": 30.0,
+                        "active_days": 1,
+                        "ranked_at": pd.Timestamp("2025-02-02"),
+                        "discovery_rank": 2,
+                        "final_selected": True,
+                        "selected_status": "active",
+                        "suppressed_by_override": False,
+                        "pinned_by_override": False,
+                    },
+                    {
+                        "author_account_id": "acct-macro",
+                        "author_handle": "macroalpha",
+                        "author_display_name": "Macro Alpha",
+                        "source_platform": "X",
+                        "discovery_score": 12.0,
+                        "mention_count": 3,
+                        "engagement_mean": 45.0,
+                        "active_days": 1,
+                        "ranked_at": pd.Timestamp("2025-02-03"),
+                        "discovery_rank": 1,
+                        "final_selected": True,
+                        "selected_status": "active",
+                        "suppressed_by_override": False,
+                        "pinned_by_override": False,
+                    },
+                    {
+                        "author_account_id": "acct-policy",
+                        "author_handle": "policywatch",
+                        "author_display_name": "Policy Watch",
+                        "source_platform": "X",
+                        "discovery_score": 9.0,
+                        "mention_count": 1,
+                        "engagement_mean": 10.0,
+                        "active_days": 1,
+                        "ranked_at": pd.Timestamp("2025-02-03"),
+                        "discovery_rank": 2,
+                        "final_selected": True,
+                        "selected_status": "pinned",
+                        "suppressed_by_override": False,
+                        "pinned_by_override": True,
+                    },
+                    {
+                        "author_account_id": "acct-muted",
+                        "author_handle": "muted",
+                        "author_display_name": "Muted Account",
+                        "source_platform": "X",
+                        "discovery_score": 3.0,
+                        "mention_count": 1,
+                        "engagement_mean": 1.0,
+                        "active_days": 1,
+                        "ranked_at": pd.Timestamp("2025-02-03"),
+                        "discovery_rank": 3,
+                        "final_selected": False,
+                        "selected_status": "excluded",
+                        "suppressed_by_override": True,
+                        "pinned_by_override": False,
+                    },
+                ],
+                columns=RANKING_HISTORY_COLUMNS,
+            ),
+        )
+        self.store.save_frame(
+            "manual_account_overrides",
+            pd.DataFrame(
+                [
+                    {
+                        "override_id": "",
+                        "account_id": "acct-policy",
+                        "handle": "policywatch",
+                        "display_name": "Policy Watch",
+                        "source_platform": "X",
+                        "action": "PIN",
+                        "effective_from": pd.Timestamp("2025-02-01"),
+                        "effective_to": pd.NaT,
+                        "note": "Always inspect",
+                        "created_at": pd.Timestamp("2025-02-01 12:00:00", tz="UTC"),
+                    },
+                    {
+                        "override_id": "",
+                        "account_id": "acct-muted",
+                        "handle": "muted",
+                        "display_name": "Muted Account",
+                        "source_platform": "X",
+                        "action": "suppress",
+                        "effective_from": pd.Timestamp("2025-02-03"),
+                        "effective_to": pd.NaT,
+                        "note": "Low quality",
+                        "created_at": pd.Timestamp("2025-02-03 12:00:00", tz="UTC"),
+                    },
+                ],
+                columns=MANUAL_OVERRIDE_COLUMNS,
             ),
         )
 
@@ -624,6 +775,63 @@ class ApiContractTests(unittest.TestCase):
             self.assertEqual(manifest["source_mode"]["mode"], "truth_only")
             self.assertTrue(manifest["filters"]["trump_authored_only"])
             self.assertEqual(manifest["headline_metrics"]["posts_in_view"], 1)
+
+    def test_discovery_endpoint_returns_empty_state_without_posts(self) -> None:
+        response = self.client.get("/api/discovery")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["ready"])
+        self.assertIn("Refresh datasets", payload["message"])
+        self.assertEqual(payload["source_mode"]["mode"], "unknown")
+        self.assertEqual(payload["active_accounts"], [])
+        self.assertEqual(payload["latest_rankings"], [])
+        self.assertIn("top_discovered_accounts", payload["charts"])
+
+    def test_discovery_endpoint_explains_truth_only_mode(self) -> None:
+        self._save_truth_posts()
+
+        response = self.client.get("/api/discovery")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["ready"])
+        self.assertEqual(payload["source_mode"]["mode"], "truth_only")
+        self.assertIn("Discovery ranks non-Trump X accounts", payload["message"])
+        self.assertEqual(payload["summary"]["x_candidate_post_count"], 0)
+
+    def test_discovery_endpoint_returns_rankings_active_accounts_and_overrides(self) -> None:
+        self._save_discovery_frames()
+
+        response = self.client.get("/api/discovery")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ready"])
+        self.assertEqual(payload["message"], "")
+        self.assertEqual(payload["summary"]["x_candidate_post_count"], 1)
+        self.assertEqual(payload["summary"]["active_account_count"], 2)
+        self.assertEqual(payload["summary"]["latest_ranking_count"], 3)
+        self.assertEqual(payload["summary"]["pin_override_count"], 1)
+        self.assertEqual(payload["summary"]["suppress_override_count"], 1)
+        self.assertEqual(payload["latest_rankings"][0]["author_account_id"], "acct-macro")
+        self.assertEqual(payload["latest_rankings"][0]["discovery_score"], 12.0)
+        self.assertEqual({row["handle"] for row in payload["active_accounts"]}, {"macroalpha", "policywatch"})
+        self.assertEqual({row["action"] for row in payload["override_history"]}, {"pin", "suppress"})
+        self.assertGreaterEqual(len(payload["recent_ranking_history"]), 1)
+        self.assertIsNotNone(payload["latest_ranked_at"])
+
+    def test_discovery_endpoint_handles_schema_less_ranking_history(self) -> None:
+        self._save_research_frames(include_x=True)
+        self.store.save_frame("account_rankings", pd.DataFrame({"other": [1]}))
+
+        response = self.client.get("/api/discovery")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["ready"])
+        self.assertIn("rankings have not been built", payload["message"])
+        self.assertEqual(payload["latest_rankings"], [])
 
     def test_dataset_health_returns_summary_rows_and_registry(self) -> None:
         self._save_truth_posts()

--- a/trump_workbench/api.py
+++ b/trump_workbench/api.py
@@ -8,6 +8,8 @@ from fastapi import FastAPI, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import AppSettings
+from .discovery import DiscoveryService
+from .discovery_workspace import build_discovery_workspace
 from .enrichment import LLMEnrichmentService
 from .experiments import ExperimentStore
 from .health import DataHealthService, build_health_summary, build_health_trend_frame, ensure_refresh_history_frame
@@ -67,6 +69,7 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
     settings = settings or AppSettings()
     store = store or DuckDBStore(settings)
     health_service = DataHealthService()
+    discovery_service = DiscoveryService()
     experiment_store = ExperimentStore(store)
     model_service = ModelService()
     enrichment_service = LLMEnrichmentService(store)
@@ -193,6 +196,10 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
             media_type="application/zip",
             headers={"Content-Disposition": f'attachment; filename="{result.export_filename}"'},
         )
+
+    @app.get("/api/discovery")
+    def discovery() -> dict[str, Any]:
+        return _json_safe(build_discovery_workspace(store, discovery_service=discovery_service))
 
     @app.get("/api/datasets/health")
     def dataset_health() -> dict[str, Any]:

--- a/trump_workbench/discovery_workspace.py
+++ b/trump_workbench/discovery_workspace.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from .contracts import MANUAL_OVERRIDE_COLUMNS, RANKING_HISTORY_COLUMNS, TRACKED_ACCOUNT_COLUMNS
+from .discovery import DiscoveryService
+from .research_workspace import _figure_json, _frame_records, detect_source_mode
+from .storage import DuckDBStore
+
+TABLE_LIMIT = 250
+
+
+def _series_or_default(frame: pd.DataFrame, column: str, default: Any = False) -> pd.Series:
+    if column in frame.columns:
+        return frame[column]
+    return pd.Series(default, index=frame.index)
+
+
+def latest_ranking_snapshot(ranking_history: pd.DataFrame) -> pd.DataFrame:
+    required = {"author_account_id", "ranked_at"}
+    if ranking_history.empty or not required.issubset(ranking_history.columns):
+        return pd.DataFrame(columns=RANKING_HISTORY_COLUMNS)
+
+    snapshot = ranking_history.copy()
+    for column in RANKING_HISTORY_COLUMNS:
+        if column not in snapshot.columns:
+            snapshot[column] = pd.NA
+    snapshot["ranked_at"] = pd.to_datetime(snapshot["ranked_at"], errors="coerce")
+    snapshot = snapshot.dropna(subset=["ranked_at"]).copy()
+    if snapshot.empty:
+        return pd.DataFrame(columns=RANKING_HISTORY_COLUMNS)
+    return (
+        snapshot.sort_values(["ranked_at", "discovery_score"], ascending=[False, False])
+        .drop_duplicates("author_account_id")
+        .sort_values("discovery_score", ascending=False)
+        .reset_index(drop=True)[RANKING_HISTORY_COLUMNS]
+    )
+
+
+def _x_candidate_posts(posts: pd.DataFrame) -> pd.DataFrame:
+    if posts.empty:
+        return posts.copy()
+    platform = _series_or_default(posts, "source_platform", "").fillna("").astype(str)
+    mentions = _series_or_default(posts, "mentions_trump", False).fillna(False).astype(bool)
+    is_trump = _series_or_default(posts, "author_is_trump", False).fillna(False).astype(bool)
+    return posts.loc[(platform == "X") & mentions & (~is_trump)].copy()
+
+
+def _active_accounts(discovery_service: DiscoveryService, tracked_accounts: pd.DataFrame, posts: pd.DataFrame) -> pd.DataFrame:
+    if tracked_accounts.empty or posts.empty or "post_timestamp" not in posts.columns:
+        return pd.DataFrame(columns=TRACKED_ACCOUNT_COLUMNS)
+    if not {"effective_from", "effective_to", "status"}.issubset(tracked_accounts.columns):
+        return pd.DataFrame(columns=TRACKED_ACCOUNT_COLUMNS)
+    timestamps = pd.to_datetime(posts["post_timestamp"], errors="coerce")
+    timestamps = timestamps.dropna()
+    if timestamps.empty:
+        return pd.DataFrame(columns=TRACKED_ACCOUNT_COLUMNS)
+    active = discovery_service.current_active_accounts(tracked_accounts, as_of=timestamps.max())
+    for column in TRACKED_ACCOUNT_COLUMNS:
+        if column not in active.columns:
+            active[column] = pd.NA
+    return active[TRACKED_ACCOUNT_COLUMNS].reset_index(drop=True)
+
+
+def _normalize_recent_history(ranking_history: pd.DataFrame) -> pd.DataFrame:
+    if ranking_history.empty or "ranked_at" not in ranking_history.columns:
+        return pd.DataFrame(columns=RANKING_HISTORY_COLUMNS)
+    history = ranking_history.copy()
+    for column in RANKING_HISTORY_COLUMNS:
+        if column not in history.columns:
+            history[column] = pd.NA
+    history["ranked_at"] = pd.to_datetime(history["ranked_at"], errors="coerce")
+    history = history.dropna(subset=["ranked_at"]).copy()
+    if history.empty:
+        return pd.DataFrame(columns=RANKING_HISTORY_COLUMNS)
+    return history.sort_values(["ranked_at", "discovery_score"], ascending=[False, False]).head(TABLE_LIMIT)[RANKING_HISTORY_COLUMNS]
+
+
+def _top_accounts_chart(latest_rankings: pd.DataFrame) -> dict[str, Any]:
+    if latest_rankings.empty:
+        fig = go.Figure()
+        fig.update_layout(title="Top discovered accounts", xaxis_title="Discovery score", yaxis_title="Account")
+        return _figure_json(fig)
+
+    chart_data = latest_rankings.head(15).sort_values("discovery_score")
+    labels = chart_data["author_handle"].fillna("").astype(str).replace("", "[unknown]")
+    fig = go.Figure(
+        go.Bar(
+            x=chart_data["discovery_score"],
+            y=labels,
+            orientation="h",
+            marker_color="#14532d",
+        ),
+    )
+    fig.update_layout(
+        title="Top discovered accounts",
+        xaxis_title="Discovery score",
+        yaxis_title="Account",
+        margin={"l": 20, "r": 20, "t": 60, "b": 20},
+    )
+    return _figure_json(fig)
+
+
+def _ranking_trend_chart(ranking_history: pd.DataFrame) -> dict[str, Any]:
+    if ranking_history.empty or not {"ranked_at", "author_account_id"}.issubset(ranking_history.columns):
+        fig = go.Figure()
+        fig.update_layout(title="Discovery ranking history", xaxis_title="Ranked at", yaxis_title="Accounts")
+        return _figure_json(fig)
+    history = ranking_history.copy()
+    history["ranked_at"] = pd.to_datetime(history["ranked_at"], errors="coerce").dt.normalize()
+    history = history.dropna(subset=["ranked_at"]).copy()
+    if history.empty:
+        fig = go.Figure()
+        fig.update_layout(title="Discovery ranking history", xaxis_title="Ranked at", yaxis_title="Accounts")
+        return _figure_json(fig)
+    if "final_selected" not in history.columns:
+        history["final_selected"] = False
+    trend = (
+        history.groupby("ranked_at", as_index=False)
+        .agg(
+            ranked_accounts=("author_account_id", "nunique"),
+            selected_accounts=("final_selected", lambda values: int(pd.Series(values).fillna(False).astype(bool).sum())),
+        )
+        .sort_values("ranked_at")
+    )
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=trend["ranked_at"], y=trend["ranked_accounts"], mode="lines+markers", name="Ranked accounts"))
+    fig.add_trace(go.Scatter(x=trend["ranked_at"], y=trend["selected_accounts"], mode="lines+markers", name="Selected accounts"))
+    fig.update_layout(title="Discovery ranking history", xaxis_title="Ranked at", yaxis_title="Accounts")
+    return _figure_json(fig)
+
+
+def _message(posts: pd.DataFrame, source_mode: dict[str, Any], x_candidates: pd.DataFrame, latest_rankings: pd.DataFrame) -> str:
+    if posts.empty:
+        return "Refresh datasets first so Discovery can inspect X mention data."
+    if source_mode.get("mode") == "truth_only":
+        return (
+            "This dataset is currently Truth Social-only. Discovery ranks non-Trump X accounts that mention Trump, "
+            "so it is optional for reviewing sentiment based only on Donald Trump's Truth Social posts. "
+            "Load X/mention CSVs in Datasets if you want account discovery."
+        )
+    if x_candidates.empty:
+        return "No non-Trump X posts mentioning Trump are available for Discovery ranking."
+    if latest_rankings.empty:
+        return "Discovery rankings have not been built yet. Refresh datasets in the admin flow to populate account discovery."
+    return ""
+
+
+def build_discovery_workspace(store: DuckDBStore, discovery_service: DiscoveryService | None = None) -> dict[str, Any]:
+    discovery_service = discovery_service or DiscoveryService()
+    posts = store.read_frame("normalized_posts")
+    tracked_accounts = store.read_frame("tracked_accounts")
+    ranking_history = store.read_frame("account_rankings")
+    overrides = discovery_service.normalize_manual_overrides(store.read_frame("manual_account_overrides"))
+
+    source_mode = detect_source_mode(posts)
+    x_candidates = _x_candidate_posts(posts)
+    latest_rankings = latest_ranking_snapshot(ranking_history)
+    active_accounts = _active_accounts(discovery_service, tracked_accounts, posts)
+    recent_history = _normalize_recent_history(ranking_history)
+    message = _message(posts, source_mode, x_candidates, latest_rankings)
+    latest_ranked_at = (
+        pd.to_datetime(latest_rankings["ranked_at"], errors="coerce").max()
+        if not latest_rankings.empty and "ranked_at" in latest_rankings.columns
+        else pd.NaT
+    )
+    selected_status = latest_rankings["selected_status"].fillna("").astype(str) if "selected_status" in latest_rankings.columns else pd.Series(dtype=str)
+    override_actions = overrides["action"].fillna("").astype(str) if "action" in overrides.columns else pd.Series(dtype=str)
+
+    summary = {
+        "post_count": int(len(posts)),
+        "x_candidate_post_count": int(len(x_candidates)),
+        "active_account_count": int(len(active_accounts)),
+        "latest_ranking_count": int(len(latest_rankings)),
+        "selected_account_count": int((selected_status != "excluded").sum()) if not selected_status.empty else 0,
+        "pinned_account_count": int((selected_status == "pinned").sum()) if not selected_status.empty else 0,
+        "suppressed_latest_count": int(latest_rankings["suppressed_by_override"].fillna(False).astype(bool).sum()) if "suppressed_by_override" in latest_rankings.columns else 0,
+        "override_count": int(len(overrides)),
+        "pin_override_count": int((override_actions == "pin").sum()) if not override_actions.empty else 0,
+        "suppress_override_count": int((override_actions == "suppress").sum()) if not override_actions.empty else 0,
+    }
+
+    return {
+        "ready": bool(message == ""),
+        "message": message,
+        "source_mode": source_mode,
+        "latest_ranked_at": latest_ranked_at,
+        "summary": summary,
+        "charts": {
+            "top_discovered_accounts": _top_accounts_chart(latest_rankings),
+            "ranking_history": _ranking_trend_chart(recent_history),
+        },
+        "active_accounts": _frame_records(active_accounts.head(TABLE_LIMIT)),
+        "latest_rankings": _frame_records(latest_rankings.head(TABLE_LIMIT)),
+        "override_history": _frame_records(overrides.head(TABLE_LIMIT) if not overrides.empty else pd.DataFrame(columns=MANUAL_OVERRIDE_COLUMNS)),
+        "recent_ranking_history": _frame_records(recent_history.head(TABLE_LIMIT)),
+    }


### PR DESCRIPTION
## Summary
- Add a read-only Discovery workspace backend builder and `/api/discovery` endpoint for source mode, summary counts, active accounts, latest rankings, override history, recent ranking history, and Plotly chart payloads.
- Add a React Discovery tab with guidance, metric cards, top-account/ranking-history charts, active tracked accounts, latest rankings, and override history.
- Add backend API coverage for empty, Truth-only, schema-less, and populated Discovery states plus Playwright coverage for the new tab.

## Validation
- `.venv/bin/python -m unittest tests.test_api -v`
- `.venv/bin/python -m unittest discover -s tests -v`
- `npm run build --prefix frontend`
- `npm run test:ui --prefix frontend`
- `bash scripts/ci.sh`

Closes #53