### PR TITLE
Migrate Dataset Admin to React and FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,13 @@ bash scripts/ci.sh
 
 ## Web-First Migration Preview
 
-The Streamlit app remains the primary user interface while the web-first migration is built in slices. The first migration surface adds:
+The Streamlit app remains available while the web-first migration is built in slices. The current web surface adds:
 
-- a read-only FastAPI backend in `trump_workbench/api.py`
+- a FastAPI backend in `trump_workbench/api.py`
 - a React + TypeScript + Vite frontend in `frontend/`
-- API-backed views for status, research, data health, saved runs, live decisions, paper portfolios, and performance diagnostics
+- API-backed views for status, research, Discovery, saved runs, live decisions, paper portfolios, performance diagnostics, and dataset administration
 - a migrated read-only Research workspace with sentiment filters, interactive Plotly charts, Narrative Lab outputs, and research ZIP export
+- admin-gated React controls for Live Ops and Data Admin workflows, including pinned portfolio-run configuration, paper controls, watchlist edits, CSV inputs, and dataset refresh jobs
 
 Run the API locally:
 
@@ -118,7 +119,7 @@ Optional frontend env var:
 
 - `VITE_ALLCAPS_API_BASE_URL=http://127.0.0.1:8000`
 
-The FastAPI surface is intentionally read-only in this slice. Admin mutations, model training, and refresh workflows still live in Streamlit until they are moved behind explicit job APIs.
+The React app is now mixed read/write. Public users can browse research and status pages, while mutating Data Admin and Live Ops actions require an admin token from `/api/admin/session`. Model training and Discovery override writes still live in Streamlit until those workflows are migrated behind explicit job APIs.
 
 Run browser UI tests for the React shell:
 
@@ -243,8 +244,8 @@ The hosted deployment uses these env vars:
 
 If you are new to the app, follow this order:
 
-1. Open `Datasets`.
-2. Click `Refresh full datasets`.
+1. Open React `Data Admin` or Streamlit `Datasets`.
+2. Run `Bootstrap`, `Full`, or `Refresh full datasets`.
 3. If you have X data, upload CSVs or point the app at a remote CSV URL.
 4. Open `Discovery` and review the tracked-account universe if you loaded X/mention data.
 5. Open `Research View` to inspect mapped posts and market context.
@@ -278,6 +279,8 @@ Use it to:
 - set a remote CSV URL
 - inspect the local dataset registry and source manifest
 - preview the normalized post table the rest of the app uses
+
+The React `Data Admin` tab covers day-to-day dataset operations through FastAPI: operating mode, scheduler status, watchlist save/reset, CSV URL/upload inputs, `bootstrap`/`full`/`incremental` refresh jobs, refresh-job history, data health, registry, and manifests. These writes require an admin unlock in public mode.
 
 Buttons:
 
@@ -490,7 +493,7 @@ The code is organized as a modular monolith under `trump_workbench/`:
 - `experiments.py` for saved runs and artifacts
 - `research.py` for descriptive visualization helpers
 - `ui.py` for the Streamlit app shell
-- `api.py` for the read-only FastAPI migration surface
+- `api.py` for the FastAPI migration surface
 - `frontend/` for the React + TypeScript web shell
 
 ## Testing

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -55,6 +55,67 @@ const healthPayload = {
   ],
 };
 
+const datasetAdminPayload = {
+  ...healthPayload,
+  admin: {
+    mode: "public",
+    write_requires_unlock: true,
+  },
+  status: {
+    operating_mode: "Truth Social-only",
+    source_mode: statusPayload.source_mode,
+    state_root: statusPayload.state_root,
+    db_path: statusPayload.db_path,
+    scheduler_enabled: false,
+    missing_core_datasets: [],
+    missing_core_dataset_count: 0,
+    last_refresh: {
+      refresh_mode: "incremental",
+      status: "success",
+      completed_at: "2026-04-20T12:00:00Z",
+    },
+    active_job_id: "",
+  },
+  watchlist_symbols: ["NVDA", "TSLA"],
+  asset_universe: [
+    {
+      symbol: "SPY",
+      display_name: "SPDR S&P 500 ETF Trust",
+      asset_type: "etf",
+      source: "core_etf",
+    },
+    {
+      symbol: "NVDA",
+      display_name: "NVDA",
+      asset_type: "equity",
+      source: "watchlist",
+    },
+  ],
+  source_manifests: [
+    {
+      source: "truth_archive",
+      status: "ok",
+      post_count: 42,
+    },
+  ],
+  asset_market_manifest: [
+    {
+      symbol: "SPY",
+      dataset_kind: "daily",
+      status: "ok",
+      row_count: 300,
+    },
+  ],
+  refresh_jobs: [
+    {
+      job_id: "dataset-refresh-1",
+      refresh_mode: "incremental",
+      status: "success",
+      normalized_post_count: 42,
+    },
+  ],
+};
+
 const runsPayload = {
   count: 2,
   runs: [
@@ -618,6 +679,36 @@ async function fulfillJson(page: Page, path: string, payload: unknown) {
 async function mockApi(page: Page) {
   await fulfillJson(page, "/api/status", statusPayload);
   await fulfillJson(page, "/api/datasets/health", healthPayload);
+  await fulfillJson(page, "/api/datasets/admin", datasetAdminPayload);
+  await fulfillJson(page, "/api/datasets/watchlist", datasetAdminPayload);
+  await fulfillJson(page, "/api/datasets/refresh", {
+    ...datasetAdminPayload,
+    job_id: "dataset-refresh-2",
+    status: {
+      ...datasetAdminPayload.status,
+      active_job_id: "dataset-refresh-2",
+    },
+    refresh_jobs: [
+      ...datasetAdminPayload.refresh_jobs,
+      {
+        job_id: "dataset-refresh-2",
+        refresh_mode: "full",
+        status: "success",
+        uploaded_file_count: 1,
+        normalized_post_count: 43,
+      },
+    ],
+  });
+  await fulfillJson(page, "/api/datasets/jobs/dataset-refresh-2", {
+    job_id: "dataset-refresh-2",
+    found: true,
+    job: {
+      job_id: "dataset-refresh-2",
+      refresh_mode: "full",
+      status: "success",
+    },
+    recent_jobs: datasetAdminPayload.refresh_jobs,
+  });
   await fulfillJson(page, "/api/runs", runsPayload);
   await fulfillJson(page, "/api/runs/run-portfolio-1**", runDetailPayload);
   await fulfillJson(page, "/api/runs/compare**", runComparisonPayload);
@@ -647,14 +738,31 @@ test("renders the overview shell from API-backed data", async ({ page }) => {
   await expect(page.getByText("Portfolio Alpha")).toBeVisible();
 });
 
-test("shows data health warnings and registry rows", async ({ page }) => {
+test("shows data admin controls, health rows, and refresh jobs", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Data Health/ }).click();
+  await page.getByRole("button", { name: /Data Admin/ }).click();
 
-  await expect(page.getByRole("heading", { name: "Freshness, completeness, and anomalies" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Refresh jobs, watchlist, and data health" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Data Admin Console" })).toBeVisible();
+  await expect(page.getByText("Read-only until unlocked")).toBeVisible();
+  await page.getByPlaceholder("Admin password").fill("secret");
+  await page.getByRole("button", { name: "Unlock admin writes" }).click();
+  await expect(page.getByText("Unlocked for this browser session")).toBeVisible();
+  await page.getByLabel("Watchlist symbols").fill("NVDA, TSLA, XOM");
+  await page.getByRole("button", { name: "Save watchlist" }).click();
+  await page.getByLabel("Remote X / mention CSV URL").fill("https://example.invalid/mentions.csv");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "mentions.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from("author,text\nmacro,hello\n"),
+  });
+  await page.getByRole("button", { name: "Start refresh job" }).click();
+  await expect(page.getByRole("cell", { name: "dataset-refresh-2" })).toBeVisible();
   await expect(page.getByText("asset_intraday")).toBeVisible();
   await expect(page.getByText("freshness_hours")).toBeVisible();
   await expect(page.getByText("normalized_posts")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Source manifest" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "truth_archive" })).toBeVisible();
 });
 
 test("shows the migrated research workspace with narratives and export", async ({ page }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import createPlotlyComponentModule from "react-plotly.js/factory";
 import Plotly from "plotly.js-dist-min";
 import type { Data, Frame, Layout } from "plotly.js";
-import { api, type LiveOpsPayload, type PlotlyFigure, type RecordRow, type ResearchFilters } from "./api";
+import { api, type DatasetAdminPayload, type LiveOpsPayload, type PlotlyFigure, type RecordRow, type ResearchFilters } from "./api";
 
 type PlotComponentFactory = (plotly: unknown) => ComponentType<Record<string, unknown>>;
 const createPlotlyComponent = (
@@ -19,7 +19,7 @@ const pages: Array<{ key: PageKey; label: string; deck: string }> = [
   { key: "research", label: "Research", deck: "Sentiment, narratives, and export pack" },
   { key: "discovery", label: "Discovery", deck: "Tracked account ranking workspace" },
   { key: "runs", label: "Run Explorer", deck: "Saved model results and comparisons" },
-  { key: "data", label: "Data Health", deck: "Freshness, completeness, and anomalies" },
+  { key: "data", label: "Data Admin", deck: "Refresh jobs, watchlist, and data health" },
   { key: "live", label: "Live Ops", deck: "Operate deployed portfolio" },
   { key: "paper", label: "Paper + Performance", deck: "Portfolio audit and drift" },
 ];
@@ -123,6 +123,13 @@ function DataTable({ rows, emptyLabel = "No rows returned yet." }: { rows: Recor
       </table>
     </div>
   );
+}
+
+function parseSymbolList(value: string): string[] {
+  return value
+    .split(/[\s,]+/)
+    .map((item) => item.trim().toUpperCase())
+    .filter(Boolean);
 }
 
 function ResearchPage() {
@@ -896,39 +903,270 @@ function OverviewPage() {
   );
 }
 
-function DataHealthPage() {
-  const health = useQuery({ queryKey: ["health"], queryFn: api.health });
-  if (health.isLoading) {
-    return <LoadingBlock label="Loading data health..." />;
+function DataAdminPage() {
+  const queryClient = useQueryClient();
+  const admin = useQuery({ queryKey: ["dataset-admin"], queryFn: api.datasetAdmin, refetchInterval: 10_000 });
+  const [adminToken, setAdminToken] = useState(() =>
+    typeof window === "undefined" ? "" : window.sessionStorage.getItem("allcaps_admin_token") ?? "",
+  );
+  const [password, setPassword] = useState("");
+  const [watchlistText, setWatchlistText] = useState("");
+  const [refreshMode, setRefreshMode] = useState<"bootstrap" | "full" | "incremental">("incremental");
+  const [remoteUrl, setRemoteUrl] = useState("");
+  const [uploadFiles, setUploadFiles] = useState<FileList | null>(null);
+
+  const applyDatasetPayload = (payload: DatasetAdminPayload) => {
+    queryClient.setQueryData(["dataset-admin"], payload);
+  };
+  const unlock = useMutation({
+    mutationFn: () => api.adminSession(password),
+    onSuccess: (payload) => {
+      setAdminToken(payload.token);
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem("allcaps_admin_token", payload.token);
+      }
+      setPassword("");
+    },
+  });
+  const saveWatchlist = useMutation({
+    mutationFn: () => api.saveWatchlist(parseSymbolList(watchlistText), false, adminToken),
+    onSuccess: applyDatasetPayload,
+  });
+  const resetWatchlist = useMutation({
+    mutationFn: () => api.saveWatchlist([], true, adminToken),
+    onSuccess: (payload) => {
+      setWatchlistText("");
+      applyDatasetPayload(payload);
+    },
+  });
+  const startRefresh = useMutation({
+    mutationFn: () => api.startDatasetRefresh({ refresh_mode: refreshMode, remote_url: remoteUrl, files: uploadFiles ?? undefined }, adminToken),
+    onSuccess: applyDatasetPayload,
+  });
+
+  useEffect(() => {
+    const symbols = admin.data?.watchlist_symbols ?? [];
+    if (!watchlistText && symbols.length) {
+      setWatchlistText(symbols.join(", "));
+    }
+  }, [admin.data?.watchlist_symbols, watchlistText]);
+
+  if (admin.isLoading) {
+    return <LoadingBlock label="Loading data admin..." />;
   }
-  if (health.error) {
-    return <ErrorBlock error={health.error} />;
+  if (admin.error) {
+    return <ErrorBlock error={admin.error} />;
   }
 
-  const summary = health.data?.summary ?? {};
+  const payload = admin.data;
+  const summary = payload?.summary ?? {};
+  const status = payload?.status;
+  const isUnlocked = Boolean(adminToken);
+  const mutationError = unlock.error ?? saveWatchlist.error ?? resetWatchlist.error ?? startRefresh.error;
+  const latestProblems = (payload?.latest ?? []).filter((row) => row.severity === "warn" || row.severity === "severe");
+  const refreshJobs = payload?.refresh_jobs ?? [];
+  const activeJob = refreshJobs.find((row) => row.job_id === status?.active_job_id) ?? refreshJobs[refreshJobs.length - 1];
+
   return (
     <section className="page-grid">
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <div>
+            <h2>Data Admin Console</h2>
+            <p>
+              Manage stored datasets, watchlist symbols, CSV inputs, refresh jobs, and warn-only data health from the web UI.
+              Refresh jobs reuse the same lock as the scheduler and Streamlit controls.
+            </p>
+          </div>
+          <StatusPill label={status?.operating_mode ?? "Unknown mode"} tone={summary.overall_severity === "severe" ? "severe" : summary.overall_severity === "warn" ? "warn" : "ok"} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Admin unlock
+            <input
+              type="password"
+              placeholder={payload?.admin.mode === "private" ? "Private mode: password optional" : "Admin password"}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          <label>
+            Session status
+            <button
+              className="action-button"
+              type="button"
+              aria-label={isUnlocked ? "Refresh admin token" : "Unlock admin writes"}
+              onClick={() => unlock.mutate()}
+              disabled={unlock.isPending}
+            >
+              {isUnlocked ? "Refresh admin token" : "Unlock admin writes"}
+            </button>
+          </label>
+          <label>
+            Write state
+            <span className="form-readout">{isUnlocked ? "Unlocked for this browser session" : "Read-only until unlocked"}</span>
+          </label>
+          <label>
+            Scheduler
+            <span className="form-readout">{status?.scheduler_enabled ? "Enabled" : "Disabled"}</span>
+          </label>
+        </div>
+        {mutationError ? <ErrorBlock error={mutationError} /> : null}
+      </article>
+
       <div className="metric-grid">
-        <MetricCard label="Overall" value={summary.overall_severity} />
-        <MetricCard label="Severe checks" value={summary.severe_count} />
-        <MetricCard label="Warn checks" value={summary.warn_count} />
-        <MetricCard label="Last refresh" value={summary.last_refresh_status} />
+        <MetricCard label="Overall health" value={summary.overall_severity} />
+        <MetricCard label="Missing core datasets" value={status?.missing_core_dataset_count ?? 0} />
+        <MetricCard label="Last refresh" value={summary.last_refresh_status} caption={String(summary.last_refresh_mode ?? "")} />
+        <MetricCard label="Active/latest job" value={activeJob?.status ?? "n/a"} caption={String(activeJob?.refresh_mode ?? "")} />
       </div>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Runtime status</h2>
+          <StatusPill label={payload?.admin.mode ?? "private"} />
+        </div>
+        <dl className="detail-list">
+          <div>
+            <dt>State root</dt>
+            <dd>{status?.state_root ?? "n/a"}</dd>
+          </div>
+          <div>
+            <dt>Database</dt>
+            <dd>{status?.db_path ?? "n/a"}</dd>
+          </div>
+          <div>
+            <dt>Source mode</dt>
+            <dd>
+              {status?.source_mode.mode ?? "unknown"} ({status?.source_mode.truth_post_count ?? 0} Truth,{" "}
+              {status?.source_mode.x_post_count ?? 0} X)
+            </dd>
+          </div>
+        </dl>
+        {status?.missing_core_datasets.length ? (
+          <div className="empty-state">Missing core datasets: {status.missing_core_datasets.join(", ")}</div>
+        ) : null}
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Watchlist controls</h2>
+          <StatusPill label={`${payload?.watchlist_symbols.length ?? 0} symbols`} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          <label className="filter-grid__wide">
+            Watchlist symbols
+            <textarea
+              value={watchlistText}
+              onChange={(event) => setWatchlistText(event.target.value)}
+              placeholder="NVDA, TSLA, XOM"
+              disabled={!isUnlocked}
+            />
+          </label>
+          <label>
+            Save
+            <button
+              className="action-button"
+              type="button"
+              aria-label="Save watchlist"
+              disabled={!isUnlocked || saveWatchlist.isPending}
+              onClick={() => saveWatchlist.mutate()}
+            >
+              Save watchlist
+            </button>
+          </label>
+          <label>
+            Reset
+            <button
+              className="action-button action-button--danger"
+              type="button"
+              aria-label="Reset watchlist"
+              disabled={!isUnlocked || resetWatchlist.isPending}
+              onClick={() => resetWatchlist.mutate()}
+            >
+              Reset watchlist
+            </button>
+          </label>
+        </div>
+        <DataTable rows={payload?.asset_universe ?? []} emptyLabel="No asset universe rows yet." />
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Refresh controls</h2>
+          <StatusPill label="Background job" />
+        </div>
+        <p>
+          Refreshes run against stored state and are single-instance. A manual refresh here does not bypass the scheduler lock.
+        </p>
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Refresh mode
+            <select value={refreshMode} onChange={(event) => setRefreshMode(event.target.value as "bootstrap" | "full" | "incremental")} disabled={!isUnlocked}>
+              <option value="bootstrap">Bootstrap</option>
+              <option value="full">Full</option>
+              <option value="incremental">Incremental</option>
+            </select>
+          </label>
+          <label className="filter-grid__wide">
+            Remote X / mention CSV URL
+            <input value={remoteUrl} onChange={(event) => setRemoteUrl(event.target.value)} placeholder="https://..." disabled={!isUnlocked} />
+          </label>
+          <label>
+            CSV upload
+            <input type="file" accept=".csv,text/csv" multiple disabled={!isUnlocked} onChange={(event) => setUploadFiles(event.target.files)} />
+          </label>
+          <label>
+            Start
+            <button
+              className="action-button"
+              type="button"
+              aria-label="Start refresh job"
+              disabled={!isUnlocked || startRefresh.isPending}
+              onClick={() => startRefresh.mutate()}
+            >
+              Start refresh job
+            </button>
+          </label>
+        </div>
+      </article>
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>Recent refresh jobs</h2>
+          <DataTable rows={payload?.refresh_jobs ?? []} emptyLabel="No React-submitted refresh jobs yet." />
+        </div>
+        <div>
+          <h2>Refresh history</h2>
+          <DataTable rows={payload?.refresh_history ?? []} emptyLabel="No refresh history yet." />
+        </div>
+      </article>
+
       <article className="panel panel--wide">
         <div className="panel-heading">
           <h2>Latest warn/severe diagnostics</h2>
-          <StatusPill label={`${health.data?.latest.length ?? 0} checks`} />
+          <StatusPill label={`${latestProblems.length} current issue(s)`} tone={latestProblems.some((row) => row.severity === "severe") ? "severe" : latestProblems.length ? "warn" : "ok"} />
         </div>
-        <DataTable
-          rows={(health.data?.latest ?? []).filter((row) => row.severity === "warn" || row.severity === "severe")}
-          emptyLabel="No warn or severe health rows."
-        />
+        <DataTable rows={latestProblems} emptyLabel="No warn or severe health rows." />
       </article>
+
       <article className="panel panel--wide">
         <div className="panel-heading">
           <h2>Dataset registry</h2>
+          <StatusPill label={`${payload?.registry.length ?? 0} datasets`} />
         </div>
-        <DataTable rows={health.data?.registry ?? []} />
+        <DataTable rows={payload?.registry ?? []} />
+      </article>
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>Source manifest</h2>
+          <DataTable rows={payload?.source_manifests ?? []} emptyLabel="No source manifest rows yet." />
+        </div>
+        <div>
+          <h2>Asset market manifest</h2>
+          <DataTable rows={payload?.asset_market_manifest ?? []} emptyLabel="No asset market manifest rows yet." />
+        </div>
       </article>
     </section>
   );
@@ -1310,7 +1548,7 @@ export function App() {
       {activePage === "research" ? <ResearchPage /> : null}
       {activePage === "discovery" ? <DiscoveryPage /> : null}
       {activePage === "runs" ? <RunExplorerPage /> : null}
-      {activePage === "data" ? <DataHealthPage /> : null}
+      {activePage === "data" ? <DataAdminPage /> : null}
       {activePage === "live" ? <LiveDecisionPage /> : null}
       {activePage === "paper" ? <PaperPerformancePage /> : null}
     </main>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,6 +29,43 @@ export type HealthPayload = {
   registry: RecordRow[];
 };
 
+export type DatasetAdminPayload = HealthPayload & {
+  admin: {
+    mode: string;
+    write_requires_unlock: boolean;
+  };
+  status: {
+    operating_mode: string;
+    source_mode: StatusPayload["source_mode"];
+    state_root: string;
+    db_path: string;
+    scheduler_enabled: boolean;
+    missing_core_datasets: string[];
+    missing_core_dataset_count: number;
+    last_refresh: Record<string, unknown>;
+    active_job_id: string;
+  };
+  watchlist_symbols: string[];
+  asset_universe: RecordRow[];
+  source_manifests: RecordRow[];
+  asset_market_manifest: RecordRow[];
+  refresh_jobs: RecordRow[];
+  job_id?: string;
+};
+
+export type DatasetRefreshJobPayload = {
+  job_id: string;
+  found: boolean;
+  job: RecordRow | null;
+  recent_jobs: RecordRow[];
+};
+
+export type DatasetRefreshRequest = {
+  refresh_mode: "bootstrap" | "full" | "incremental";
+  remote_url?: string;
+  files?: FileList | File[];
+};
+
 export type RunsPayload = {
   count: number;
   runs: RecordRow[];
@@ -298,11 +335,45 @@ async function postJson<T>(path: string, payload: unknown = {}, token?: string):
   return response.json() as Promise<T>;
 }
 
+async function postForm<T>(path: string, formData: FormData, token?: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: formData,
+  });
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`;
+    try {
+      const body = (await response.json()) as { detail?: unknown };
+      if (body.detail) {
+        detail = Array.isArray(body.detail) ? body.detail.join("; ") : String(body.detail);
+      }
+    } catch {
+      // Keep the HTTP status fallback when the response is not JSON.
+    }
+    throw new Error(`API request failed: ${detail}`);
+  }
+  return response.json() as Promise<T>;
+}
+
 export const api = {
   baseUrl: API_BASE_URL,
   status: () => getJson<StatusPayload>("/api/status"),
   adminSession: (password = "") => postJson<AdminSessionPayload>("/api/admin/session", { password }),
   health: () => getJson<HealthPayload>("/api/datasets/health"),
+  datasetAdmin: () => getJson<DatasetAdminPayload>("/api/datasets/admin"),
+  saveWatchlist: (symbols: string[], reset: boolean, token: string) =>
+    postJson<DatasetAdminPayload>("/api/datasets/watchlist", { symbols, reset }, token),
+  startDatasetRefresh: (request: DatasetRefreshRequest, token: string) => {
+    const formData = new FormData();
+    formData.set("refresh_mode", request.refresh_mode);
+    formData.set("remote_url", request.remote_url ?? "");
+    Array.from(request.files ?? []).forEach((file) => formData.append("files", file));
+    return postForm<DatasetAdminPayload>("/api/datasets/refresh", formData, token);
+  },
+  datasetRefreshJob: (jobId: string) => getJson<DatasetRefreshJobPayload>(`/api/datasets/jobs/${encodeURIComponent(jobId)}`),
   runs: () => getJson<RunsPayload>("/api/runs"),
   runDetail: (runId: string, options: { variantName?: string; sessionDate?: string } = {}) => {
     const params = new URLSearchParams();

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -33,7 +33,8 @@ body {
 
 button,
 select,
-input {
+input,
+textarea {
   font: inherit;
 }
 
@@ -295,13 +296,19 @@ select {
   background: rgba(255, 255, 255, 0.68);
 }
 
-input {
+input,
+textarea {
   width: 100%;
   padding: 14px 16px;
   color: var(--ink);
   border: 1px solid var(--line);
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.68);
+}
+
+textarea {
+  min-height: 112px;
+  resize: vertical;
 }
 
 select[multiple] {
@@ -338,6 +345,10 @@ select[multiple] {
   border: 1px solid var(--line);
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.42);
+}
+
+.filter-grid__wide {
+  grid-column: span 2;
 }
 
 .checkbox-field input {
@@ -449,6 +460,10 @@ select[multiple] {
   .filter-grid,
   .chart-grid {
     grid-template-columns: 1fr;
+  }
+
+  .filter-grid__wide {
+    grid-column: auto;
   }
 
   .page-tabs {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 streamlit>=1.50
 fastapi>=0.115
+python-multipart>=0.0.20
 uvicorn>=0.32
 pandas>=2.2
 numpy>=1.26

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,8 @@ from trump_workbench.api import create_app
 from trump_workbench.config import AppSettings
 from trump_workbench.contracts import BacktestRun, MANUAL_OVERRIDE_COLUMNS, RANKING_HISTORY_COLUMNS, TRACKED_ACCOUNT_COLUMNS
 from trump_workbench.experiments import ExperimentStore
+from trump_workbench.health import HEALTH_CHECK_COLUMNS
+from trump_workbench.scheduler import acquire_refresh_lock, release_refresh_lock
 from trump_workbench.paper_trading import (
     PAPER_BENCHMARK_CURVE_COLUMNS,
     PAPER_DECISION_JOURNAL_COLUMNS,
@@ -22,6 +24,183 @@ from trump_workbench.paper_trading import (
     PAPER_TRADE_LEDGER_COLUMNS,
 )
 from trump_workbench.storage import DuckDBStore
+
+
+class FakeIngestionService:
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+
+    def _posts(self, post_id: str = "truth-refresh-1") -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {
+                    "source_platform": "Truth Social",
+                    "source_type": "truth_archive",
+                    "author_account_id": "truth-account",
+                    "author_handle": "realDonaldTrump",
+                    "author_display_name": "Donald Trump",
+                    "author_is_trump": True,
+                    "post_id": post_id,
+                    "post_url": "https://truthsocial.com/@realDonaldTrump/posts/refresh",
+                    "post_timestamp": pd.Timestamp("2025-02-03 08:00:00", tz="America/New_York"),
+                    "raw_text": "Synthetic refresh post",
+                    "cleaned_text": "Synthetic refresh post",
+                    "is_reshare": False,
+                    "has_media": False,
+                    "replies_count": 0,
+                    "reblogs_count": 0,
+                    "favourites_count": 0,
+                    "mentions_trump": False,
+                    "source_provenance": "unit-test",
+                    "engagement_score": 0.0,
+                    "sentiment_score": 0.2,
+                    "sentiment_label": "positive",
+                },
+            ],
+        )
+
+    def _manifest(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {
+                    "source": "fake-truth",
+                    "status": "ok",
+                    "post_count": 1,
+                    "error_message": "",
+                },
+            ],
+        )
+
+    def run_refresh(self, adapters) -> tuple[pd.DataFrame, pd.DataFrame]:
+        del adapters
+        if self.fail:
+            raise RuntimeError("fake ingestion failed")
+        return self._posts(), self._manifest()
+
+    def run_incremental_refresh(self, adapters, last_cursor) -> tuple[pd.DataFrame, pd.DataFrame]:
+        del adapters, last_cursor
+        if self.fail:
+            raise RuntimeError("fake ingestion failed")
+        return self._posts("truth-refresh-2"), self._manifest()
+
+
+class FakeMarketDataService:
+    def load_sp500_daily(self, start: str, end: str) -> pd.DataFrame:
+        del start, end
+        return pd.DataFrame(
+            [
+                {"trade_date": pd.Timestamp("2025-02-03"), "close": 100.0},
+                {"trade_date": pd.Timestamp("2025-02-04"), "close": 101.0},
+            ],
+        )
+
+    def load_spy_daily(self, start: str, end: str) -> pd.DataFrame:
+        del start, end
+        return pd.DataFrame(
+            [
+                {"trade_date": pd.Timestamp("2025-02-03"), "open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 1000},
+                {"trade_date": pd.Timestamp("2025-02-04"), "open": 100.5, "high": 102.0, "low": 100.0, "close": 101.0, "volume": 1100},
+            ],
+        )
+
+    def load_assets_daily(self, symbols: list[str], start: str, end: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+        del start, end
+        rows = []
+        manifest_rows = []
+        for symbol in symbols:
+            rows.extend(
+                [
+                    {"symbol": symbol, "trade_date": pd.Timestamp("2025-02-03"), "open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 1000},
+                    {"symbol": symbol, "trade_date": pd.Timestamp("2025-02-04"), "open": 100.5, "high": 102.0, "low": 100.0, "close": 101.0, "volume": 1100},
+                ],
+            )
+            manifest_rows.append(
+                {
+                    "symbol": symbol,
+                    "dataset_kind": "daily",
+                    "row_count": 2,
+                    "status": "ok",
+                    "start_at": pd.Timestamp("2025-02-03"),
+                    "end_at": pd.Timestamp("2025-02-04"),
+                    "detail": "",
+                },
+            )
+        return pd.DataFrame(rows), pd.DataFrame(manifest_rows)
+
+    def load_assets_intraday(self, symbols: list[str], interval: str = "5m", lookback_days: int = 30) -> tuple[pd.DataFrame, pd.DataFrame]:
+        del lookback_days
+        rows = []
+        manifest_rows = []
+        for symbol in symbols:
+            rows.append(
+                {
+                    "symbol": symbol,
+                    "timestamp": pd.Timestamp("2025-02-04 14:30:00", tz="UTC"),
+                    "open": 100.0,
+                    "high": 100.5,
+                    "low": 99.8,
+                    "close": 100.2,
+                    "volume": 100,
+                    "interval": interval,
+                },
+            )
+            manifest_rows.append(
+                {
+                    "symbol": symbol,
+                    "dataset_kind": "intraday",
+                    "row_count": 1,
+                    "status": "ok",
+                    "start_at": pd.Timestamp("2025-02-04 14:30:00", tz="UTC"),
+                    "end_at": pd.Timestamp("2025-02-04 14:30:00", tz="UTC"),
+                    "detail": "",
+                },
+            )
+        return pd.DataFrame(rows), pd.DataFrame(manifest_rows)
+
+
+class FakeFeatureService:
+    def prepare_session_posts(self, posts: pd.DataFrame, market_calendar: pd.DataFrame, tracked_accounts: pd.DataFrame, llm_enabled: bool) -> pd.DataFrame:
+        del market_calendar, tracked_accounts, llm_enabled
+        return posts.assign(session_date=pd.Timestamp("2025-02-03"))
+
+    def build_asset_post_mappings(self, prepared_posts: pd.DataFrame, asset_universe: pd.DataFrame, llm_enabled: bool) -> pd.DataFrame:
+        del llm_enabled
+        symbols = asset_universe["symbol"].astype(str).tolist() if not asset_universe.empty else ["SPY"]
+        return pd.DataFrame(
+            [
+                {
+                    "asset_symbol": symbols[0],
+                    "post_id": str(prepared_posts.iloc[0]["post_id"]) if not prepared_posts.empty else "post-1",
+                    "session_date": pd.Timestamp("2025-02-03"),
+                    "asset_relevance_score": 1.0,
+                    "mapping_reason": "unit-test",
+                },
+            ],
+        )
+
+    def build_asset_session_dataset(
+        self,
+        asset_post_mappings: pd.DataFrame,
+        asset_market: pd.DataFrame,
+        feature_version: str,
+        llm_enabled: bool,
+        asset_universe: pd.DataFrame,
+    ) -> pd.DataFrame:
+        del asset_post_mappings, asset_market, feature_version, llm_enabled
+        symbols = asset_universe["symbol"].astype(str).tolist() if not asset_universe.empty else ["SPY"]
+        return pd.DataFrame(
+            [
+                {
+                    "asset_symbol": symbol,
+                    "signal_session_date": pd.Timestamp("2025-02-03"),
+                    "next_session_date": pd.Timestamp("2025-02-04"),
+                    "post_count": 1,
+                    "target_next_session_return": 0.01,
+                    "target_available": True,
+                }
+                for symbol in symbols
+            ],
+        )
 
 
 class ApiContractTests(unittest.TestCase):
@@ -718,8 +897,8 @@ class ApiContractTests(unittest.TestCase):
             ),
         )
 
-    def _admin_token(self) -> str:
-        response = self.client.post("/api/admin/session", json={})
+    def _admin_token(self, client: TestClient | None = None) -> str:
+        response = (client or self.client).post("/api/admin/session", json={})
         self.assertEqual(response.status_code, 200)
         return str(response.json()["token"])
 
@@ -915,6 +1094,136 @@ class ApiContractTests(unittest.TestCase):
         self.assertIn("overall_severity", payload["summary"])
         self.assertIsInstance(payload["latest"], list)
         self.assertGreaterEqual(len(payload["registry"]), 1)
+
+    def test_dataset_admin_returns_safe_empty_state_payload(self) -> None:
+        response = self.client.get("/api/datasets/admin")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["admin"]["mode"], "private")
+        self.assertIn("status", payload)
+        self.assertGreaterEqual(payload["status"]["missing_core_dataset_count"], 1)
+        self.assertIn("normalized_posts", payload["status"]["missing_core_datasets"])
+        self.assertIn("overall_severity", payload["summary"])
+        self.assertEqual(payload["watchlist_symbols"], [])
+        self.assertEqual(payload["refresh_jobs"], [])
+
+    def test_dataset_watchlist_endpoint_requires_admin_and_persists_symbols(self) -> None:
+        rejected = self.client.post("/api/datasets/watchlist", json={"symbols": ["NVDA"], "reset": False})
+        token = self._admin_token()
+
+        saved = self.client.post(
+            "/api/datasets/watchlist",
+            json={"symbols": ["nvda", "TSLA"], "reset": False},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        reset = self.client.post(
+            "/api/datasets/watchlist",
+            json={"symbols": [], "reset": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(rejected.status_code, 401)
+        self.assertEqual(saved.status_code, 200)
+        self.assertEqual(saved.json()["watchlist_symbols"], ["NVDA", "TSLA"])
+        self.assertIn("SPY", {row["symbol"] for row in saved.json()["asset_universe"]})
+        self.assertIn("NVDA", {row["symbol"] for row in saved.json()["asset_universe"]})
+        self.assertEqual(reset.status_code, 200)
+        self.assertEqual(reset.json()["watchlist_symbols"], [])
+
+    def test_dataset_refresh_rejects_overlapping_lock(self) -> None:
+        token = self._admin_token()
+        lock_fd = acquire_refresh_lock(self.settings)
+        self.assertIsNotNone(lock_fd)
+        try:
+            response = self.client.post(
+                "/api/datasets/refresh",
+                data={"refresh_mode": "full", "remote_url": ""},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        finally:
+            release_refresh_lock(self.settings, lock_fd)
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("already running", str(response.json()["detail"]))
+
+    def test_dataset_refresh_job_persists_success_health_and_history(self) -> None:
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                ingestion_service=FakeIngestionService(),
+                market_service=FakeMarketDataService(),
+                feature_service=FakeFeatureService(),
+                run_refresh_jobs_inline=True,
+            ),
+        )
+        token = self._admin_token(client)
+
+        response = client.post(
+            "/api/datasets/refresh",
+            data={"refresh_mode": "full", "remote_url": ""},
+            files=[("files", ("mentions.csv", b"author,text\nmacro,hello\n", "text/csv"))],
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["job_id"].startswith("dataset-refresh-"))
+        jobs = self.store.read_frame("dataset_refresh_jobs")
+        self.assertFalse(jobs.empty)
+        self.assertEqual(str(jobs.iloc[-1]["status"]), "success")
+        self.assertEqual(int(jobs.iloc[-1]["uploaded_file_count"]), 1)
+        self.assertFalse(self.store.read_frame("normalized_posts").empty)
+        self.assertFalse(self.store.read_frame("refresh_history").empty)
+        self.assertFalse(self.store.read_frame("data_health_latest").empty)
+        self.assertFalse(self.store.read_frame("data_health_history").empty)
+
+    def test_dataset_refresh_job_persists_error_without_overwriting_prior_health(self) -> None:
+        prior_health = pd.DataFrame(
+            [
+                {
+                    "snapshot_id": "prior",
+                    "generated_at": pd.Timestamp("2025-02-01", tz="UTC"),
+                    "refresh_id": "prior-refresh",
+                    "scope_kind": "dataset",
+                    "scope_key": "normalized_posts",
+                    "check_name": "prior_check",
+                    "severity": "ok",
+                    "observed_value": 1.0,
+                    "baseline_value": 1.0,
+                    "detail": "prior snapshot",
+                },
+            ],
+            columns=HEALTH_CHECK_COLUMNS,
+        )
+        self.store.save_frame("data_health_latest", prior_health)
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                ingestion_service=FakeIngestionService(fail=True),
+                market_service=FakeMarketDataService(),
+                feature_service=FakeFeatureService(),
+                run_refresh_jobs_inline=True,
+            ),
+        )
+        token = self._admin_token(client)
+
+        response = client.post(
+            "/api/datasets/refresh",
+            data={"refresh_mode": "bootstrap", "remote_url": ""},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        jobs = self.store.read_frame("dataset_refresh_jobs")
+        self.assertEqual(str(jobs.iloc[-1]["status"]), "error")
+        self.assertIn("fake ingestion failed", str(jobs.iloc[-1]["error_message"]))
+        refresh_history = self.store.read_frame("refresh_history")
+        self.assertEqual(str(refresh_history.iloc[-1]["status"]), "error")
+        latest = self.store.read_frame("data_health_latest")
+        self.assertEqual(str(latest.iloc[0]["check_name"]), "prior_check")
 
     def test_runs_and_live_current_handle_empty_live_config(self) -> None:
         self._save_run_record()

--- a/trump_workbench/api.py
+++ b/trump_workbench/api.py
@@ -6,17 +6,26 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from fastapi import Depends, FastAPI, Header, HTTPException, Query, Response
+from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Query, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from .access import verify_admin_password
 from .config import AppSettings
+from .dataset_admin import (
+    UploadedCsv,
+    build_dataset_admin_payload,
+    ensure_refresh_jobs_frame,
+    save_dataset_watchlist,
+    submit_refresh_job,
+)
 from .discovery import DiscoveryService
 from .discovery_workspace import build_discovery_workspace
 from .enrichment import LLMEnrichmentService
 from .experiments import ExperimentStore
+from .features import FeatureService
 from .health import DataHealthService, build_health_summary, build_health_trend_frame, ensure_refresh_history_frame
+from .ingestion import IngestionService
 from .live_monitor import build_live_portfolio_run_state, validate_live_monitor_config
 from .live_ops import (
     apply_paper_action,
@@ -24,6 +33,7 @@ from .live_ops import (
     build_live_ops_payload,
     run_live_capture,
 )
+from .market import MarketDataService
 from .modeling import ModelService
 from .paper_trading import (
     PaperTradingService,
@@ -65,6 +75,11 @@ class PaperCurrentActionRequest(BaseModel):
     starting_cash: float | None = None
 
 
+class WatchlistSaveRequest(BaseModel):
+    symbols: list[str] = []
+    reset: bool = False
+
+
 def _json_safe(value: Any) -> Any:
     if isinstance(value, pd.Timestamp):
         return None if pd.isna(value) else value.isoformat()
@@ -91,14 +106,26 @@ def _frame_records(frame: pd.DataFrame, limit: int | None = None) -> list[dict[s
     return [_json_safe(record) for record in out.to_dict(orient="records")]
 
 
-def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = None) -> FastAPI:
+def create_app(
+    settings: AppSettings | None = None,
+    store: DuckDBStore | None = None,
+    ingestion_service: IngestionService | None = None,
+    market_service: MarketDataService | None = None,
+    discovery_service: DiscoveryService | None = None,
+    feature_service: FeatureService | None = None,
+    health_service: DataHealthService | None = None,
+    run_refresh_jobs_inline: bool = False,
+) -> FastAPI:
     settings = settings or AppSettings()
     store = store or DuckDBStore(settings)
-    health_service = DataHealthService()
-    discovery_service = DiscoveryService()
+    health_service = health_service or DataHealthService()
+    discovery_service = discovery_service or DiscoveryService()
     experiment_store = ExperimentStore(store)
     model_service = ModelService()
     enrichment_service = LLMEnrichmentService(store)
+    ingestion_service = ingestion_service or IngestionService()
+    market_service = market_service or MarketDataService()
+    feature_service = feature_service or FeatureService(enrichment_service)
     paper_service = PaperTradingService(store)
     performance_service = PerformanceObservatoryService(store)
 
@@ -110,6 +137,7 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
     app.state.settings = settings
     app.state.store = store
     app.state.admin_tokens = {}
+    app.state.run_refresh_jobs_inline = bool(run_refresh_jobs_inline)
 
     if settings.api_cors_origins:
         app.add_middleware(
@@ -279,6 +307,81 @@ def create_app(settings: AppSettings | None = None, store: DuckDBStore | None = 
             "refresh_history": _frame_records(refresh_history.tail(25)),
             "registry": _frame_records(store.dataset_registry()),
         }
+
+    @app.get("/api/datasets/admin")
+    def dataset_admin() -> dict[str, Any]:
+        return _json_safe(
+            build_dataset_admin_payload(
+                settings=settings,
+                store=store,
+                health_service=health_service,
+                public_mode=settings.public_mode,
+            ),
+        )
+
+    @app.post("/api/datasets/watchlist")
+    def save_watchlist_endpoint(
+        request: WatchlistSaveRequest,
+        _admin: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        save_dataset_watchlist(store, request.symbols, reset=request.reset)
+        return _json_safe(
+            build_dataset_admin_payload(
+                settings=settings,
+                store=store,
+                health_service=health_service,
+                public_mode=settings.public_mode,
+            ),
+        )
+
+    @app.post("/api/datasets/refresh")
+    async def start_dataset_refresh(
+        refresh_mode: str = Form("incremental"),
+        remote_url: str = Form(""),
+        files: list[UploadFile] | None = File(default=None),
+        _admin: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        uploaded_files: list[UploadedCsv] = []
+        for upload in files or []:
+            uploaded_files.append(UploadedCsv(name=upload.filename or "uploaded.csv", raw_bytes=await upload.read()))
+        job_id, errors = submit_refresh_job(
+            settings=settings,
+            store=store,
+            refresh_mode=refresh_mode,
+            remote_url=remote_url,
+            uploaded_files=uploaded_files,
+            ingestion_service=ingestion_service,
+            market_service=market_service,
+            discovery_service=discovery_service,
+            feature_service=feature_service,
+            health_service=health_service,
+            run_inline=bool(app.state.run_refresh_jobs_inline),
+        )
+        if errors:
+            status_code = 409 if any("already running" in error for error in errors) else 400
+            raise HTTPException(status_code=status_code, detail=errors)
+        payload = build_dataset_admin_payload(
+            settings=settings,
+            store=store,
+            health_service=health_service,
+            public_mode=settings.public_mode,
+            active_job_id=job_id,
+        )
+        payload["job_id"] = job_id
+        return _json_safe(payload)
+
+    @app.get("/api/datasets/jobs/{job_id}")
+    def dataset_refresh_job(job_id: str) -> dict[str, Any]:
+        jobs = ensure_refresh_jobs_frame(store.read_frame("dataset_refresh_jobs"))
+        current = jobs.loc[jobs["job_id"].astype(str) == str(job_id)].copy()
+        return _json_safe(
+            {
+                "job_id": job_id,
+                "found": not current.empty,
+                "job": _frame_records(current.tail(1))[0] if not current.empty else None,
+                "recent_jobs": _frame_records(jobs.tail(10)),
+            },
+        )
 
     @app.get("/api/runs")
     def runs() -> dict[str, Any]:

--- a/trump_workbench/dataset_admin.py
+++ b/trump_workbench/dataset_admin.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+import uuid
+from typing import Any
+
+import pandas as pd
+
+from .config import AppSettings
+from .discovery import DiscoveryService
+from .features import FeatureService
+from .health import DataHealthService, build_health_summary, build_health_trend_frame, ensure_refresh_history_frame
+from .ingestion import IngestionService
+from .market import MarketDataService, normalize_symbols
+from .research_workspace import detect_source_mode, source_mode_label
+from .runtime import missing_core_datasets, refresh_datasets, save_watchlist, watchlist_symbols
+from .scheduler import acquire_refresh_lock, release_refresh_lock
+from .storage import DuckDBStore
+
+DATASET_REFRESH_JOB_COLUMNS = [
+    "job_id",
+    "refresh_id",
+    "refresh_mode",
+    "status",
+    "started_at",
+    "completed_at",
+    "error_message",
+    "remote_url",
+    "uploaded_file_count",
+    "normalized_post_count",
+    "asset_daily_row_count",
+    "asset_intraday_row_count",
+    "tracked_account_count",
+]
+
+VALID_REFRESH_MODES = {"bootstrap", "full", "incremental"}
+
+
+@dataclass(frozen=True)
+class UploadedCsv:
+    name: str
+    raw_bytes: bytes
+
+    def getvalue(self) -> bytes:
+        return self.raw_bytes
+
+
+def ensure_refresh_jobs_frame(frame: pd.DataFrame | None) -> pd.DataFrame:
+    if frame is None or frame.empty:
+        return pd.DataFrame(columns=DATASET_REFRESH_JOB_COLUMNS)
+    out = frame.copy()
+    for column in DATASET_REFRESH_JOB_COLUMNS:
+        if column not in out.columns:
+            out[column] = pd.NA
+    out["started_at"] = pd.to_datetime(out["started_at"], errors="coerce", utc=True)
+    out["completed_at"] = pd.to_datetime(out["completed_at"], errors="coerce", utc=True)
+    for column in ["uploaded_file_count", "normalized_post_count", "asset_daily_row_count", "asset_intraday_row_count", "tracked_account_count"]:
+        out[column] = pd.to_numeric(out[column], errors="coerce")
+    for column in ["job_id", "refresh_id", "refresh_mode", "status", "error_message", "remote_url"]:
+        out[column] = out[column].fillna("").astype(str)
+    return out[DATASET_REFRESH_JOB_COLUMNS].copy()
+
+
+def _frame_records(frame: pd.DataFrame, limit: int | None = None) -> list[dict[str, Any]]:
+    if frame.empty:
+        return []
+    out = frame.copy()
+    if limit is not None:
+        out = out.tail(max(0, int(limit)))
+    return out.to_dict(orient="records")
+
+
+def _count_rows(summary: dict[str, Any], key: str) -> int:
+    value = summary.get(key)
+    if isinstance(value, pd.DataFrame):
+        return int(len(value))
+    return 0
+
+
+def _job_row(
+    *,
+    job_id: str,
+    refresh_mode: str,
+    status: str,
+    started_at: pd.Timestamp,
+    completed_at: pd.Timestamp | pd.NaT = pd.NaT,
+    error_message: str = "",
+    remote_url: str = "",
+    uploaded_file_count: int = 0,
+    refresh_id: str = "",
+    normalized_post_count: int | float | None = None,
+    asset_daily_row_count: int | float | None = None,
+    asset_intraday_row_count: int | float | None = None,
+    tracked_account_count: int | float | None = None,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "job_id": str(job_id),
+                "refresh_id": str(refresh_id or ""),
+                "refresh_mode": str(refresh_mode),
+                "status": str(status),
+                "started_at": pd.Timestamp(started_at),
+                "completed_at": completed_at,
+                "error_message": str(error_message or ""),
+                "remote_url": str(remote_url or ""),
+                "uploaded_file_count": int(uploaded_file_count),
+                "normalized_post_count": normalized_post_count,
+                "asset_daily_row_count": asset_daily_row_count,
+                "asset_intraday_row_count": asset_intraday_row_count,
+                "tracked_account_count": tracked_account_count,
+            },
+        ],
+        columns=DATASET_REFRESH_JOB_COLUMNS,
+    )
+
+
+def save_refresh_job(store: DuckDBStore, row: pd.DataFrame) -> pd.DataFrame:
+    current = ensure_refresh_jobs_frame(store.read_frame("dataset_refresh_jobs"))
+    combined = pd.concat([current, ensure_refresh_jobs_frame(row)], ignore_index=True)
+    combined = combined.drop_duplicates(subset=["job_id"], keep="last").reset_index(drop=True)
+    store.save_frame(
+        "dataset_refresh_jobs",
+        combined,
+        metadata={
+            "row_count": int(len(combined)),
+            "latest_status": str(combined.iloc[-1]["status"]) if not combined.empty else "",
+        },
+    )
+    return combined
+
+
+def _health_latest(store: DuckDBStore, health_service: DataHealthService) -> pd.DataFrame:
+    latest = store.read_frame("data_health_latest")
+    if latest.empty:
+        latest = health_service.evaluate_store(store)
+    return latest
+
+
+def build_dataset_admin_payload(
+    *,
+    settings: AppSettings,
+    store: DuckDBStore,
+    health_service: DataHealthService,
+    public_mode: bool = False,
+    active_job_id: str = "",
+) -> dict[str, Any]:
+    posts = store.read_frame("normalized_posts")
+    source_mode = detect_source_mode(posts)
+    latest = _health_latest(store, health_service)
+    history = store.read_frame("data_health_history")
+    refresh_history = ensure_refresh_history_frame(store.read_frame("refresh_history"))
+    trend_source = history if not history.empty else latest
+    refresh_jobs = ensure_refresh_jobs_frame(store.read_frame("dataset_refresh_jobs"))
+    watchlist = watchlist_symbols(store)
+    asset_universe = store.read_frame("asset_universe")
+    registry = store.dataset_registry()
+
+    last_refresh = {}
+    if not refresh_history.empty:
+        order_col = "completed_at" if refresh_history["completed_at"].notna().any() else "started_at"
+        last_refresh = refresh_history.sort_values(order_col).tail(1).to_dict(orient="records")[0]
+
+    missing = missing_core_datasets(store)
+    return {
+        "admin": {
+            "mode": "public" if public_mode else "private",
+            "write_requires_unlock": bool(public_mode),
+        },
+        "status": {
+            "operating_mode": source_mode_label(source_mode),
+            "source_mode": source_mode,
+            "state_root": str(settings.state_root),
+            "db_path": str(settings.db_path),
+            "scheduler_enabled": bool(settings.scheduler_enabled),
+            "missing_core_datasets": missing,
+            "missing_core_dataset_count": int(len(missing)),
+            "last_refresh": last_refresh,
+            "active_job_id": str(active_job_id or ""),
+        },
+        "watchlist_symbols": watchlist,
+        "asset_universe": _frame_records(asset_universe, limit=500),
+        "summary": build_health_summary(latest, refresh_history),
+        "latest": _frame_records(latest, limit=500),
+        "trend": _frame_records(build_health_trend_frame(trend_source), limit=100),
+        "refresh_history": _frame_records(refresh_history, limit=50),
+        "registry": _frame_records(registry, limit=500),
+        "source_manifests": _frame_records(store.read_frame("source_manifests"), limit=200),
+        "asset_market_manifest": _frame_records(store.read_frame("asset_market_manifest"), limit=300),
+        "refresh_jobs": _frame_records(refresh_jobs, limit=50),
+    }
+
+
+def save_dataset_watchlist(store: DuckDBStore, symbols: list[str] | tuple[str, ...], reset: bool = False) -> dict[str, Any]:
+    resolved_symbols = [] if reset else normalize_symbols(list(symbols))
+    watchlist, asset_universe = save_watchlist(store, resolved_symbols)
+    return {
+        "watchlist_symbols": watchlist["symbol"].astype(str).tolist() if not watchlist.empty else [],
+        "asset_universe": asset_universe.to_dict(orient="records") if not asset_universe.empty else [],
+    }
+
+
+def run_refresh_job(
+    *,
+    settings: AppSettings,
+    store: DuckDBStore,
+    job_id: str,
+    refresh_mode: str,
+    remote_url: str,
+    uploaded_files: list[UploadedCsv],
+    ingestion_service: IngestionService,
+    market_service: MarketDataService,
+    discovery_service: DiscoveryService,
+    feature_service: FeatureService,
+    health_service: DataHealthService,
+    lock_fd: int | None,
+) -> None:
+    started_at = pd.Timestamp.now(tz="UTC")
+    try:
+        save_refresh_job(
+            store,
+            _job_row(
+                job_id=job_id,
+                refresh_mode=refresh_mode,
+                status="running",
+                started_at=started_at,
+                remote_url=remote_url,
+                uploaded_file_count=len(uploaded_files),
+            ),
+        )
+        summary = refresh_datasets(
+            settings=settings,
+            store=store,
+            ingestion_service=ingestion_service,
+            market_service=market_service,
+            discovery_service=discovery_service,
+            feature_service=feature_service,
+            health_service=health_service,
+            remote_url=remote_url,
+            uploaded_files=uploaded_files,
+            incremental=refresh_mode == "incremental",
+            refresh_mode=refresh_mode,
+        )
+        save_refresh_job(
+            store,
+            _job_row(
+                job_id=job_id,
+                refresh_id=str(summary.get("refresh_id", "")),
+                refresh_mode=refresh_mode,
+                status="success",
+                started_at=started_at,
+                completed_at=pd.Timestamp.now(tz="UTC"),
+                remote_url=remote_url,
+                uploaded_file_count=len(uploaded_files),
+                normalized_post_count=_count_rows(summary, "posts"),
+                asset_daily_row_count=_count_rows(summary, "asset_daily"),
+                asset_intraday_row_count=_count_rows(summary, "asset_intraday"),
+                tracked_account_count=_count_rows(summary, "tracked_accounts"),
+            ),
+        )
+    except Exception as exc:
+        save_refresh_job(
+            store,
+            _job_row(
+                job_id=job_id,
+                refresh_mode=refresh_mode,
+                status="error",
+                started_at=started_at,
+                completed_at=pd.Timestamp.now(tz="UTC"),
+                error_message=str(exc),
+                remote_url=remote_url,
+                uploaded_file_count=len(uploaded_files),
+            ),
+        )
+    finally:
+        release_refresh_lock(settings, lock_fd)
+
+
+def submit_refresh_job(
+    *,
+    settings: AppSettings,
+    store: DuckDBStore,
+    refresh_mode: str,
+    remote_url: str,
+    uploaded_files: list[UploadedCsv],
+    ingestion_service: IngestionService,
+    market_service: MarketDataService,
+    discovery_service: DiscoveryService,
+    feature_service: FeatureService,
+    health_service: DataHealthService,
+    run_inline: bool = False,
+) -> tuple[str, list[str]]:
+    resolved_mode = str(refresh_mode or "").strip().lower()
+    if resolved_mode not in VALID_REFRESH_MODES:
+        return "", [f"Unsupported refresh mode: {refresh_mode}."]
+
+    lock_fd = acquire_refresh_lock(settings)
+    if lock_fd is None:
+        return "", ["A dataset refresh is already running."]
+
+    job_id = f"dataset-refresh-{pd.Timestamp.now(tz='UTC').strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    save_refresh_job(
+        store,
+        _job_row(
+            job_id=job_id,
+            refresh_mode=resolved_mode,
+            status="queued",
+            started_at=pd.Timestamp.now(tz="UTC"),
+            remote_url=remote_url,
+            uploaded_file_count=len(uploaded_files),
+        ),
+    )
+    if run_inline:
+        run_refresh_job(
+            settings=settings,
+            store=store,
+            job_id=job_id,
+            refresh_mode=resolved_mode,
+            remote_url=remote_url,
+            uploaded_files=uploaded_files,
+            ingestion_service=ingestion_service,
+            market_service=market_service,
+            discovery_service=discovery_service,
+            feature_service=feature_service,
+            health_service=health_service,
+            lock_fd=lock_fd,
+        )
+    else:
+        thread = threading.Thread(
+            target=run_refresh_job,
+            kwargs={
+                "settings": settings,
+                "store": store,
+                "job_id": job_id,
+                "refresh_mode": resolved_mode,
+                "remote_url": remote_url,
+                "uploaded_files": uploaded_files,
+                "ingestion_service": ingestion_service,
+                "market_service": market_service,
+                "discovery_service": discovery_service,
+                "feature_service": feature_service,
+                "health_service": health_service,
+                "lock_fd": lock_fd,
+            },
+            daemon=True,
+        )
+        thread.start()
+    return job_id, []


### PR DESCRIPTION
Closes #57.

## Summary
- adds a FastAPI Dataset Admin payload builder plus admin-protected watchlist, refresh-job, and job-status endpoints
- persists `dataset_refresh_jobs` and runs lock-aware background refresh jobs using the existing refresh pipeline
- expands the React Data Health tab into a Data Admin console with admin unlock, watchlist save/reset, CSV URL/upload inputs, refresh controls, job history, health, registry, and manifests
- documents the updated mixed read/write React migration state and adds `python-multipart` for uploads

## Validation
- `bash scripts/ci.sh`
