### PR TITLE
[codex] Migrate live ops console

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -469,6 +469,85 @@ const livePayload = {
   ],
 };
 
+const liveOpsPayload = {
+  ...livePayload,
+  admin: {
+    mode: "public",
+    write_requires_unlock: true,
+    capture_scope: "stored_data_only",
+  },
+  current_config: {
+    mode: "portfolio_run",
+    portfolio_run_id: "run-portfolio-1",
+    portfolio_run_name: "Portfolio Alpha",
+    deployment_variant: "per_asset_hybrid",
+    fallback_mode: "SPY",
+  },
+  seeded_config: {
+    mode: "portfolio_run",
+    portfolio_run_id: "run-portfolio-1",
+    fallback_mode: "SPY",
+  },
+  run_options: [
+    {
+      run_id: "run-portfolio-1",
+      run_name: "Portfolio Alpha",
+      deployment_variant: "per_asset_hybrid",
+      deployment_narrative_feature_mode: "hybrid",
+      selected_symbols: "SPY, QQQ",
+      transaction_cost_bps: 2,
+    },
+  ],
+  asset_history: [],
+  decision_history: [
+    {
+      generated_at: "2026-04-20T12:00:00Z",
+      winning_asset: "QQQ",
+      winner_score: 0.024,
+    },
+  ],
+  paper: {
+    current_config: {
+      paper_portfolio_id: "paper-1",
+      portfolio_run_name: "Portfolio Alpha",
+      enabled: true,
+    },
+    active_config: {
+      paper_portfolio_id: "paper-1",
+      portfolio_run_name: "Portfolio Alpha",
+      deployment_variant: "per_asset_hybrid",
+      transaction_cost_bps: 2,
+      starting_cash: 100000,
+      enabled: true,
+    },
+    portfolios: [
+      {
+        paper_portfolio_id: "paper-1",
+        portfolio_run_name: "Portfolio Alpha",
+        deployment_variant: "per_asset_hybrid",
+        enabled: true,
+      },
+    ],
+    decision_journal: [
+      {
+        paper_portfolio_id: "paper-1",
+        winning_asset: "QQQ",
+        settlement_status: "pending",
+      },
+    ],
+    trade_ledger: [],
+    equity_curve: [],
+    benchmark_curve: [],
+  },
+  capture_result: {
+    persisted_assets: 2,
+    persisted_decisions: 1,
+    captured: 1,
+    settled: 0,
+    performance_persisted: true,
+  },
+};
+
 const portfoliosPayload = {
   current_config: {
     paper_portfolio_id: "paper-1",
@@ -545,6 +624,11 @@ async function mockApi(page: Page) {
   await fulfillJson(page, "/api/research**", researchPayload);
   await fulfillJson(page, "/api/discovery", discoveryPayload);
   await fulfillJson(page, "/api/live/current", livePayload);
+  await fulfillJson(page, "/api/live/ops", liveOpsPayload);
+  await fulfillJson(page, "/api/admin/session", { token: "admin-token", token_type: "bearer", expires_at: "2026-04-20T20:00:00Z", expires_in_seconds: 43200, mode: "public" });
+  await fulfillJson(page, "/api/live/config", liveOpsPayload);
+  await fulfillJson(page, "/api/live/capture", liveOpsPayload);
+  await fulfillJson(page, "/api/paper/current", liveOpsPayload);
   await fulfillJson(page, "/api/paper/portfolios", portfoliosPayload);
   await fulfillJson(page, "/api/performance/paper-1", performancePayload);
 }
@@ -630,14 +714,28 @@ test("shows the migrated run explorer with detail and comparison tables", async 
   await expect(page.getByText("run-asset-1: robust score")).toBeVisible();
 });
 
-test("shows the current live decision and candidate board", async ({ page }) => {
+test("shows live ops controls and supports admin actions", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Live Decision/ }).click();
+  await page.getByRole("button", { name: /Live Ops/ }).click();
 
-  await expect(page.getByRole("cell", { name: "QQQ" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Live Ops Console" })).toBeVisible();
+  await expect(page.getByText("Stored-data capture only")).toBeVisible();
+  await expect(page.getByText("Read-only until unlocked")).toBeVisible();
+  await page.getByPlaceholder("Admin password").fill("secret");
+  await page.getByRole("button", { name: "Unlock admin writes" }).click();
+  await expect(page.getByText("Unlocked for this browser session")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Pinned portfolio run" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save pinned portfolio run" })).toBeEnabled();
+  await page.getByRole("button", { name: "Save pinned portfolio run" }).click();
+  await page.getByRole("button", { name: "Capture current board" }).click();
+  await expect(page.getByRole("cell", { name: "QQQ", exact: true }).first()).toBeVisible();
   await expect(page.getByText("eligible", { exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Current ranked board" })).toBeVisible();
-  await expect(page.getByRole("cell", { name: "SPY" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "SPY", exact: true }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Paper portfolio controls" })).toBeVisible();
+  await page.getByRole("button", { name: "Disable paper trading" }).click();
+  await expect(page.getByRole("heading", { name: "Recent paper journal" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "pending" })).toBeVisible();
 });
 
 test("shows paper performance diagnostics and winner distribution", async ({ page }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ComponentType } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import createPlotlyComponentModule from "react-plotly.js/factory";
 import Plotly from "plotly.js-dist-min";
 import type { Data, Frame, Layout } from "plotly.js";
-import { api, type PlotlyFigure, type RecordRow, type ResearchFilters } from "./api";
+import { api, type LiveOpsPayload, type PlotlyFigure, type RecordRow, type ResearchFilters } from "./api";
 
 type PlotComponentFactory = (plotly: unknown) => ComponentType<Record<string, unknown>>;
 const createPlotlyComponent = (
@@ -20,7 +20,7 @@ const pages: Array<{ key: PageKey; label: string; deck: string }> = [
   { key: "discovery", label: "Discovery", deck: "Tracked account ranking workspace" },
   { key: "runs", label: "Run Explorer", deck: "Saved model results and comparisons" },
   { key: "data", label: "Data Health", deck: "Freshness, completeness, and anomalies" },
-  { key: "live", label: "Live Decision", deck: "Current portfolio board" },
+  { key: "live", label: "Live Ops", deck: "Operate deployed portfolio" },
   { key: "paper", label: "Paper + Performance", deck: "Portfolio audit and drift" },
 ];
 
@@ -935,43 +935,267 @@ function DataHealthPage() {
 }
 
 function LiveDecisionPage() {
-  const live = useQuery({ queryKey: ["live"], queryFn: api.live, refetchInterval: 60_000 });
+  const queryClient = useQueryClient();
+  const live = useQuery({ queryKey: ["live-ops"], queryFn: api.liveOps, refetchInterval: 60_000 });
+  const [adminToken, setAdminToken] = useState(() =>
+    typeof window === "undefined" ? "" : window.sessionStorage.getItem("allcaps_admin_token") ?? "",
+  );
+  const [password, setPassword] = useState("");
+  const [selectedRunId, setSelectedRunId] = useState("");
+  const [fallbackMode, setFallbackMode] = useState<"SPY" | "FLAT">("SPY");
+  const [startingCash, setStartingCash] = useState(100000);
+  const [resetCash, setResetCash] = useState(100000);
+
+  const applyLivePayload = (payload: LiveOpsPayload) => {
+    queryClient.setQueryData(["live-ops"], payload);
+  };
+  const unlock = useMutation({
+    mutationFn: () => api.adminSession(password),
+    onSuccess: (payload) => {
+      setAdminToken(payload.token);
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem("allcaps_admin_token", payload.token);
+      }
+      setPassword("");
+    },
+  });
+  const saveConfig = useMutation({
+    mutationFn: () => api.saveLiveConfig({ portfolio_run_id: selectedRunId, fallback_mode: fallbackMode }, adminToken),
+    onSuccess: applyLivePayload,
+  });
+  const capture = useMutation({
+    mutationFn: () => api.captureLive(adminToken),
+    onSuccess: applyLivePayload,
+  });
+  const paperAction = useMutation({
+    mutationFn: (request: { action: "enable" | "disable" | "reset" | "archive"; starting_cash?: number }) =>
+      api.paperCurrentAction(request, adminToken),
+    onSuccess: applyLivePayload,
+  });
+
+  useEffect(() => {
+    const config = live.data?.current_config ?? live.data?.seeded_config;
+    const nextRunId = String(config?.portfolio_run_id ?? live.data?.run_options[0]?.run_id ?? "");
+    const nextFallback = String(config?.fallback_mode ?? "SPY").toUpperCase() === "FLAT" ? "FLAT" : "SPY";
+    if (nextRunId && !selectedRunId) {
+      setSelectedRunId(nextRunId);
+    }
+    setFallbackMode(nextFallback);
+    const activeStartingCash = Number(live.data?.paper.active_config?.starting_cash ?? 100000);
+    if (Number.isFinite(activeStartingCash)) {
+      setResetCash(activeStartingCash);
+    }
+  }, [live.data, selectedRunId]);
+
   if (live.isLoading) {
-    return <LoadingBlock label="Loading live decision..." />;
+    return <LoadingBlock label="Loading live ops..." />;
   }
   if (live.error) {
     return <ErrorBlock error={live.error} />;
   }
 
-  if (!live.data?.configured) {
-    return (
-      <article className="panel panel--wide">
-        <div className="panel-heading">
-          <h2>Live monitor is not configured</h2>
-          <StatusPill label="Setup needed" tone="warn" />
-        </div>
-        {(live.data?.errors ?? []).map((error) => (
-          <p key={error}>{error}</p>
-        ))}
-      </article>
-    );
-  }
-
-  const decision = live.data.decision ?? {};
+  const payload = live.data;
+  const decision = payload?.decision ?? {};
+  const activePaper = payload?.paper.active_config ?? null;
+  const isUnlocked = Boolean(adminToken);
+  const mutationError = unlock.error ?? saveConfig.error ?? capture.error ?? paperAction.error;
   return (
     <section className="page-grid">
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <div>
+            <h2>Live Ops Console</h2>
+            <p>
+              Configure the pinned joint portfolio run, capture stored-data live snapshots, and manage the matching
+              paper portfolio. Dataset refreshes and model training remain in Streamlit for now.
+            </p>
+          </div>
+          <StatusPill label={payload?.admin.capture_scope === "stored_data_only" ? "Stored-data capture only" : "Live ops"} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Admin unlock
+            <input
+              type="password"
+              placeholder={payload?.admin.mode === "private" ? "Private mode: password optional" : "Admin password"}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          <label>
+            Session status
+            <button
+              className="action-button"
+              type="button"
+              aria-label={isUnlocked ? "Refresh admin token" : "Unlock admin writes"}
+              onClick={() => unlock.mutate()}
+              disabled={unlock.isPending}
+            >
+              {isUnlocked ? "Refresh admin token" : "Unlock admin writes"}
+            </button>
+          </label>
+          <label>
+            Write state
+            <span className="form-readout">{isUnlocked ? "Unlocked for this browser session" : "Read-only until unlocked"}</span>
+          </label>
+          <label>
+            App mode
+            <span className="form-readout">{payload?.admin.mode ?? "unknown"}</span>
+          </label>
+        </div>
+        {mutationError ? <ErrorBlock error={mutationError} /> : null}
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Pinned portfolio run</h2>
+          <StatusPill label={payload?.configured ? "Configured" : "Setup needed"} tone={payload?.configured ? "ok" : "warn"} />
+        </div>
+        {(payload?.errors ?? []).map((error) => (
+          <p key={error}>{error}</p>
+        ))}
+        {payload?.run_options.length ? (
+          <div className="filter-grid filter-grid--compact">
+            <label>
+              Pinned joint portfolio run
+              <select value={selectedRunId} onChange={(event) => setSelectedRunId(event.target.value)} disabled={!isUnlocked}>
+                {payload.run_options.map((run) => (
+                  <option key={String(run.run_id)} value={String(run.run_id)}>
+                    {String(run.run_name ?? run.run_id)} | {String(run.deployment_variant ?? "n/a")} |{" "}
+                    {String(run.selected_symbols ?? "n/a")}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Fallback mode
+              <select value={fallbackMode} onChange={(event) => setFallbackMode(event.target.value as "SPY" | "FLAT")} disabled={!isUnlocked}>
+                <option value="SPY">SPY</option>
+                <option value="FLAT">FLAT</option>
+              </select>
+            </label>
+            <label>
+              Config action
+              <button
+                className="action-button"
+                type="button"
+                aria-label="Save pinned portfolio run"
+                disabled={!isUnlocked || !selectedRunId || saveConfig.isPending}
+                onClick={() => saveConfig.mutate()}
+              >
+                Save pinned portfolio run
+              </button>
+            </label>
+            <label>
+              Capture action
+              <button className="action-button" type="button" aria-label="Capture current board" disabled={!isUnlocked || capture.isPending} onClick={() => capture.mutate()}>
+                Capture current board
+              </button>
+            </label>
+          </div>
+        ) : (
+          <div className="empty-state">Save a joint portfolio model run before configuring Live Ops.</div>
+        )}
+        <DataTable rows={payload?.run_options ?? []} emptyLabel="No joint portfolio runs returned." />
+      </article>
+
       <div className="metric-grid">
         <MetricCard label="Winner" value={decision.winning_asset ?? "FLAT"} />
         <MetricCard label="Decision source" value={decision.decision_source} />
         <MetricCard label="Winner score" value={decision.winner_score} />
         <MetricCard label="Eligible assets" value={decision.eligible_asset_count} />
       </div>
+
       <article className="panel panel--wide">
         <div className="panel-heading">
           <h2>Current ranked board</h2>
-          <StatusPill label="Read-only" />
+          <StatusPill label={payload?.warnings.length ? `${payload.warnings.length} warning(s)` : "Current"} />
         </div>
-        <DataTable rows={live.data.board} />
+        {(payload?.warnings ?? []).map((warning) => (
+          <p key={warning}>{warning}</p>
+        ))}
+        <DataTable rows={payload?.board ?? []} />
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Capture status</h2>
+          <StatusPill label="No ingestion refresh" />
+        </div>
+        <div className="metric-grid">
+          <MetricCard label="Asset rows persisted" value={payload?.capture_result.persisted_assets ?? 0} />
+          <MetricCard label="Decision rows persisted" value={payload?.capture_result.persisted_decisions ?? 0} />
+          <MetricCard label="Paper decisions captured" value={payload?.capture_result.captured ?? 0} />
+          <MetricCard label="Paper decisions settled" value={payload?.capture_result.settled ?? 0} />
+        </div>
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Paper portfolio controls</h2>
+          <StatusPill label={activePaper ? (activePaper.enabled ? "Enabled" : "Disabled") : "Not enabled"} tone={activePaper ? "ok" : "warn"} />
+        </div>
+        <div className="metric-grid">
+          <MetricCard label="Paper portfolio" value={activePaper?.paper_portfolio_id ?? "none"} />
+          <MetricCard label="Starting cash" value={activePaper?.starting_cash ?? startingCash} />
+          <MetricCard label="Trade cost bps" value={activePaper?.transaction_cost_bps ?? "n/a"} />
+          <MetricCard label="Archived portfolios" value={(payload?.paper.portfolios ?? []).filter((row) => row.archived_at).length} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Starting cash
+            <input type="number" min={1000} step={1000} value={startingCash} onChange={(event) => setStartingCash(Number(event.target.value))} disabled={!isUnlocked} />
+          </label>
+          <label>
+            Enable
+            <button className="action-button" type="button" aria-label="Enable paper trading" disabled={!isUnlocked || paperAction.isPending} onClick={() => paperAction.mutate({ action: "enable", starting_cash: startingCash })}>
+              Enable paper trading
+            </button>
+          </label>
+          <label>
+            Toggle
+            <button
+              className="action-button"
+              type="button"
+              aria-label={activePaper?.enabled ? "Disable paper trading" : "Enable existing portfolio"}
+              disabled={!isUnlocked || !activePaper || paperAction.isPending}
+              onClick={() => paperAction.mutate({ action: activePaper?.enabled ? "disable" : "enable", starting_cash: Number(activePaper?.starting_cash ?? startingCash) })}
+            >
+              {activePaper?.enabled ? "Disable paper trading" : "Enable existing portfolio"}
+            </button>
+          </label>
+          <label>
+            Archive
+            <button className="action-button action-button--danger" type="button" aria-label="Archive current portfolio" disabled={!isUnlocked || !activePaper || paperAction.isPending} onClick={() => paperAction.mutate({ action: "archive" })}>
+              Archive current portfolio
+            </button>
+          </label>
+          <label>
+            Reset cash
+            <input type="number" min={1000} step={1000} value={resetCash} onChange={(event) => setResetCash(Number(event.target.value))} disabled={!isUnlocked || !activePaper} />
+          </label>
+          <label>
+            Reset
+            <button className="action-button" type="button" aria-label="Reset portfolio" disabled={!isUnlocked || paperAction.isPending} onClick={() => paperAction.mutate({ action: "reset", starting_cash: resetCash })}>
+              Reset portfolio
+            </button>
+          </label>
+        </div>
+        <DataTable rows={payload?.paper.portfolios ?? []} emptyLabel="No paper portfolios have been created yet." />
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Recent live decisions</h2>
+        </div>
+        <DataTable rows={payload?.decision_history ?? []} emptyLabel="No persisted live decision history yet." />
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Recent paper journal</h2>
+        </div>
+        <DataTable rows={payload?.paper.decision_journal ?? []} emptyLabel="No paper decisions captured yet." />
       </article>
     </section>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -101,6 +101,55 @@ export type LivePayload = {
   board: RecordRow[];
 };
 
+export type AdminSessionPayload = {
+  token: string;
+  token_type: string;
+  expires_at: string;
+  expires_in_seconds: number;
+  mode: string;
+};
+
+export type LiveConfigSaveRequest = {
+  portfolio_run_id: string;
+  fallback_mode: "SPY" | "FLAT";
+};
+
+export type LiveCapturePayload = {
+  persisted_assets: number;
+  persisted_decisions: number;
+  captured: number;
+  settled: number;
+  performance_persisted: boolean;
+};
+
+export type PaperCurrentActionRequest = {
+  action: "enable" | "disable" | "reset" | "archive";
+  starting_cash?: number;
+};
+
+export type LiveOpsPayload = LivePayload & {
+  admin: {
+    mode: string;
+    write_requires_unlock: boolean;
+    capture_scope: string;
+  };
+  current_config: RecordRow | null;
+  seeded_config: RecordRow | null;
+  run_options: RecordRow[];
+  asset_history: RecordRow[];
+  decision_history: RecordRow[];
+  paper: {
+    current_config: RecordRow | null;
+    active_config: RecordRow | null;
+    portfolios: RecordRow[];
+    decision_journal: RecordRow[];
+    trade_ledger: RecordRow[];
+    equity_curve: RecordRow[];
+    benchmark_curve: RecordRow[];
+  };
+  capture_result: LiveCapturePayload;
+};
+
 export type PaperPortfoliosPayload = {
   current_config: RecordRow | null;
   portfolios: RecordRow[];
@@ -225,9 +274,34 @@ async function getJson<T>(path: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
+async function postJson<T>(path: string, payload: unknown = {}, token?: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`;
+    try {
+      const body = (await response.json()) as { detail?: unknown };
+      if (body.detail) {
+        detail = Array.isArray(body.detail) ? body.detail.join("; ") : String(body.detail);
+      }
+    } catch {
+      // Keep the HTTP status fallback when the response is not JSON.
+    }
+    throw new Error(`API request failed: ${detail}`);
+  }
+  return response.json() as Promise<T>;
+}
+
 export const api = {
   baseUrl: API_BASE_URL,
   status: () => getJson<StatusPayload>("/api/status"),
+  adminSession: (password = "") => postJson<AdminSessionPayload>("/api/admin/session", { password }),
   health: () => getJson<HealthPayload>("/api/datasets/health"),
   runs: () => getJson<RunsPayload>("/api/runs"),
   runDetail: (runId: string, options: { variantName?: string; sessionDate?: string } = {}) => {
@@ -254,6 +328,10 @@ export const api = {
   researchExportUrl: (filters?: ResearchFilters) => `${API_BASE_URL}/api/research/export${researchQuery(filters)}`,
   discovery: () => getJson<DiscoveryPayload>("/api/discovery"),
   live: () => getJson<LivePayload>("/api/live/current"),
+  liveOps: () => getJson<LiveOpsPayload>("/api/live/ops"),
+  saveLiveConfig: (request: LiveConfigSaveRequest, token: string) => postJson<LiveOpsPayload>("/api/live/config", request, token),
+  captureLive: (token: string) => postJson<LiveOpsPayload>("/api/live/capture", {}, token),
+  paperCurrentAction: (request: PaperCurrentActionRequest, token: string) => postJson<LiveOpsPayload>("/api/paper/current", request, token),
   paperPortfolios: () => getJson<PaperPortfoliosPayload>("/api/paper/portfolios"),
   performance: (paperPortfolioId: string) => getJson<PerformancePayload>(`/api/performance/${paperPortfolioId}`),
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -374,6 +374,46 @@ select[multiple] {
   background: var(--field);
 }
 
+.action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  width: min(100%, 360px);
+  padding: 12px 16px;
+  color: #0f1b12;
+  font-size: 0.82rem;
+  font-weight: 900;
+  border: 1px solid rgba(23, 32, 24, 0.12);
+  border-radius: 16px;
+  background: var(--field);
+  cursor: pointer;
+}
+
+.action-button:disabled {
+  color: var(--muted);
+  background: rgba(23, 32, 24, 0.06);
+  cursor: not-allowed;
+}
+
+.action-button--danger {
+  color: #fff;
+  background: var(--severe);
+}
+
+.form-readout {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  padding: 12px 16px;
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.42);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
 .note-list {
   display: grid;
   gap: 10px;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -571,10 +571,29 @@ class ApiContractTests(unittest.TestCase):
                         "variant_name": "per_asset_hybrid",
                         "topology": "per_asset",
                         "narrative_feature_mode": "hybrid",
+                        "selected_symbols": ["SPY", "QQQ"],
+                        "threshold": 0.001,
+                        "min_post_count": 1,
                         "model_family": "ridge",
                         "models": {
-                            "SPY": {"feature_names": ["post_count", "semantic_relevance_avg"]},
-                            "QQQ": {"feature_names": ["post_count", "policy_trade_count"]},
+                            "SPY": {
+                                "model_version": "spy-live-test",
+                                "feature_names": ["post_count", "semantic_relevance_avg"],
+                                "intercept": 0.0,
+                                "coefficients": [0.004, 0.0],
+                                "means": [0.0, 0.0],
+                                "stds": [1.0, 1.0],
+                                "residual_std": 0.05,
+                            },
+                            "QQQ": {
+                                "model_version": "qqq-live-test",
+                                "feature_names": ["post_count", "policy_trade_count"],
+                                "intercept": 0.0,
+                                "coefficients": [0.006, 0.0],
+                                "means": [0.0, 0.0],
+                                "stds": [1.0, 1.0],
+                                "residual_std": 0.05,
+                            },
                         },
                     },
                 },
@@ -698,6 +717,59 @@ class ApiContractTests(unittest.TestCase):
                 columns=PAPER_BENCHMARK_CURVE_COLUMNS,
             ),
         )
+
+    def _admin_token(self) -> str:
+        response = self.client.post("/api/admin/session", json={})
+        self.assertEqual(response.status_code, 200)
+        return str(response.json()["token"])
+
+    def _save_live_ops_fixture(self) -> None:
+        self._save_portfolio_run_artifacts()
+        signal_date = pd.Timestamp("2025-02-04")
+        next_date = pd.Timestamp("2025-02-05")
+        self.store.save_frame(
+            "asset_session_features",
+            pd.DataFrame(
+                [
+                    {
+                        "asset_symbol": "SPY",
+                        "signal_session_date": signal_date,
+                        "next_session_date": next_date,
+                        "post_count": 3,
+                        "semantic_relevance_avg": 0.5,
+                        "policy_trade_count": 0.0,
+                        "target_available": True,
+                        "tradeable": True,
+                        "next_session_open": 100.0,
+                        "next_session_close": 101.0,
+                        "next_session_open_ts": pd.Timestamp("2025-02-05 14:30:00", tz="UTC"),
+                    },
+                    {
+                        "asset_symbol": "QQQ",
+                        "signal_session_date": signal_date,
+                        "next_session_date": next_date,
+                        "post_count": 2,
+                        "semantic_relevance_avg": 0.1,
+                        "policy_trade_count": 1.0,
+                        "target_available": True,
+                        "tradeable": True,
+                        "next_session_open": 200.0,
+                        "next_session_close": 204.0,
+                        "next_session_open_ts": pd.Timestamp("2025-02-05 14:30:00", tz="UTC"),
+                    },
+                ],
+            ),
+        )
+        self.store.save_frame(
+            "asset_daily",
+            pd.DataFrame(
+                [
+                    {"symbol": "SPY", "trade_date": next_date, "open": 100.0, "close": 101.0},
+                    {"symbol": "QQQ", "trade_date": next_date, "open": 200.0, "close": 204.0},
+                ],
+            ),
+        )
+        self.store.save_frame("asset_post_mappings", pd.DataFrame())
 
     def test_status_reports_source_mode_and_state_paths(self) -> None:
         self._save_truth_posts()
@@ -855,6 +927,105 @@ class ApiContractTests(unittest.TestCase):
         self.assertEqual(live_response.status_code, 200)
         self.assertFalse(live_response.json()["configured"])
         self.assertIn("No live monitor config", live_response.json()["errors"][0])
+
+    def test_admin_session_auth_modes_and_protected_writes(self) -> None:
+        private_response = self.client.post("/api/admin/session", json={})
+        self.assertEqual(private_response.status_code, 200)
+        self.assertIn("token", private_response.json())
+        protected_response = self.client.post("/api/live/config", json={"portfolio_run_id": "missing", "fallback_mode": "SPY"})
+        self.assertEqual(protected_response.status_code, 401)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            public_settings = AppSettings(base_dir=Path(temp_dir), public_mode=True, admin_password="secret")
+            public_client = TestClient(create_app(settings=public_settings, store=DuckDBStore(public_settings)))
+            bad = public_client.post("/api/admin/session", json={"password": "wrong"})
+            good = public_client.post("/api/admin/session", json={"password": "secret"})
+            self.assertEqual(bad.status_code, 401)
+            self.assertEqual(good.status_code, 200)
+
+    def test_live_ops_config_save_validates_and_returns_payload(self) -> None:
+        self._save_portfolio_run_artifacts()
+        token = self._admin_token()
+
+        bad = self.client.post(
+            "/api/live/config",
+            json={"portfolio_run_id": "missing", "fallback_mode": "SPY"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        good = self.client.post(
+            "/api/live/config",
+            json={"portfolio_run_id": "portfolio-run-1", "fallback_mode": "FLAT"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        ops = self.client.get("/api/live/ops")
+
+        self.assertEqual(bad.status_code, 400)
+        self.assertEqual(good.status_code, 200)
+        self.assertEqual(good.json()["current_config"]["portfolio_run_id"], "portfolio-run-1")
+        self.assertEqual(good.json()["current_config"]["fallback_mode"], "FLAT")
+        self.assertEqual(ops.status_code, 200)
+        self.assertEqual(ops.json()["run_options"][0]["run_id"], "portfolio-run-1")
+
+    def test_live_ops_capture_persists_snapshots_without_refresh(self) -> None:
+        self._save_live_ops_fixture()
+        token = self._admin_token()
+        self.client.post(
+            "/api/live/config",
+            json={"portfolio_run_id": "portfolio-run-1", "fallback_mode": "SPY"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        response = self.client.post("/api/live/capture", json={}, headers={"Authorization": f"Bearer {token}"})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["capture_result"]["persisted_assets"], 2)
+        self.assertEqual(payload["capture_result"]["persisted_decisions"], 1)
+        self.assertFalse(self.store.read_frame("live_asset_snapshots").empty)
+        self.assertFalse(self.store.read_frame("live_decision_snapshots").empty)
+        self.assertTrue(self.store.read_frame("refresh_history").empty)
+
+    def test_paper_current_actions_manage_active_portfolio(self) -> None:
+        self._save_live_ops_fixture()
+        token = self._admin_token()
+        self.client.post(
+            "/api/live/config",
+            json={"portfolio_run_id": "portfolio-run-1", "fallback_mode": "SPY"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        enabled = self.client.post(
+            "/api/paper/current",
+            json={"action": "enable", "starting_cash": 123000},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        disabled = self.client.post(
+            "/api/paper/current",
+            json={"action": "disable"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        reset = self.client.post(
+            "/api/paper/current",
+            json={"action": "reset", "starting_cash": 125000},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        archived = self.client.post(
+            "/api/paper/current",
+            json={"action": "archive"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(enabled.status_code, 200)
+        self.assertEqual(enabled.json()["paper"]["active_config"]["starting_cash"], 123000.0)
+        self.assertEqual(disabled.status_code, 200)
+        self.assertFalse(disabled.json()["paper"]["active_config"]["enabled"])
+        self.assertEqual(reset.status_code, 200)
+        self.assertEqual(reset.json()["paper"]["active_config"]["starting_cash"], 125000.0)
+        self.assertEqual(archived.status_code, 200)
+        self.assertIsNone(archived.json()["paper"]["active_config"])
+        registry = self.store.read_frame("paper_portfolio_registry")
+        self.assertGreaterEqual(len(registry), 2)
+        self.assertTrue(registry["archived_at"].notna().any())
 
     def test_run_compare_endpoint_handles_empty_store(self) -> None:
         response = self.client.get("/api/runs/compare")

--- a/trump_workbench/api.py
+++ b/trump_workbench/api.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import secrets
+import time
 from typing import Any
 
 import numpy as np
 import pandas as pd
-from fastapi import FastAPI, Query, Response
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 
+from .access import verify_admin_password
 from .config import AppSettings
 from .discovery import DiscoveryService
 from .discovery_workspace import build_discovery_workspace
@@ -14,6 +18,12 @@ from .enrichment import LLMEnrichmentService
 from .experiments import ExperimentStore
 from .health import DataHealthService, build_health_summary, build_health_trend_frame, ensure_refresh_history_frame
 from .live_monitor import build_live_portfolio_run_state, validate_live_monitor_config
+from .live_ops import (
+    apply_paper_action,
+    build_live_config_from_run,
+    build_live_ops_payload,
+    run_live_capture,
+)
 from .modeling import ModelService
 from .paper_trading import (
     PaperTradingService,
@@ -37,6 +47,22 @@ from .runtime import missing_core_datasets
 from .research_workspace import build_research_workspace, detect_source_mode
 from .run_explorer import build_run_comparison_payload, build_run_detail_payload
 from .storage import DuckDBStore
+
+ADMIN_TOKEN_TTL_SECONDS = 12 * 60 * 60
+
+
+class AdminSessionRequest(BaseModel):
+    password: str = ""
+
+
+class LiveConfigSaveRequest(BaseModel):
+    portfolio_run_id: str
+    fallback_mode: str = "SPY"
+
+
+class PaperCurrentActionRequest(BaseModel):
+    action: str
+    starting_cash: float | None = None
 
 
 def _json_safe(value: Any) -> Any:
@@ -83,15 +109,43 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
     )
     app.state.settings = settings
     app.state.store = store
+    app.state.admin_tokens = {}
 
     if settings.api_cors_origins:
         app.add_middleware(
             CORSMiddleware,
             allow_origins=list(settings.api_cors_origins),
             allow_credentials=False,
-            allow_methods=["GET", "OPTIONS"],
-            allow_headers=["*"],
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["Authorization", "Content-Type"],
         )
+
+    def issue_admin_token() -> dict[str, Any]:
+        token = secrets.token_urlsafe(32)
+        expires_at = time.time() + ADMIN_TOKEN_TTL_SECONDS
+        app.state.admin_tokens[token] = expires_at
+        return {
+            "token": token,
+            "token_type": "bearer",
+            "expires_at": pd.Timestamp(expires_at, unit="s", tz="UTC").isoformat(),
+            "expires_in_seconds": ADMIN_TOKEN_TTL_SECONDS,
+            "mode": "public" if settings.public_mode else "private",
+        }
+
+    def require_admin(authorization: str | None = Header(default=None)) -> None:
+        if not authorization or not authorization.lower().startswith("bearer "):
+            raise HTTPException(status_code=401, detail="Admin token is required.")
+        token = authorization.split(" ", 1)[1].strip()
+        now = time.time()
+        tokens = {
+            key: expiry
+            for key, expiry in dict(app.state.admin_tokens).items()
+            if float(expiry) > now
+        }
+        app.state.admin_tokens = tokens
+        expiry = tokens.get(token)
+        if expiry is None or float(expiry) <= now:
+            raise HTTPException(status_code=401, detail="Admin token is invalid or expired.")
 
     @app.get("/api/status")
     def status() -> dict[str, Any]:
@@ -108,6 +162,13 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
                 "dataset_count": int(len(registry)),
             },
         )
+
+    @app.post("/api/admin/session")
+    def admin_session(request: AdminSessionRequest | None = None) -> dict[str, Any]:
+        password = request.password if request is not None else ""
+        if settings.public_mode and not verify_admin_password(settings, password):
+            raise HTTPException(status_code=401, detail="Invalid admin password.")
+        return _json_safe(issue_admin_token())
 
     @app.get("/api/research")
     def research(
@@ -289,6 +350,68 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
             "board": _frame_records(board),
         }
 
+    @app.get("/api/live/ops")
+    def live_ops() -> dict[str, Any]:
+        return _json_safe(
+            build_live_ops_payload(
+                store=store,
+                experiment_store=experiment_store,
+                model_service=model_service,
+                paper_service=paper_service,
+                performance_service=performance_service,
+                public_mode=settings.public_mode,
+            ),
+        )
+
+    @app.post("/api/live/config")
+    def save_live_config(
+        request: LiveConfigSaveRequest,
+        _admin: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        config, errors = build_live_config_from_run(
+            experiment_store.list_runs(),
+            portfolio_run_id=request.portfolio_run_id,
+            fallback_mode=request.fallback_mode,
+        )
+        if errors or config is None:
+            raise HTTPException(status_code=400, detail=errors or ["Invalid live config."])
+        experiment_store.save_live_monitor_config(config)
+        return _json_safe(
+            build_live_ops_payload(
+                store=store,
+                experiment_store=experiment_store,
+                model_service=model_service,
+                paper_service=paper_service,
+                performance_service=performance_service,
+                public_mode=settings.public_mode,
+            ),
+        )
+
+    @app.post("/api/live/capture")
+    def capture_live(
+        _admin: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        capture_result = run_live_capture(
+            store=store,
+            experiment_store=experiment_store,
+            model_service=model_service,
+            paper_service=paper_service,
+            performance_service=performance_service,
+        )
+        if capture_result.get("errors"):
+            raise HTTPException(status_code=400, detail=capture_result["errors"])
+        return _json_safe(
+            build_live_ops_payload(
+                store=store,
+                experiment_store=experiment_store,
+                model_service=model_service,
+                paper_service=paper_service,
+                performance_service=performance_service,
+                capture_result=capture_result,
+                public_mode=settings.public_mode,
+            ),
+        )
+
     @app.get("/api/paper/portfolios")
     def paper_portfolios() -> dict[str, Any]:
         registry = paper_service.list_portfolios()
@@ -297,6 +420,31 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
             "current_config": _json_safe(current_config.to_dict()) if current_config is not None else None,
             "portfolios": _frame_records(registry),
         }
+
+    @app.post("/api/paper/current")
+    def paper_current_action(
+        request: PaperCurrentActionRequest,
+        _admin: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        _config, errors = apply_paper_action(
+            store=store,
+            experiment_store=experiment_store,
+            paper_service=paper_service,
+            action=request.action,
+            starting_cash=request.starting_cash,
+        )
+        if errors:
+            raise HTTPException(status_code=400, detail=errors)
+        return _json_safe(
+            build_live_ops_payload(
+                store=store,
+                experiment_store=experiment_store,
+                model_service=model_service,
+                paper_service=paper_service,
+                performance_service=performance_service,
+                public_mode=settings.public_mode,
+            ),
+        )
 
     @app.get("/api/paper/{paper_portfolio_id}")
     def paper_portfolio(paper_portfolio_id: str) -> dict[str, Any]:

--- a/trump_workbench/live_ops.py
+++ b/trump_workbench/live_ops.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .contracts import LiveMonitorConfig, PaperPortfolioConfig
+from .experiments import ExperimentStore
+from .live_monitor import build_live_portfolio_run_state, seed_live_monitor_config, validate_live_monitor_config
+from .modeling import ModelService
+from .paper_trading import (
+    PaperTradingService,
+    ensure_paper_benchmark_curve_frame,
+    ensure_paper_decision_journal_frame,
+    ensure_paper_equity_curve_frame,
+    ensure_paper_portfolio_registry_frame,
+    ensure_paper_trade_ledger_frame,
+    paper_config_matches_live,
+)
+from .performance import PerformanceObservatoryService
+from .storage import DuckDBStore
+
+
+def _records(frame: pd.DataFrame, limit: int | None = None, tail: bool = False) -> list[dict[str, Any]]:
+    if frame.empty:
+        return []
+    out = frame.copy()
+    if limit is not None:
+        out = out.tail(limit) if tail else out.head(limit)
+    return out.to_dict(orient="records")
+
+
+def _joint_portfolio_runs(runs: pd.DataFrame) -> pd.DataFrame:
+    if runs.empty:
+        return pd.DataFrame()
+    normalized = runs.copy()
+    for column, default in [("run_type", "asset_model"), ("allocator_mode", "")]:
+        if column not in normalized.columns:
+            normalized[column] = default
+        normalized[column] = normalized[column].fillna(default).astype(str)
+    return normalized.loc[
+        (normalized["run_type"] == "portfolio_allocator")
+        & (normalized["allocator_mode"] == "joint_model")
+    ].copy()
+
+
+def _run_options(joint_runs: pd.DataFrame) -> list[dict[str, Any]]:
+    options: list[dict[str, Any]] = []
+    for _, row in joint_runs.iterrows():
+        selected = row.get("selected_params_json", {}) or {}
+        metrics = row.get("metrics_json", {}) or {}
+        options.append(
+            {
+                "run_id": str(row.get("run_id", "") or ""),
+                "run_name": str(row.get("run_name", "") or ""),
+                "created_at": row.get("created_at"),
+                "fallback_mode": str(selected.get("fallback_mode", "SPY") or "SPY").upper(),
+                "deployment_variant": str(selected.get("deployment_variant", "") or ""),
+                "deployment_narrative_feature_mode": str(selected.get("deployment_narrative_feature_mode", "") or ""),
+                "selected_symbols": ", ".join(str(symbol).upper() for symbol in selected.get("selected_symbols", []) or []),
+                "transaction_cost_bps": float(selected.get("transaction_cost_bps", 0.0) or 0.0),
+                "robust_score": metrics.get("robust_score"),
+                "total_return": metrics.get("total_return"),
+            },
+        )
+    return options
+
+
+def _selected_run_row(joint_runs: pd.DataFrame, run_id: str) -> pd.Series | None:
+    matches = joint_runs.loc[joint_runs["run_id"].astype(str) == str(run_id)].copy()
+    if matches.empty:
+        return None
+    return matches.iloc[0]
+
+
+def build_live_config_from_run(
+    runs: pd.DataFrame,
+    portfolio_run_id: str,
+    fallback_mode: str,
+) -> tuple[LiveMonitorConfig | None, list[str]]:
+    normalized_fallback = str(fallback_mode or "SPY").upper()
+    joint_runs = _joint_portfolio_runs(runs)
+    selected_row = _selected_run_row(joint_runs, portfolio_run_id)
+    if selected_row is None:
+        return None, [f"Portfolio run `{portfolio_run_id}` is not available."]
+    selected = selected_row.get("selected_params_json", {}) or {}
+    config = LiveMonitorConfig(
+        mode="portfolio_run",
+        fallback_mode=normalized_fallback,
+        portfolio_run_id=str(portfolio_run_id),
+        portfolio_run_name=str(selected_row.get("run_name", portfolio_run_id) or portfolio_run_id),
+        deployment_variant=str(selected.get("deployment_variant", "") or ""),
+    )
+    return config, validate_live_monitor_config(config, runs)
+
+
+def _active_run_context(runs: pd.DataFrame, config: LiveMonitorConfig | None) -> dict[str, Any]:
+    if config is None:
+        return {"run_name": "", "transaction_cost_bps": 0.0}
+    joint_runs = _joint_portfolio_runs(runs)
+    row = _selected_run_row(joint_runs, str(config.portfolio_run_id or ""))
+    if row is None:
+        return {"run_name": str(config.portfolio_run_name or config.portfolio_run_id or ""), "transaction_cost_bps": 0.0}
+    selected = row.get("selected_params_json", {}) or {}
+    return {
+        "run_name": str(row.get("run_name", config.portfolio_run_name or config.portfolio_run_id) or config.portfolio_run_name or config.portfolio_run_id),
+        "transaction_cost_bps": float(selected.get("transaction_cost_bps", 0.0) or 0.0),
+    }
+
+
+def _paper_payload(store: DuckDBStore, paper_service: PaperTradingService, config: LiveMonitorConfig | None) -> dict[str, Any]:
+    registry = ensure_paper_portfolio_registry_frame(store.read_frame("paper_portfolio_registry"))
+    current_config = paper_service.load_current_config()
+    active_config = current_config if paper_config_matches_live(current_config, config) else None
+    journal = ensure_paper_decision_journal_frame(store.read_frame("paper_decision_journal"))
+    trades = ensure_paper_trade_ledger_frame(store.read_frame("paper_trade_ledger"))
+    equity = ensure_paper_equity_curve_frame(store.read_frame("paper_equity_curve"))
+    benchmark = ensure_paper_benchmark_curve_frame(store.read_frame("paper_benchmark_curve"))
+    active_id = str(active_config.paper_portfolio_id) if active_config is not None else ""
+    return {
+        "current_config": current_config.to_dict() if current_config is not None else None,
+        "active_config": active_config.to_dict() if active_config is not None else None,
+        "portfolios": _records(registry.sort_values("created_at", ascending=False) if not registry.empty else registry, limit=50),
+        "decision_journal": _records(journal.loc[journal["paper_portfolio_id"].astype(str) == active_id].sort_values("signal_session_date") if active_id else pd.DataFrame(), limit=25, tail=True),
+        "trade_ledger": _records(trades.loc[trades["paper_portfolio_id"].astype(str) == active_id].sort_values("signal_session_date") if active_id else pd.DataFrame(), limit=25, tail=True),
+        "equity_curve": _records(equity.loc[equity["paper_portfolio_id"].astype(str) == active_id].sort_values("signal_session_date") if active_id else pd.DataFrame()),
+        "benchmark_curve": _records(benchmark.loc[benchmark["paper_portfolio_id"].astype(str) == active_id].sort_values("signal_session_date") if active_id else pd.DataFrame()),
+    }
+
+
+def build_live_ops_payload(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    model_service: ModelService,
+    paper_service: PaperTradingService,
+    performance_service: PerformanceObservatoryService | None = None,
+    generated_at: pd.Timestamp | None = None,
+    capture_result: dict[str, Any] | None = None,
+    public_mode: bool = False,
+) -> dict[str, Any]:
+    runs = experiment_store.list_runs()
+    joint_runs = _joint_portfolio_runs(runs)
+    saved_config = experiment_store.load_live_monitor_config()
+    saved_is_portfolio = saved_config is not None and str(saved_config.mode or "portfolio_run") == "portfolio_run"
+    active_config = saved_config if saved_is_portfolio else None
+    seeded_config = seed_live_monitor_config(runs)
+    config_errors = validate_live_monitor_config(active_config, runs) if active_config is not None else []
+
+    board = pd.DataFrame()
+    decision = pd.DataFrame()
+    warnings: list[str] = []
+    if active_config is not None and not config_errors:
+        board, decision, _explanations, warnings = build_live_portfolio_run_state(
+            store=store,
+            model_service=model_service,
+            experiment_store=experiment_store,
+            config=active_config,
+            generated_at=generated_at or pd.Timestamp.now(tz="UTC").floor("s"),
+        )
+
+    asset_history = store.read_frame("live_asset_snapshots")
+    decision_history = store.read_frame("live_decision_snapshots")
+    if active_config is not None:
+        if not asset_history.empty and "run_id" in asset_history.columns:
+            asset_history = asset_history.loc[asset_history["run_id"].astype(str) == str(active_config.portfolio_run_id)].copy()
+        if not asset_history.empty and "variant_name" in asset_history.columns and active_config.deployment_variant:
+            asset_history = asset_history.loc[asset_history["variant_name"].astype(str) == str(active_config.deployment_variant)].copy()
+        if not decision_history.empty and "portfolio_run_id" in decision_history.columns:
+            decision_history = decision_history.loc[decision_history["portfolio_run_id"].astype(str) == str(active_config.portfolio_run_id)].copy()
+        if not decision_history.empty and "deployment_variant" in decision_history.columns and active_config.deployment_variant:
+            decision_history = decision_history.loc[decision_history["deployment_variant"].astype(str) == str(active_config.deployment_variant)].copy()
+
+    return {
+        "configured": bool(active_config is not None and not config_errors),
+        "errors": config_errors if active_config is not None else ["No live monitor config has been saved yet."],
+        "warnings": warnings,
+        "admin": {
+            "mode": "public" if public_mode else "private",
+            "write_requires_unlock": True,
+            "capture_scope": "stored_data_only",
+        },
+        "current_config": active_config.to_dict() if active_config is not None else None,
+        "seeded_config": seeded_config.to_dict() if seeded_config is not None else None,
+        "run_options": _run_options(joint_runs),
+        "decision": _records(decision)[0] if not decision.empty else None,
+        "board": _records(board),
+        "asset_history": _records(asset_history.sort_values("generated_at") if not asset_history.empty and "generated_at" in asset_history.columns else asset_history, limit=250, tail=True),
+        "decision_history": _records(decision_history.sort_values("generated_at") if not decision_history.empty and "generated_at" in decision_history.columns else decision_history, limit=50, tail=True),
+        "paper": _paper_payload(store, paper_service, active_config),
+        "capture_result": capture_result or {"persisted_assets": 0, "persisted_decisions": 0, "captured": 0, "settled": 0, "performance_persisted": False},
+    }
+
+
+def run_live_capture(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    model_service: ModelService,
+    paper_service: PaperTradingService,
+    performance_service: PerformanceObservatoryService | None = None,
+    generated_at: pd.Timestamp | None = None,
+) -> dict[str, Any]:
+    runs = experiment_store.list_runs()
+    live_config = experiment_store.load_live_monitor_config()
+    errors = validate_live_monitor_config(live_config, runs)
+    if errors or live_config is None or str(live_config.mode or "portfolio_run") != "portfolio_run":
+        return {"errors": errors or ["Save a portfolio-run live config before capturing."], "persisted_assets": 0, "persisted_decisions": 0, "captured": 0, "settled": 0, "performance_persisted": False}
+
+    snapshot_time = pd.Timestamp.now(tz="UTC").floor("s") if generated_at is None else pd.Timestamp(generated_at).floor("s")
+    board, decision, _explanations, warnings = build_live_portfolio_run_state(
+        store=store,
+        model_service=model_service,
+        experiment_store=experiment_store,
+        config=live_config,
+        generated_at=snapshot_time,
+    )
+    result: dict[str, Any] = {
+        "generated_at": snapshot_time,
+        "warnings": warnings,
+        "persisted_assets": 0,
+        "persisted_decisions": 0,
+        "captured": 0,
+        "settled": 0,
+        "performance_persisted": False,
+    }
+    if board.empty or decision.empty:
+        return result
+
+    experiment_store.save_live_asset_snapshots(board)
+    experiment_store.save_live_decision_snapshots(decision)
+    result["persisted_assets"] = int(len(board))
+    result["persisted_decisions"] = int(len(decision))
+
+    paper_config = paper_service.load_current_config()
+    if paper_config_matches_live(paper_config, live_config):
+        paper_update = paper_service.process_live_history(paper_config, as_of=snapshot_time)
+        result.update(paper_update)
+        if performance_service is not None and isinstance(paper_config, PaperPortfolioConfig):
+            performance_service.persist_snapshot(paper_config.paper_portfolio_id, generated_at=snapshot_time)
+            result["performance_persisted"] = True
+    return result
+
+
+def apply_paper_action(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    paper_service: PaperTradingService,
+    action: str,
+    starting_cash: float | None = None,
+    now: pd.Timestamp | None = None,
+) -> tuple[PaperPortfolioConfig | None, list[str]]:
+    live_config = experiment_store.load_live_monitor_config()
+    runs = experiment_store.list_runs()
+    errors = validate_live_monitor_config(live_config, runs)
+    if errors or live_config is None or str(live_config.mode or "portfolio_run") != "portfolio_run":
+        return None, errors or ["Save a portfolio-run live config before changing paper trading."]
+
+    context = _active_run_context(runs, live_config)
+    current = paper_service.load_current_config()
+    active = current if paper_config_matches_live(current, live_config) else None
+    normalized_action = str(action or "").strip().lower()
+    timestamp = pd.Timestamp.now(tz="UTC").floor("s") if now is None else pd.Timestamp(now).floor("s")
+
+    if normalized_action == "enable":
+        return (
+            paper_service.upsert_current_for_live_config(
+                live_config=live_config,
+                portfolio_run_name=context["run_name"],
+                transaction_cost_bps=float(context["transaction_cost_bps"]),
+                starting_cash=float(starting_cash or 100000.0),
+                enabled=True,
+                reset=False,
+                now=timestamp,
+            ),
+            [],
+        )
+    if normalized_action == "reset":
+        return (
+            paper_service.upsert_current_for_live_config(
+                live_config=live_config,
+                portfolio_run_name=context["run_name"],
+                transaction_cost_bps=float(context["transaction_cost_bps"]),
+                starting_cash=float(starting_cash or (active.starting_cash if active is not None else 100000.0)),
+                enabled=True,
+                reset=True,
+                now=timestamp,
+            ),
+            [],
+        )
+    if active is None:
+        return None, ["No active paper portfolio matches the pinned live config."]
+    if normalized_action == "disable":
+        return (
+            paper_service.upsert_current_for_live_config(
+                live_config=live_config,
+                portfolio_run_name=context["run_name"],
+                transaction_cost_bps=float(active.transaction_cost_bps),
+                starting_cash=float(active.starting_cash),
+                enabled=False,
+                reset=False,
+                now=timestamp,
+            ),
+            [],
+        )
+    if normalized_action == "archive":
+        return paper_service.archive_current_config(now=timestamp), []
+    return None, ["Paper action must be one of: enable, disable, reset, archive."]


### PR DESCRIPTION
## Summary
- Adds a minimal FastAPI admin unlock flow with 12-hour in-memory bearer tokens for write endpoints.
- Adds Live Ops backend orchestration for config save, stored-data live capture, paper portfolio actions, and composite live/paper status payloads.
- Expands the React Live page into a write-capable Live Ops Console with admin unlock, pinned-run config, capture, and paper controls.

Closes #55.

## Scope Notes
- React capture is stored-data only. It does not run ingestion, market refresh, discovery ranking, or feature refresh.
- Streamlit remains the owner of dataset refreshes, model training, and other admin-heavy flows.

## Validation
- `.venv/bin/python -m unittest tests.test_api -v`
- `.venv/bin/python -m unittest discover -s tests -v`
- `npm run build --prefix frontend`
- `npm run test:ui --prefix frontend`
- `bash scripts/ci.sh`