### PR TITLE
Improve scheduler and modeling test coverage

### DIFF
--- a/tests/test_hosting.py
+++ b/tests/test_hosting.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pandas as pd
 
@@ -10,7 +12,14 @@ from trump_workbench.access import ADMIN_SESSION_KEY, app_mode_label, verify_adm
 from trump_workbench.config import AppSettings
 from trump_workbench.health import make_refresh_history_frame
 from trump_workbench.runtime import CORE_DATASET_NAMES, ensure_bootstrap
-from trump_workbench.scheduler import acquire_refresh_lock, choose_scheduler_refresh, release_refresh_lock
+from trump_workbench.scheduler import (
+    SchedulerDecision,
+    acquire_refresh_lock,
+    choose_scheduler_refresh,
+    release_refresh_lock,
+    run_scheduler_cycle,
+    run_scheduler_once,
+)
 from trump_workbench.storage import DuckDBStore
 
 
@@ -116,6 +125,213 @@ class HostingBehaviorTests(unittest.TestCase):
         third_lock_fd = acquire_refresh_lock(self.settings)
         self.assertIsNotNone(third_lock_fd)
         release_refresh_lock(self.settings, third_lock_fd)
+
+    def test_release_refresh_lock_ignores_missing_lock(self) -> None:
+        release_refresh_lock(self.settings, None)
+
+        self.assertFalse(self.settings.scheduler_lock_path.exists())
+
+    def test_scheduler_chooses_full_when_history_is_missing_or_invalid(self) -> None:
+        self._seed_core_datasets()
+
+        empty_history_decision = choose_scheduler_refresh(
+            self.store,
+            self.settings,
+            now=pd.Timestamp("2026-04-15 01:00:00"),
+        )
+
+        error_history = make_refresh_history_frame(
+            refresh_id="failed-1",
+            refresh_mode="incremental",
+            status="error",
+            started_at=pd.Timestamp("2026-04-15 01:00:00", tz="UTC"),
+            completed_at=pd.Timestamp("2026-04-15 01:01:00", tz="UTC"),
+            error_message="boom",
+        )
+        self.store.save_frame("refresh_history", error_history, metadata={"latest_status": "error"})
+        error_history_decision = choose_scheduler_refresh(
+            self.store,
+            self.settings,
+            now=pd.Timestamp("2026-04-15 01:05:00", tz="America/New_York"),
+        )
+
+        invalid_history = make_refresh_history_frame(
+            refresh_id="bad-1",
+            refresh_mode="incremental",
+            status="success",
+            started_at=pd.Timestamp("2026-04-15 01:00:00", tz="UTC"),
+            completed_at=pd.NaT,
+        )
+        self.store.save_frame("refresh_history", invalid_history, metadata={"latest_status": "success"})
+        invalid_history_decision = choose_scheduler_refresh(
+            self.store,
+            self.settings,
+            now=pd.Timestamp("2026-04-15 01:10:00", tz="America/New_York"),
+        )
+
+        self.assertEqual(empty_history_decision.refresh_mode, "full")
+        self.assertEqual(error_history_decision.refresh_mode, "full")
+        self.assertEqual(invalid_history_decision.refresh_mode, "full")
+
+    def test_scheduler_skips_when_recent_success_is_fresh(self) -> None:
+        self._seed_core_datasets()
+        history = make_refresh_history_frame(
+            refresh_id="full-1",
+            refresh_mode="full",
+            status="success",
+            started_at=pd.Timestamp("2026-04-15 06:00:00", tz="UTC"),
+            completed_at=pd.Timestamp("2026-04-15 06:05:00", tz="UTC"),
+        )
+        self.store.save_frame("refresh_history", history, metadata={"latest_status": "success"})
+
+        decision = choose_scheduler_refresh(
+            self.store,
+            AppSettings(
+                base_dir=Path(self.temp_dir.name),
+                scheduler_incremental_minutes=30,
+                scheduler_full_hour=1,
+                scheduler_full_minute=0,
+            ),
+            now=pd.Timestamp("2026-04-15 02:15:00", tz="America/New_York"),
+        )
+
+        self.assertFalse(decision.should_run)
+
+    def test_run_scheduler_cycle_skips_refresh_when_no_decision(self) -> None:
+        with patch("trump_workbench.scheduler.refresh_datasets") as refresh_mock:
+            result = run_scheduler_cycle(
+                settings=self.settings,
+                store=self.store,
+                decision=SchedulerDecision(),
+                ingestion_service=Mock(),
+                market_service=Mock(),
+                discovery_service=Mock(),
+                feature_service=Mock(),
+                health_service=Mock(),
+                experiment_store=Mock(),
+                model_service=Mock(),
+                paper_service=Mock(),
+            )
+
+        self.assertFalse(result.should_run)
+        refresh_mock.assert_not_called()
+
+    def test_run_scheduler_cycle_returns_after_refresh_without_live_config(self) -> None:
+        experiment_store = Mock()
+        experiment_store.load_live_monitor_config.return_value = None
+
+        with patch("trump_workbench.scheduler.refresh_datasets") as refresh_mock:
+            result = run_scheduler_cycle(
+                settings=self.settings,
+                store=self.store,
+                decision=SchedulerDecision(refresh_mode="incremental", incremental=True),
+                ingestion_service=Mock(),
+                market_service=Mock(),
+                discovery_service=Mock(),
+                feature_service=Mock(),
+                health_service=Mock(),
+                experiment_store=experiment_store,
+                model_service=Mock(),
+                paper_service=Mock(),
+            )
+
+        self.assertEqual(result.refresh_mode, "incremental")
+        refresh_mock.assert_called_once()
+        experiment_store.list_runs.assert_not_called()
+
+    def test_run_scheduler_cycle_persists_live_paper_and_performance_outputs(self) -> None:
+        board = pd.DataFrame(
+            [
+                {
+                    "generated_at": pd.Timestamp("2026-04-15 12:00:00", tz="UTC"),
+                    "asset_symbol": "SPY",
+                    "expected_return_score": 0.01,
+                },
+            ],
+        )
+        decision_row = pd.DataFrame(
+            [
+                {
+                    "generated_at": pd.Timestamp("2026-04-15 12:00:00", tz="UTC"),
+                    "signal_session_date": pd.Timestamp("2026-04-14", tz="UTC"),
+                    "winning_asset": "SPY",
+                    "stance": "LONG",
+                },
+            ],
+        )
+        live_config = SimpleNamespace(
+            mode="portfolio_run",
+            portfolio_run_id="run-1",
+            deployment_variant="per_asset__baseline",
+            fallback_mode="SPY",
+        )
+        paper_config = SimpleNamespace(paper_portfolio_id="paper-1")
+        experiment_store = Mock()
+        experiment_store.load_live_monitor_config.return_value = live_config
+        experiment_store.list_runs.return_value = pd.DataFrame([{"run_id": "run-1"}])
+        paper_service = Mock()
+        paper_service.load_current_config.return_value = paper_config
+        performance_service = Mock()
+
+        with (
+            patch("trump_workbench.scheduler.refresh_datasets") as refresh_mock,
+            patch("trump_workbench.scheduler.validate_live_monitor_config", return_value=[]),
+            patch("trump_workbench.scheduler.build_live_portfolio_run_state", return_value=(board, decision_row, None, [])),
+            patch("trump_workbench.scheduler.paper_config_matches_live", return_value=True),
+        ):
+            result = run_scheduler_cycle(
+                settings=self.settings,
+                store=self.store,
+                decision=SchedulerDecision(refresh_mode="full", incremental=False),
+                ingestion_service=Mock(),
+                market_service=Mock(),
+                discovery_service=Mock(),
+                feature_service=Mock(),
+                health_service=Mock(),
+                experiment_store=experiment_store,
+                model_service=Mock(),
+                paper_service=paper_service,
+                performance_service=performance_service,
+                generated_at=pd.Timestamp("2026-04-15 12:00:00", tz="UTC"),
+            )
+
+        self.assertEqual(result.refresh_mode, "full")
+        refresh_mock.assert_called_once()
+        experiment_store.save_live_asset_snapshots.assert_called_once()
+        experiment_store.save_live_decision_snapshots.assert_called_once()
+        paper_service.process_live_history.assert_called_once_with(
+            paper_config,
+            as_of=pd.Timestamp("2026-04-15 12:00:00", tz="UTC"),
+        )
+        performance_service.persist_snapshot.assert_called_once_with(
+            "paper-1",
+            generated_at=pd.Timestamp("2026-04-15 12:00:00", tz="UTC"),
+        )
+
+    def test_run_scheduler_once_returns_empty_decision_when_lock_is_held(self) -> None:
+        lock_fd = acquire_refresh_lock(self.settings)
+        self.assertIsNotNone(lock_fd)
+        try:
+            decision = run_scheduler_once(self.settings)
+        finally:
+            release_refresh_lock(self.settings, lock_fd)
+
+        self.assertFalse(decision.should_run)
+
+    def test_run_scheduler_once_releases_lock_after_cycle_failure(self) -> None:
+        with (
+            patch(
+                "trump_workbench.scheduler.choose_scheduler_refresh",
+                return_value=SchedulerDecision(refresh_mode="full", incremental=False),
+            ),
+            patch("trump_workbench.scheduler.run_scheduler_cycle", side_effect=RuntimeError("cycle failed")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "cycle failed"):
+                run_scheduler_once(self.settings)
+
+        lock_fd = acquire_refresh_lock(self.settings)
+        self.assertIsNotNone(lock_fd)
+        release_refresh_lock(self.settings, lock_fd)
 
 
 if __name__ == "__main__":

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 import unittest
 
+import numpy as np
 import pandas as pd
 
-from trump_workbench.modeling import ModelService
+from trump_workbench.contracts import LinearModelArtifact, ModelRunConfig
+from trump_workbench.modeling import (
+    ASSET_INDICATOR_PREFIX,
+    ModelService,
+    add_asset_indicator_columns,
+    classify_feature_family,
+    normalize_narrative_feature_mode,
+)
 
 
 class ModelFeatureSelectionTests(unittest.TestCase):
@@ -68,6 +76,184 @@ class ModelFeatureSelectionTests(unittest.TestCase):
         )
 
         self.assertEqual(features, [])
+
+
+class ModelTrainingAndPredictionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.service = ModelService()
+        dates = pd.date_range("2025-02-03", periods=24, freq="B")
+        index = np.arange(len(dates), dtype=float)
+        self.frame = pd.DataFrame(
+            {
+                "signal_session_date": dates,
+                "next_session_date": dates + pd.offsets.BDay(1),
+                "asset_symbol": ["SPY", "QQQ", "NVDA"] * 8,
+                "target_next_session_return": (index - 11.5) / 2500.0,
+                "post_count": (index % 5) + 1,
+                "sentiment_avg": np.linspace(-0.45, 0.55, len(dates)),
+                "session_return": np.linspace(-0.012, 0.014, len(dates)),
+                "tracked_author_count": (index % 4) + 1,
+                "engagement_score_avg": np.linspace(0.1, 1.2, len(dates)),
+                "semantic_market_relevance_avg": np.linspace(0.2, 0.9, len(dates)),
+                "policy_trade": [1.0, 0.0, 0.0] * 8,
+            },
+        )
+        self.feature_columns = ["post_count", "sentiment_avg", "session_return", "tracked_author_count"]
+
+    def test_feature_mode_and_family_helpers_cover_expected_branches(self) -> None:
+        self.assertEqual(normalize_narrative_feature_mode("narrative-only"), "narrative_only")
+        self.assertEqual(normalize_narrative_feature_mode("bad-mode"), "hybrid")
+        self.assertEqual(classify_feature_family("policy_trade"), "policy")
+        self.assertEqual(classify_feature_family("semantic_topic_trade"), "semantic")
+        self.assertEqual(classify_feature_family(f"{ASSET_INDICATOR_PREFIX}spy"), "asset_identity")
+        self.assertEqual(classify_feature_family("rolling_vol_5d"), "market_context")
+        self.assertEqual(classify_feature_family("sentiment_avg"), "social_sentiment")
+        self.assertEqual(classify_feature_family("engagement_score_avg"), "social_engagement")
+        self.assertEqual(classify_feature_family("tracked_author_count"), "account_structure")
+        self.assertEqual(classify_feature_family("mention_post_count"), "activity")
+        self.assertEqual(classify_feature_family("unclassified_feature"), "other")
+
+        with_indicators = add_asset_indicator_columns(self.frame[["asset_symbol"]].head(3), ["spy", "qqq"])
+
+        self.assertEqual(with_indicators[f"{ASSET_INDICATOR_PREFIX}spy"].tolist(), [1.0, 0.0, 0.0])
+        self.assertEqual(with_indicators[f"{ASSET_INDICATOR_PREFIX}qqq"].tolist(), [0.0, 1.0, 0.0])
+
+    def test_custom_train_predict_and_explain_round_trip(self) -> None:
+        artifact, importance = self.service.train(
+            ModelRunConfig(run_name="unit-model", llm_enabled=True, target_asset="SPY"),
+            self.frame,
+            "custom-v1",
+        )
+
+        predictions = self.service.predict(artifact, self.frame.head(3).drop(columns=["tracked_author_count"]))
+        explanation = self.service.explain_predictions(artifact, predictions.head(1))
+
+        self.assertEqual(artifact.model_family, "custom_linear")
+        self.assertFalse(importance.empty)
+        self.assertIn("expected_return_score", predictions.columns)
+        self.assertIn("tracked_author_count", predictions.columns)
+        self.assertFalse(explanation.empty)
+        self.assertEqual(set(explanation["model_version"]), {"custom-v1"})
+
+    def test_train_rejects_empty_targets_and_missing_features(self) -> None:
+        no_targets = self.frame.copy()
+        no_targets["target_next_session_return"] = pd.NA
+        no_features = self.frame[["signal_session_date", "target_next_session_return"]].copy()
+
+        with self.assertRaisesRegex(RuntimeError, "No trainable rows"):
+            self.service.train(ModelRunConfig(run_name="empty"), no_targets, "empty-v1")
+        with self.assertRaisesRegex(RuntimeError, "No numeric feature columns"):
+            self.service.train(ModelRunConfig(run_name="no-features"), no_features, "no-features-v1")
+
+    def test_sklearn_linear_families_fit_predict_and_explain(self) -> None:
+        for family in ["ridge", "lasso", "elastic_net"]:
+            with self.subTest(family=family):
+                artifact, importance = self.service.train_with_family(
+                    self.frame,
+                    llm_enabled=True,
+                    model_family=family,
+                    model_version=f"{family}-v1",
+                    metadata={"family": family},
+                    feature_columns=self.feature_columns,
+                    regularization=0.01,
+                )
+                predictions = self.service.predict(artifact, self.frame.head(4))
+                explanation = self.service.explain_predictions(artifact, predictions.head(2))
+
+                self.assertEqual(artifact.model_family, family)
+                self.assertEqual(artifact.explanation_kind, "linear_exact")
+                self.assertEqual(set(artifact.feature_names), set(self.feature_columns))
+                self.assertFalse(importance.empty)
+                self.assertTrue(np.isfinite(predictions["expected_return_score"]).all())
+                self.assertFalse(explanation.empty)
+
+    def test_tree_families_fit_with_serialized_estimators(self) -> None:
+        for family, compute_importance in [
+            ("random_forest_regressor", True),
+            ("hist_gradient_boosting_regressor", False),
+        ]:
+            with self.subTest(family=family):
+                artifact, importance = self.service.train_with_family(
+                    self.frame,
+                    llm_enabled=True,
+                    model_family=family,
+                    model_version=f"{family}-v1",
+                    metadata={"family": family},
+                    feature_columns=self.feature_columns,
+                    compute_importance=compute_importance,
+                )
+                predictions = self.service.predict(artifact, self.frame.head(4))
+
+                self.assertEqual(artifact.model_family, family)
+                self.assertEqual(artifact.explanation_kind, "importance_proxy")
+                self.assertTrue(artifact.serialized_estimator_b64)
+                self.assertEqual(len(artifact.feature_importances), len(self.feature_columns))
+                self.assertFalse(importance.empty)
+                self.assertTrue(np.isfinite(predictions["expected_return_score"]).all())
+                if family == "hist_gradient_boosting_regressor":
+                    self.assertEqual(artifact.feature_importances, [0.0 for _ in self.feature_columns])
+
+    def test_train_with_family_rejects_invalid_inputs(self) -> None:
+        no_targets = self.frame.copy()
+        no_targets["target_next_session_return"] = pd.NA
+        no_features = self.frame[["signal_session_date", "target_next_session_return"]].copy()
+
+        with self.assertRaisesRegex(RuntimeError, "No trainable rows"):
+            self.service.train_with_family(
+                no_targets,
+                llm_enabled=True,
+                model_family="ridge",
+                model_version="empty-v1",
+                metadata={},
+            )
+        with self.assertRaisesRegex(RuntimeError, "No numeric feature columns"):
+            self.service.train_with_family(
+                no_features,
+                llm_enabled=True,
+                model_family="ridge",
+                model_version="no-features-v1",
+                metadata={},
+            )
+        with self.assertRaisesRegex(RuntimeError, "Unsupported model family"):
+            self.service.train_with_family(
+                self.frame,
+                llm_enabled=True,
+                model_family="unsupported",
+                model_version="bad-v1",
+                metadata={},
+                feature_columns=self.feature_columns,
+            )
+
+    def test_predict_empty_and_importance_proxy_explanations_are_safe(self) -> None:
+        artifact = LinearModelArtifact(
+            model_version="proxy-v1",
+            feature_names=["post_count", "sentiment_avg"],
+            means=[0.0],
+            stds=[0.0],
+            residual_std=0.2,
+            model_family="random_forest_regressor",
+            feature_importances=[0.75],
+            explanation_kind="importance_proxy",
+        )
+        rows = pd.DataFrame(
+            {
+                "signal_session_date": pd.date_range("2025-03-03", periods=2),
+                "next_session_date": pd.date_range("2025-03-04", periods=2),
+                "model_version": ["proxy-v1", "proxy-v1"],
+                "expected_return_score": [0.01, -0.002],
+                "prediction_confidence": [0.8, 0.7],
+                "post_count": [3.0, 0.0],
+                "sentiment_avg": [0.2, -0.1],
+            },
+        )
+
+        empty_predictions = self.service.predict(artifact, pd.DataFrame())
+        explanation = self.service.explain_predictions(artifact, rows)
+
+        self.assertEqual(list(empty_predictions.columns), ["expected_return_score", "prediction_confidence", "model_version"])
+        self.assertEqual(len(explanation), 4)
+        self.assertTrue(np.isfinite(explanation["contribution_share"]).all())
+        self.assertEqual(set(explanation["feature_family"]), {"activity", "social_sentiment"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds scheduler tests for refresh decision fallbacks, stale/invalid refresh history, lock handling, scheduler-cycle early exits, and live/paper/performance side effects.
- Adds modeling tests for narrative feature helper branches, custom linear training, sklearn model-family training, serialized estimator prediction, missing-feature prediction, and explanation fallback behavior.
- Keeps this test-only; no production code changes.

## Coverage impact
- Total Python coverage increased from 91% to 92%.
- `trump_workbench/scheduler.py` increased from 68% to 90%.
- `trump_workbench/modeling.py` increased from 76% to 96%.

## Validation
- `bash scripts/ci.sh`

Closes #59