### PR TITLE
Migrate model training jobs to React

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -136,6 +136,100 @@ const runsPayload = {
   ],
 };
 
+const modelTrainingPayload = {
+  admin: {
+    write_requires_unlock: true,
+  },
+  status: {
+    ready: true,
+    active_job_id: "",
+    readiness_errors: {
+      single_asset: [],
+      saved_run_portfolio: [],
+      joint_portfolio: [],
+    },
+  },
+  defaults: {
+    single_asset: {
+      run_name: "baseline-research-run",
+      target_asset: "SPY",
+      feature_version: "v1",
+    },
+    saved_run_portfolio: {
+      run_name: "portfolio-allocator-run",
+      fallback_mode: "SPY",
+    },
+    joint_portfolio: {
+      run_name: "joint-portfolio-run",
+      feature_version: "asset-v1",
+      selected_symbols: ["SPY", "QQQ", "NVDA"],
+    },
+  },
+  asset_options: [
+    { symbol: "SPY", label: "SPY - SPDR S&P 500 ETF Trust" },
+    { symbol: "QQQ", label: "QQQ - Invesco QQQ Trust" },
+  ],
+  feature_versions: ["asset-v1"],
+  asset_session_symbols: ["SPY", "QQQ", "NVDA"],
+  narrative_feature_modes: ["baseline", "narrative_only", "hybrid"],
+  model_families: ["ridge", "elastic_net", "hist_gradient_boosting_regressor"],
+  topology_variants: ["per_asset", "pooled"],
+  run_options: runsPayload.runs,
+  asset_model_runs: [
+    {
+      run_id: "run-asset-1",
+      run_name: "SPY Baseline",
+      target_asset: "SPY",
+      run_type: "asset_model",
+      selected_params: {
+        threshold: 0.001,
+      },
+    },
+    {
+      run_id: "run-asset-qqq",
+      run_name: "QQQ Baseline",
+      target_asset: "QQQ",
+      run_type: "asset_model",
+    },
+  ],
+  recent_jobs: [
+    {
+      job_id: "model-training-1",
+      workflow_mode: "joint_portfolio",
+      status: "success",
+      run_id: "run-portfolio-1",
+      run_name: "Portfolio Alpha",
+    },
+  ],
+};
+
+const modelTrainingStartedPayload = {
+  ...modelTrainingPayload,
+  job_id: "model-training-2",
+  status: {
+    ...modelTrainingPayload.status,
+    active_job_id: "model-training-2",
+  },
+  recent_jobs: [
+    {
+      job_id: "model-training-2",
+      workflow_mode: "joint_portfolio",
+      status: "success",
+      run_id: "run-portfolio-2",
+      run_name: "Joint Portfolio Web Test",
+      run_type: "portfolio_allocator",
+      target_asset: "PORTFOLIO",
+      summary: JSON.stringify({
+        metrics: {
+          total_return: 0.07,
+          robust_score: 1.4,
+        },
+      }),
+    },
+    ...modelTrainingPayload.recent_jobs,
+  ],
+};
+
 const runDetailPayload = {
   found: true,
   run_id: "run-portfolio-1",
@@ -710,6 +804,14 @@ async function mockApi(page: Page) {
     recent_jobs: datasetAdminPayload.refresh_jobs,
   });
   await fulfillJson(page, "/api/runs", runsPayload);
+  await fulfillJson(page, "/api/models/training", modelTrainingPayload);
+  await fulfillJson(page, "/api/models/jobs", modelTrainingStartedPayload);
+  await fulfillJson(page, "/api/models/jobs/model-training-2", {
+    job_id: "model-training-2",
+    found: true,
+    job: modelTrainingStartedPayload.recent_jobs[0],
+    recent_jobs: modelTrainingStartedPayload.recent_jobs,
+  });
   await fulfillJson(page, "/api/runs/run-portfolio-1**", runDetailPayload);
   await fulfillJson(page, "/api/runs/compare**", runComparisonPayload);
   await fulfillJson(page, "/api/research**", researchPayload);
@@ -820,6 +922,34 @@ test("shows the migrated run explorer with detail and comparison tables", async 
   await expect(page.getByRole("heading", { name: "Compare saved runs" })).toBeVisible();
   await expect(page.getByRole("cell", { name: "SPY Baseline" })).toBeVisible();
   await expect(page.getByText("run-asset-1: robust score")).toBeVisible();
+});
+
+test("shows model training forms and submits an admin job", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /Model Training/ }).click();
+
+  await expect(page.getByRole("heading", { name: "Model Training Job Console" })).toBeVisible();
+  await expect(page.getByText("Read-only until unlocked")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Single Asset" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Saved-Run Portfolio" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Joint Portfolio" })).toBeVisible();
+  await page.getByPlaceholder("Admin password").fill("secret");
+  await page.getByRole("button", { name: "Unlock admin writes" }).click();
+  await expect(page.getByText("Unlocked for this browser session")).toBeVisible();
+  await page.getByRole("button", { name: "Saved-Run Portfolio" }).click();
+  await expect(page.getByRole("heading", { name: "Saved-Run Portfolio configuration" })).toBeVisible();
+  await page.getByRole("button", { name: "Single Asset" }).click();
+  await expect(page.getByRole("heading", { name: "Single Asset configuration" })).toBeVisible();
+  await page.getByRole("button", { name: "Joint Portfolio" }).click();
+  await expect(page.getByRole("heading", { name: "Joint Portfolio configuration" })).toBeVisible();
+  await page.getByRole("button", { name: "Start model training job" }).click();
+  await expect(page.getByRole("heading", { name: "Latest training result" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Inspect in Run Explorer" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Configure in Live Ops" })).toBeEnabled();
+  await expect(page.getByRole("cell", { name: "model-training-2" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "run-portfolio-2" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Saved asset-model run options" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "QQQ Baseline" })).toBeVisible();
 });
 
 test("shows live ops controls and supports admin actions", async ({ page }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,17 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import createPlotlyComponentModule from "react-plotly.js/factory";
 import Plotly from "plotly.js-dist-min";
 import type { Data, Frame, Layout } from "plotly.js";
-import { api, type DatasetAdminPayload, type LiveOpsPayload, type PlotlyFigure, type RecordRow, type ResearchFilters } from "./api";
+import {
+  api,
+  type DatasetAdminPayload,
+  type LiveOpsPayload,
+  type ModelTrainingJobRequest,
+  type ModelTrainingPayload,
+  type ModelTrainingWorkflow,
+  type PlotlyFigure,
+  type RecordRow,
+  type ResearchFilters,
+} from "./api";
 
 type PlotComponentFactory = (plotly: unknown) => ComponentType<Record<string, unknown>>;
 const createPlotlyComponent = (
@@ -12,13 +22,14 @@ const createPlotlyComponent = (
 ) as PlotComponentFactory;
 const Plot = createPlotlyComponent(Plotly);
 
-type PageKey = "overview" | "research" | "discovery" | "runs" | "data" | "live" | "paper";
+type PageKey = "overview" | "research" | "discovery" | "runs" | "models" | "data" | "live" | "paper";
 
 const pages: Array<{ key: PageKey; label: string; deck: string }> = [
   { key: "overview", label: "Overview", deck: "API status and migration posture" },
   { key: "research", label: "Research", deck: "Sentiment, narratives, and export pack" },
   { key: "discovery", label: "Discovery", deck: "Tracked account ranking workspace" },
   { key: "runs", label: "Run Explorer", deck: "Saved model results and comparisons" },
+  { key: "models", label: "Model Training", deck: "Train and save model runs" },
   { key: "data", label: "Data Admin", deck: "Refresh jobs, watchlist, and data health" },
   { key: "live", label: "Live Ops", deck: "Operate deployed portfolio" },
   { key: "paper", label: "Paper + Performance", deck: "Portfolio audit and drift" },
@@ -903,6 +914,422 @@ function OverviewPage() {
   );
 }
 
+function modelRunLabel(row: RecordRow): string {
+  const runName = String(row.run_name ?? row.run_id ?? "");
+  const asset = String(row.target_asset ?? "");
+  const score = row.robust_score !== undefined && row.robust_score !== null ? ` | robust ${formatValue(row.robust_score)}` : "";
+  return `${asset} | ${runName}${score}`;
+}
+
+function modelWorkflowLabel(mode: ModelTrainingWorkflow): string {
+  if (mode === "single_asset") {
+    return "Single Asset";
+  }
+  if (mode === "saved_run_portfolio") {
+    return "Saved-Run Portfolio";
+  }
+  return "Joint Portfolio";
+}
+
+function parseModelJobSummary(job: RecordRow | undefined): Record<string, unknown> {
+  const summary = job?.summary;
+  if (!summary) {
+    return {};
+  }
+  if (typeof summary === "object") {
+    return summary as Record<string, unknown>;
+  }
+  try {
+    return JSON.parse(String(summary)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function ModelTrainingPage({ onNavigate }: { onNavigate: (page: PageKey) => void }) {
+  const queryClient = useQueryClient();
+  const training = useQuery({ queryKey: ["model-training"], queryFn: api.modelTraining, refetchInterval: 10_000 });
+  const [adminToken, setAdminToken] = useState(() =>
+    typeof window === "undefined" ? "" : window.sessionStorage.getItem("allcaps_admin_token") ?? "",
+  );
+  const [password, setPassword] = useState("");
+  const [workflowMode, setWorkflowMode] = useState<ModelTrainingWorkflow>("joint_portfolio");
+  const [runName, setRunName] = useState("joint-portfolio-run");
+  const [targetAsset, setTargetAsset] = useState("SPY");
+  const [featureVersion, setFeatureVersion] = useState("asset-v1");
+  const [llmEnabled, setLlmEnabled] = useState(false);
+  const [trainWindow, setTrainWindow] = useState(90);
+  const [validationWindow, setValidationWindow] = useState(30);
+  const [testWindow, setTestWindow] = useState(30);
+  const [stepSize, setStepSize] = useState(30);
+  const [transactionCostBps, setTransactionCostBps] = useState(2);
+  const [ridgeAlpha, setRidgeAlpha] = useState(1);
+  const [thresholdGrid, setThresholdGrid] = useState("0,0.001,0.0025,0.005");
+  const [minimumSignalGrid, setMinimumSignalGrid] = useState("1,2,3");
+  const [accountWeightGrid, setAccountWeightGrid] = useState("0.5,1.0,1.5");
+  const [fallbackMode, setFallbackMode] = useState<"SPY" | "FLAT">("SPY");
+  const [componentRunIds, setComponentRunIds] = useState<string[]>([]);
+  const [selectedSymbolsText, setSelectedSymbolsText] = useState("SPY, QQQ, NVDA");
+  const [topologyVariants, setTopologyVariants] = useState<string[]>(["per_asset", "pooled"]);
+  const [modelFamilies, setModelFamilies] = useState<string[]>(["ridge", "elastic_net", "hist_gradient_boosting_regressor"]);
+  const [narrativeFeatureModes, setNarrativeFeatureModes] = useState<string[]>(["baseline"]);
+
+  const applyTrainingPayload = (payload: ModelTrainingPayload) => {
+    queryClient.setQueryData(["model-training"], payload);
+    queryClient.invalidateQueries({ queryKey: ["runs"] });
+  };
+  const unlock = useMutation({
+    mutationFn: () => api.adminSession(password),
+    onSuccess: (payload) => {
+      setAdminToken(payload.token);
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem("allcaps_admin_token", payload.token);
+      }
+      setPassword("");
+    },
+  });
+  const startTraining = useMutation({
+    mutationFn: (request: ModelTrainingJobRequest) => api.startModelTrainingJob(request, adminToken),
+    onSuccess: applyTrainingPayload,
+  });
+
+  useEffect(() => {
+    const payload = training.data;
+    if (!payload) {
+      return;
+    }
+    const jointDefaults = payload.defaults.joint_portfolio;
+    if (!featureVersion && typeof jointDefaults.feature_version === "string") {
+      setFeatureVersion(jointDefaults.feature_version);
+    }
+    const defaultSymbols = Array.isArray(jointDefaults.selected_symbols) ? jointDefaults.selected_symbols.map(String) : [];
+    if (defaultSymbols.length && selectedSymbolsText === "SPY, QQQ, NVDA") {
+      setSelectedSymbolsText(defaultSymbols.join(", "));
+    }
+    const defaultComponents = payload.asset_model_runs
+      .filter((row) => row.target_asset === "SPY")
+      .slice(0, 1)
+      .map((row) => String(row.run_id ?? ""))
+      .filter(Boolean);
+    if (!componentRunIds.length && defaultComponents.length) {
+      setComponentRunIds(defaultComponents);
+    }
+  }, [training.data, featureVersion, selectedSymbolsText, componentRunIds.length]);
+
+  if (training.isLoading) {
+    return <LoadingBlock label="Loading model training console..." />;
+  }
+  if (training.error) {
+    return <ErrorBlock error={training.error} />;
+  }
+
+  const payload = training.data;
+  const isUnlocked = Boolean(adminToken);
+  const mutationError = unlock.error ?? startTraining.error;
+  const readiness = payload?.status.readiness_errors?.[workflowMode] ?? [];
+  const recentJobs = payload?.recent_jobs ?? [];
+  const activeJob = recentJobs.find((row) => row.job_id === payload?.status.active_job_id) ?? recentJobs[recentJobs.length - 1];
+  const latestSuccessfulJob = recentJobs.find((row) => row.status === "success" && row.run_id);
+  const latestSummary = parseModelJobSummary(latestSuccessfulJob);
+  const latestMetrics = (latestSummary.metrics && typeof latestSummary.metrics === "object" ? latestSummary.metrics : {}) as Record<string, unknown>;
+  const assetModelRuns = payload?.asset_model_runs ?? [];
+  const selectedSymbols = parseSymbolList(selectedSymbolsText);
+
+  const submit = () => {
+    const common = {
+      workflow_mode: workflowMode,
+      run_name: runName,
+      target_asset: targetAsset,
+      feature_version: featureVersion,
+      llm_enabled: llmEnabled,
+      train_window: trainWindow,
+      validation_window: validationWindow,
+      test_window: testWindow,
+      step_size: stepSize,
+      transaction_cost_bps: transactionCostBps,
+      ridge_alpha: ridgeAlpha,
+      threshold_grid: thresholdGrid,
+      minimum_signal_grid: minimumSignalGrid,
+      account_weight_grid: accountWeightGrid,
+      fallback_mode: fallbackMode,
+    } satisfies ModelTrainingJobRequest;
+    if (workflowMode === "saved_run_portfolio") {
+      startTraining.mutate({ ...common, component_run_ids: componentRunIds });
+      return;
+    }
+    if (workflowMode === "joint_portfolio") {
+      startTraining.mutate({
+        ...common,
+        selected_symbols: selectedSymbols,
+        topology_variants: topologyVariants,
+        model_families: modelFamilies,
+        narrative_feature_modes: llmEnabled ? narrativeFeatureModes : ["baseline"],
+      });
+      return;
+    }
+    startTraining.mutate(common);
+  };
+
+  return (
+    <section className="page-grid">
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <div>
+            <h2>Model Training Job Console</h2>
+            <p>
+              Start single-asset, saved-run portfolio, and joint portfolio model jobs from React. Jobs reuse existing
+              artifact formats and the shared scheduler/refresh lock.
+            </p>
+          </div>
+          <StatusPill label={activeJob?.status ? String(activeJob.status) : "No active job"} tone={activeJob?.status === "error" ? "severe" : activeJob?.status ? "ok" : "neutral"} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Admin unlock
+            <input
+              type="password"
+              placeholder="Admin password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          <label>
+            Session status
+            <button className="action-button" type="button" aria-label={isUnlocked ? "Refresh admin token" : "Unlock admin writes"} onClick={() => unlock.mutate()} disabled={unlock.isPending}>
+              {isUnlocked ? "Refresh admin token" : "Unlock admin writes"}
+            </button>
+          </label>
+          <label>
+            Write state
+            <span className="form-readout">{isUnlocked ? "Unlocked for this browser session" : "Read-only until unlocked"}</span>
+          </label>
+          <label>
+            Active/latest job
+            <span className="form-readout">{activeJob?.job_id ? `${activeJob.job_id} (${activeJob.status})` : "none"}</span>
+          </label>
+        </div>
+        {mutationError ? <ErrorBlock error={mutationError} /> : null}
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>Training workflow</h2>
+          <StatusPill label={modelWorkflowLabel(workflowMode)} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          {(["single_asset", "saved_run_portfolio", "joint_portfolio"] as ModelTrainingWorkflow[]).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              className="action-button"
+              aria-label={`Use ${modelWorkflowLabel(mode)} workflow`}
+              onClick={() => {
+                setWorkflowMode(mode);
+                if (mode === "single_asset") {
+                  setRunName("baseline-research-run");
+                  setFeatureVersion("v1");
+                } else if (mode === "saved_run_portfolio") {
+                  setRunName("portfolio-allocator-run");
+                } else {
+                  setRunName("joint-portfolio-run");
+                  setFeatureVersion(payload?.feature_versions[0] ?? "asset-v1");
+                }
+              }}
+            >
+              {modelWorkflowLabel(mode)}
+            </button>
+          ))}
+        </div>
+        {readiness.length ? <div className="empty-state">{readiness.join(" ")}</div> : null}
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <h2>{modelWorkflowLabel(workflowMode)} configuration</h2>
+          <StatusPill label="Admin-only write" tone={isUnlocked ? "ok" : "warn"} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Run name
+            <input value={runName} onChange={(event) => setRunName(event.target.value)} disabled={!isUnlocked} />
+          </label>
+          {workflowMode === "single_asset" ? (
+            <label>
+              Target asset
+              <select value={targetAsset} onChange={(event) => setTargetAsset(event.target.value)} disabled={!isUnlocked}>
+                {(payload?.asset_options ?? []).map((asset) => (
+                  <option key={asset.symbol} value={asset.symbol}>{asset.label}</option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          {workflowMode !== "saved_run_portfolio" ? (
+            <label>
+              Feature version
+              <select value={featureVersion} onChange={(event) => setFeatureVersion(event.target.value)} disabled={!isUnlocked}>
+                {(workflowMode === "single_asset" ? ["v1", ...(payload?.feature_versions ?? [])] : payload?.feature_versions ?? ["asset-v1"]).map((version) => (
+                  <option key={version} value={version}>{version}</option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          <label>
+            Fallback mode
+            <select value={fallbackMode} onChange={(event) => setFallbackMode(event.target.value === "FLAT" ? "FLAT" : "SPY")} disabled={!isUnlocked || workflowMode === "single_asset"}>
+              <option value="SPY">SPY</option>
+              <option value="FLAT">FLAT</option>
+            </select>
+          </label>
+          <label className="checkbox-field">
+            <input type="checkbox" checked={llmEnabled} onChange={(event) => setLlmEnabled(event.target.checked)} disabled={!isUnlocked || workflowMode === "saved_run_portfolio"} />
+            Use semantic rows
+          </label>
+        </div>
+
+        {workflowMode === "saved_run_portfolio" ? (
+          <div className="filter-grid filter-grid--compact">
+            <label className="filter-grid__wide">
+              Component runs
+              <select multiple value={componentRunIds} onChange={(event) => setComponentRunIds(selectedOptions(event.currentTarget.selectedOptions))} disabled={!isUnlocked}>
+                {assetModelRuns.map((row) => (
+                  <option key={String(row.run_id)} value={String(row.run_id)}>{modelRunLabel(row)}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+        ) : null}
+
+        {workflowMode === "joint_portfolio" ? (
+          <div className="filter-grid filter-grid--compact">
+            <label className="filter-grid__wide">
+              Selected symbols
+              <textarea value={selectedSymbolsText} onChange={(event) => setSelectedSymbolsText(event.target.value)} disabled={!isUnlocked} />
+            </label>
+            <label>
+              Topology variants
+              <select multiple value={topologyVariants} onChange={(event) => setTopologyVariants(selectedOptions(event.currentTarget.selectedOptions))} disabled={!isUnlocked}>
+                {(payload?.topology_variants ?? []).map((topology) => <option key={topology} value={topology}>{topology}</option>)}
+              </select>
+            </label>
+            <label>
+              Model families
+              <select multiple value={modelFamilies} onChange={(event) => setModelFamilies(selectedOptions(event.currentTarget.selectedOptions))} disabled={!isUnlocked}>
+                {(payload?.model_families ?? []).map((family) => <option key={family} value={family}>{family}</option>)}
+              </select>
+            </label>
+            <label>
+              Narrative modes
+              <select multiple value={narrativeFeatureModes} onChange={(event) => setNarrativeFeatureModes(selectedOptions(event.currentTarget.selectedOptions))} disabled={!isUnlocked || !llmEnabled}>
+                {(payload?.narrative_feature_modes ?? []).map((mode) => <option key={mode} value={mode}>{mode}</option>)}
+              </select>
+            </label>
+          </div>
+        ) : null}
+
+        {workflowMode !== "saved_run_portfolio" ? (
+          <div className="filter-grid filter-grid--compact">
+            <label>
+              Train window
+              <input type="number" min={20} value={trainWindow} onChange={(event) => setTrainWindow(Number(event.target.value))} disabled={!isUnlocked} />
+            </label>
+            <label>
+              Validation window
+              <input type="number" min={10} value={validationWindow} onChange={(event) => setValidationWindow(Number(event.target.value))} disabled={!isUnlocked} />
+            </label>
+            <label>
+              Test window
+              <input type="number" min={10} value={testWindow} onChange={(event) => setTestWindow(Number(event.target.value))} disabled={!isUnlocked} />
+            </label>
+            <label>
+              Step size
+              <input type="number" min={5} value={stepSize} onChange={(event) => setStepSize(Number(event.target.value))} disabled={!isUnlocked} />
+            </label>
+          </div>
+        ) : null}
+
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Transaction cost bps
+            <input type="number" min={0} step={0.5} value={transactionCostBps} onChange={(event) => setTransactionCostBps(Number(event.target.value))} disabled={!isUnlocked} />
+          </label>
+          {workflowMode === "single_asset" ? (
+            <label>
+              Ridge alpha
+              <input type="number" min={0} step={0.5} value={ridgeAlpha} onChange={(event) => setRidgeAlpha(Number(event.target.value))} disabled={!isUnlocked} />
+            </label>
+          ) : null}
+          {workflowMode !== "saved_run_portfolio" ? (
+            <>
+              <label>
+                Threshold grid
+                <input value={thresholdGrid} onChange={(event) => setThresholdGrid(event.target.value)} disabled={!isUnlocked} />
+              </label>
+              <label>
+                Min post grid
+                <input value={minimumSignalGrid} onChange={(event) => setMinimumSignalGrid(event.target.value)} disabled={!isUnlocked} />
+              </label>
+              <label>
+                Account weight grid
+                <input value={accountWeightGrid} onChange={(event) => setAccountWeightGrid(event.target.value)} disabled={!isUnlocked} />
+              </label>
+            </>
+          ) : null}
+          <label>
+            Start
+            <button className="action-button" type="button" aria-label="Start model training job" disabled={!isUnlocked || startTraining.isPending || readiness.length > 0} onClick={submit}>
+              Start model training job
+            </button>
+          </label>
+        </div>
+      </article>
+
+      {latestSuccessfulJob ? (
+        <article className="panel panel--wide">
+          <div className="panel-heading">
+            <div>
+              <h2>Latest training result</h2>
+              <p>
+                {formatValue(latestSuccessfulJob.run_name)} created {formatValue(latestSuccessfulJob.run_id)}.
+              </p>
+            </div>
+            <StatusPill label={formatValue(latestSuccessfulJob.workflow_mode)} tone="ok" />
+          </div>
+          <div className="metric-grid">
+            <MetricCard label="Run type" value={latestSuccessfulJob.run_type} />
+            <MetricCard label="Target asset" value={latestSuccessfulJob.target_asset} />
+            <MetricCard label="Total return" value={latestMetrics.total_return} />
+            <MetricCard label="Robust score" value={latestMetrics.robust_score} />
+          </div>
+          <div className="filter-grid filter-grid--compact">
+            <button className="action-button" type="button" onClick={() => onNavigate("runs")}>
+              Inspect in Run Explorer
+            </button>
+            <button
+              className="action-button"
+              type="button"
+              disabled={latestSuccessfulJob.run_type !== "portfolio_allocator"}
+              onClick={() => onNavigate("live")}
+            >
+              Configure in Live Ops
+            </button>
+          </div>
+        </article>
+      ) : null}
+
+      <article className="panel panel--wide chart-grid">
+        <div>
+          <h2>Recent model training jobs</h2>
+          <DataTable rows={recentJobs} emptyLabel="No model training jobs yet." />
+        </div>
+        <div>
+          <h2>Saved asset-model run options</h2>
+          <DataTable rows={assetModelRuns} emptyLabel="No asset-model runs are available yet." />
+        </div>
+      </article>
+    </section>
+  );
+}
+
 function DataAdminPage() {
   const queryClient = useQueryClient();
   const admin = useQuery({ queryKey: ["dataset-admin"], queryFn: api.datasetAdmin, refetchInterval: 10_000 });
@@ -1548,6 +1975,7 @@ export function App() {
       {activePage === "research" ? <ResearchPage /> : null}
       {activePage === "discovery" ? <DiscoveryPage /> : null}
       {activePage === "runs" ? <RunExplorerPage /> : null}
+      {activePage === "models" ? <ModelTrainingPage onNavigate={setActivePage} /> : null}
       {activePage === "data" ? <DataAdminPage /> : null}
       {activePage === "live" ? <LiveDecisionPage /> : null}
       {activePage === "paper" ? <PaperPerformancePage /> : null}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -66,6 +66,64 @@ export type DatasetRefreshRequest = {
   files?: FileList | File[];
 };
 
+export type ModelTrainingWorkflow = "single_asset" | "saved_run_portfolio" | "joint_portfolio";
+
+export type ModelTrainingPayload = {
+  admin: {
+    write_requires_unlock: boolean;
+  };
+  status: {
+    ready: boolean;
+    active_job_id: string;
+    readiness_errors: Record<string, string[]>;
+  };
+  defaults: {
+    single_asset: Record<string, unknown>;
+    saved_run_portfolio: Record<string, unknown>;
+    joint_portfolio: Record<string, unknown>;
+  };
+  asset_options: Array<{ symbol: string; label: string }>;
+  feature_versions: string[];
+  asset_session_symbols: string[];
+  narrative_feature_modes: string[];
+  model_families: string[];
+  topology_variants: string[];
+  run_options: RecordRow[];
+  asset_model_runs: RecordRow[];
+  recent_jobs: RecordRow[];
+  job_id?: string;
+};
+
+export type ModelTrainingJobPayload = {
+  job_id: string;
+  found: boolean;
+  job: RecordRow | null;
+  recent_jobs: RecordRow[];
+};
+
+export type ModelTrainingJobRequest = {
+  workflow_mode: ModelTrainingWorkflow;
+  run_name?: string;
+  target_asset?: string;
+  feature_version?: string;
+  llm_enabled?: boolean;
+  train_window?: number;
+  validation_window?: number;
+  test_window?: number;
+  step_size?: number;
+  transaction_cost_bps?: number;
+  ridge_alpha?: number;
+  threshold_grid?: string;
+  minimum_signal_grid?: string;
+  account_weight_grid?: string;
+  fallback_mode?: "SPY" | "FLAT";
+  component_run_ids?: string[];
+  selected_symbols?: string[];
+  topology_variants?: string[];
+  model_families?: string[];
+  narrative_feature_modes?: string[];
+};
+
 export type RunsPayload = {
   count: number;
   runs: RecordRow[];
@@ -374,6 +432,10 @@ export const api = {
     return postForm<DatasetAdminPayload>("/api/datasets/refresh", formData, token);
   },
   datasetRefreshJob: (jobId: string) => getJson<DatasetRefreshJobPayload>(`/api/datasets/jobs/${encodeURIComponent(jobId)}`),
+  modelTraining: () => getJson<ModelTrainingPayload>("/api/models/training"),
+  startModelTrainingJob: (request: ModelTrainingJobRequest, token: string) =>
+    postJson<ModelTrainingPayload>("/api/models/jobs", request, token),
+  modelTrainingJob: (jobId: string) => getJson<ModelTrainingJobPayload>(`/api/models/jobs/${encodeURIComponent(jobId)}`),
   runs: () => getJson<RunsPayload>("/api/runs"),
   runDetail: (runId: string, options: { variantName?: string; sessionDate?: string } = {}) => {
     const params = new URLSearchParams();

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -105,7 +105,7 @@ textarea {
 
 .page-tabs {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
   gap: 8px;
   margin-bottom: 24px;
   padding: 8px;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 from fastapi.testclient import TestClient
@@ -163,6 +164,37 @@ class FakeFeatureService:
         del market_calendar, tracked_accounts, llm_enabled
         return posts.assign(session_date=pd.Timestamp("2025-02-03"))
 
+    def build_session_dataset(
+        self,
+        posts: pd.DataFrame,
+        spy_market: pd.DataFrame,
+        tracked_accounts: pd.DataFrame,
+        feature_version: str,
+        llm_enabled: bool,
+        prepared_posts: pd.DataFrame | None = None,
+    ) -> pd.DataFrame:
+        del posts, spy_market, tracked_accounts, feature_version, llm_enabled, prepared_posts
+        return pd.DataFrame(
+            [
+                {
+                    "signal_session_date": pd.Timestamp("2025-02-03"),
+                    "next_session_date": pd.Timestamp("2025-02-04"),
+                    "post_count": 2,
+                    "sentiment_mean": 0.25,
+                    "target_next_session_return": 0.01,
+                    "target_available": True,
+                },
+                {
+                    "signal_session_date": pd.Timestamp("2025-02-04"),
+                    "next_session_date": pd.Timestamp("2025-02-05"),
+                    "post_count": 1,
+                    "sentiment_mean": -0.1,
+                    "target_next_session_return": -0.002,
+                    "target_available": True,
+                },
+            ],
+        )
+
     def build_asset_post_mappings(self, prepared_posts: pd.DataFrame, asset_universe: pd.DataFrame, llm_enabled: bool) -> pd.DataFrame:
         del llm_enabled
         symbols = asset_universe["symbol"].astype(str).tolist() if not asset_universe.empty else ["SPY"]
@@ -201,6 +233,185 @@ class FakeFeatureService:
                 for symbol in symbols
             ],
         )
+
+
+class FakeBacktestService:
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+
+    def run_walk_forward(self, run_config, feature_rows: pd.DataFrame) -> tuple[BacktestRun, dict[str, Any]]:
+        if self.fail:
+            raise RuntimeError("fake model training failed")
+        run = BacktestRun(
+            run_id="trained-asset-run",
+            run_name=run_config.run_name,
+            target_asset=run_config.target_asset,
+            config_hash="trained-asset-hash",
+            train_window=int(run_config.train_window),
+            validation_window=int(run_config.validation_window),
+            test_window=int(run_config.test_window),
+            metrics={"total_return": 0.04, "robust_score": 1.1, "max_drawdown": -0.01},
+            selected_params={"threshold": 0.001, "min_post_count": 1, "account_weight": 1.0},
+        )
+        predictions = feature_rows.copy()
+        predictions["expected_return_score"] = [0.01 + idx * 0.001 for idx in range(len(predictions))]
+        predictions["prediction_confidence"] = 0.7
+        predictions["suggested_stance"] = "LONG"
+        artifacts = {
+            "config": run_config.to_dict(),
+            "trades": pd.DataFrame(
+                {
+                    "signal_session_date": predictions["signal_session_date"],
+                    "next_session_date": predictions["next_session_date"],
+                    "trade_taken": True,
+                    "net_return": [0.01 for _ in range(len(predictions))],
+                    "equity_curve": [1.01 for _ in range(len(predictions))],
+                },
+            ),
+            "predictions": predictions,
+            "windows": pd.DataFrame({"window_id": [1], "train_start": [pd.Timestamp("2025-01-01")]}),
+            "importance": pd.DataFrame({"feature_name": ["post_count"], "coefficient": [0.2], "abs_coefficient": [0.2]}),
+            "model_artifact": {
+                "model_version": "fake-asset-model",
+                "feature_names": ["post_count"],
+                "intercept": 0.0,
+                "coefficients": [0.2],
+                "means": [1.0],
+                "stds": [1.0],
+                "residual_std": 0.01,
+                "train_rows": int(len(feature_rows)),
+                "metadata": {"run_type": "asset_model", "target_asset": run_config.target_asset},
+            },
+            "feature_contributions": pd.DataFrame(),
+            "benchmarks": pd.DataFrame({"benchmark_name": ["strategy"], "total_return": [0.04]}),
+            "diagnostics": pd.DataFrame({"expected_return_score": [0.01], "actual_next_session_return": [0.01]}),
+            "benchmark_curves": pd.DataFrame({"next_session_date": [pd.Timestamp("2025-02-04")], "strategy": [1.01]}),
+            "leakage_audit": {"overall_pass": True},
+        }
+        return run, artifacts
+
+    def run_saved_run_allocator(self, run_config, component_bundles: dict[str, dict[str, Any]]) -> tuple[BacktestRun, dict[str, Any]]:
+        if self.fail:
+            raise RuntimeError("fake saved-run allocation failed")
+        run = BacktestRun(
+            run_id="trained-saved-portfolio-run",
+            run_name=run_config.run_name,
+            target_asset="PORTFOLIO",
+            config_hash="trained-saved-portfolio-hash",
+            train_window=0,
+            validation_window=0,
+            test_window=0,
+            metrics={"total_return": 0.05, "robust_score": 1.2, "max_drawdown": -0.02},
+            selected_params={"fallback_mode": run_config.fallback_mode, "component_run_ids": list(component_bundles.keys())},
+            run_type="portfolio_allocator",
+            allocator_mode="saved_runs",
+            fallback_mode=run_config.fallback_mode,
+            component_run_ids=list(component_bundles.keys()),
+            universe_symbols=list(run_config.universe_symbols),
+        )
+        artifacts = self._portfolio_artifacts(run_config, variant_name="")
+        artifacts["config"] = run_config.to_dict()
+        return run, artifacts
+
+    def run_joint_model_allocator(self, run_config, feature_rows: pd.DataFrame) -> tuple[BacktestRun, dict[str, Any]]:
+        if self.fail:
+            raise RuntimeError("fake joint model training failed")
+        del feature_rows
+        run = BacktestRun(
+            run_id="trained-joint-portfolio-run",
+            run_name=run_config.run_name,
+            target_asset="PORTFOLIO",
+            config_hash="trained-joint-portfolio-hash",
+            train_window=int(run_config.train_window),
+            validation_window=int(run_config.validation_window),
+            test_window=int(run_config.test_window),
+            metrics={"total_return": 0.07, "robust_score": 1.4, "max_drawdown": -0.015},
+            selected_params={
+                "fallback_mode": run_config.fallback_mode,
+                "selected_symbols": list(run_config.selected_symbols),
+                "deployment_variant": "per_asset_baseline",
+            },
+            run_type="portfolio_allocator",
+            allocator_mode="joint_model",
+            fallback_mode=run_config.fallback_mode,
+            deployment_variant="per_asset_baseline",
+            selected_symbols=list(run_config.selected_symbols),
+            topology_variants=list(run_config.topology_variants),
+            model_families=list(run_config.model_families),
+            narrative_feature_modes=list(run_config.narrative_feature_modes),
+        )
+        artifacts = self._portfolio_artifacts(run_config, variant_name="per_asset_baseline")
+        artifacts["config"] = run_config.to_dict()
+        artifacts["variant_summary"] = pd.DataFrame(
+            {
+                "variant_name": ["per_asset_baseline"],
+                "topology": ["per_asset"],
+                "narrative_feature_mode": ["baseline"],
+                "model_family": ["ridge"],
+                "validation_robust_score": [1.4],
+                "test_total_return": [0.07],
+                "deployment_winner": [True],
+            },
+        )
+        artifacts["portfolio_model_bundle"] = {
+            "deployment_variant": "per_asset_baseline",
+            "selected_symbols": list(run_config.selected_symbols),
+            "variants": {"per_asset_baseline": {"variant_name": "per_asset_baseline", "model_family": "ridge"}},
+        }
+        artifacts["importance"] = pd.DataFrame({"variant_name": ["per_asset_baseline"], "feature_name": ["post_count"], "importance": [1.0]})
+        return run, artifacts
+
+    def _portfolio_artifacts(self, run_config, variant_name: str) -> dict[str, Any]:
+        variant_values = [variant_name, variant_name] if variant_name else ["", ""]
+        return {
+            "trades": pd.DataFrame(
+                {
+                    "variant_name": variant_values,
+                    "signal_session_date": [pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-04")],
+                    "next_session_date": [pd.Timestamp("2025-02-04"), pd.Timestamp("2025-02-05")],
+                    "selected_asset": ["SPY", "SPY"],
+                    "trade_taken": [True, True],
+                    "net_return": [0.01, 0.002],
+                    "equity_curve": [1.01, 1.01202],
+                },
+            ),
+            "predictions": pd.DataFrame(
+                {
+                    "variant_name": variant_values,
+                    "signal_session_date": [pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-04")],
+                    "next_session_date": [pd.Timestamp("2025-02-04"), pd.Timestamp("2025-02-05")],
+                    "winning_asset": ["SPY", "SPY"],
+                    "decision_source": ["eligible", "eligible"],
+                    "fallback_mode": [run_config.fallback_mode, run_config.fallback_mode],
+                    "stance": ["LONG SPY NEXT SESSION", "LONG SPY NEXT SESSION"],
+                    "eligible_asset_count": [1, 1],
+                    "winner_score": [0.01, 0.008],
+                    "runner_up_asset": ["", ""],
+                    "runner_up_score": [0.0, 0.0],
+                },
+            ),
+            "candidate_predictions": pd.DataFrame(
+                {
+                    "variant_name": variant_values,
+                    "signal_session_date": [pd.Timestamp("2025-02-03"), pd.Timestamp("2025-02-04")],
+                    "next_session_date": [pd.Timestamp("2025-02-04"), pd.Timestamp("2025-02-05")],
+                    "asset_symbol": ["SPY", "SPY"],
+                    "expected_return_score": [0.01, 0.008],
+                    "confidence": [0.7, 0.6],
+                    "threshold": [0.001, 0.001],
+                    "min_post_count": [1, 1],
+                    "post_count": [2, 1],
+                    "tradeable": [True, True],
+                    "qualifies": [True, True],
+                },
+            ),
+            "windows": pd.DataFrame({"component_run_id": list(getattr(run_config, "component_run_ids", [])) or ["joint"]}),
+            "importance": pd.DataFrame(),
+            "benchmarks": pd.DataFrame({"variant_name": [variant_name], "benchmark_name": ["strategy"], "total_return": [0.05]}),
+            "diagnostics": pd.DataFrame({"variant_name": [variant_name], "winner_score": [0.01]}),
+            "benchmark_curves": pd.DataFrame({"variant_name": [variant_name], "next_session_date": [pd.Timestamp("2025-02-04")], "strategy": [1.01]}),
+            "leakage_audit": {"overall_pass": True},
+        }
 
 
 class ApiContractTests(unittest.TestCase):
@@ -290,6 +501,16 @@ class ApiContractTests(unittest.TestCase):
                     {"trade_date": pd.Timestamp("2025-02-03"), "close": 100.0},
                     {"trade_date": pd.Timestamp("2025-02-04"), "close": 101.0},
                     {"trade_date": pd.Timestamp("2025-02-05"), "close": 99.0},
+                ],
+            ),
+        )
+        self.store.save_frame(
+            "spy_daily",
+            pd.DataFrame(
+                [
+                    {"trade_date": pd.Timestamp("2025-02-03"), "open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 1000},
+                    {"trade_date": pd.Timestamp("2025-02-04"), "open": 100.5, "high": 102.0, "low": 100.0, "close": 101.0, "volume": 1100},
+                    {"trade_date": pd.Timestamp("2025-02-05"), "open": 101.0, "high": 102.0, "low": 100.0, "close": 100.0, "volume": 1200},
                 ],
             ),
         )
@@ -1224,6 +1445,198 @@ class ApiContractTests(unittest.TestCase):
         self.assertEqual(str(refresh_history.iloc[-1]["status"]), "error")
         latest = self.store.read_frame("data_health_latest")
         self.assertEqual(str(latest.iloc[0]["check_name"]), "prior_check")
+
+    def test_model_training_payload_and_post_requires_admin(self) -> None:
+        response = self.client.get("/api/models/training")
+        rejected = self.client.post(
+            "/api/models/jobs",
+            json={"workflow_mode": "single_asset", "run_name": "Unauthorized"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn("asset_options", payload)
+        self.assertIn("recent_jobs", payload)
+        self.assertGreaterEqual(len(payload["status"]["readiness_errors"]), 1)
+        self.assertEqual(rejected.status_code, 401)
+
+    def test_single_asset_model_training_job_persists_run_and_job(self) -> None:
+        self._save_research_frames(include_x=False)
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                feature_service=FakeFeatureService(),
+                backtest_service=FakeBacktestService(),
+                run_model_training_jobs_inline=True,
+            ),
+        )
+        token = self._admin_token(client)
+
+        response = client.post(
+            "/api/models/jobs",
+            json={
+                "workflow_mode": "single_asset",
+                "run_name": "SPY Console Test",
+                "target_asset": "SPY",
+                "feature_version": "feature-v1",
+                "threshold_grid": [0.001],
+                "minimum_signal_grid": [1],
+                "account_weight_grid": [1.0],
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        jobs = self.store.read_frame("model_training_jobs")
+        self.assertFalse(jobs.empty)
+        self.assertEqual(str(jobs.iloc[-1]["status"]), "success")
+        self.assertEqual(str(jobs.iloc[-1]["workflow_mode"]), "single_asset")
+        self.assertEqual(str(jobs.iloc[-1]["run_id"]), "trained-asset-run")
+        self.assertEqual(str(jobs.iloc[-1]["target_asset"]), "SPY")
+        self.assertFalse(self.store.read_frame("session_features_latest").empty)
+        self.assertIsNotNone(self.experiments.load_run("trained-asset-run"))
+
+    def test_saved_run_portfolio_training_job_persists_allocator_run(self) -> None:
+        self._save_asset_run_artifacts()
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                backtest_service=FakeBacktestService(),
+                run_model_training_jobs_inline=True,
+            ),
+        )
+        token = self._admin_token(client)
+
+        response = client.post(
+            "/api/models/jobs",
+            json={
+                "workflow_mode": "saved_run_portfolio",
+                "run_name": "Saved Portfolio Console Test",
+                "component_run_ids": ["asset-run-1"],
+                "fallback_mode": "SPY",
+                "transaction_cost_bps": 2.0,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        jobs = self.store.read_frame("model_training_jobs")
+        self.assertEqual(str(jobs.iloc[-1]["status"]), "success")
+        self.assertEqual(str(jobs.iloc[-1]["workflow_mode"]), "saved_run_portfolio")
+        self.assertEqual(str(jobs.iloc[-1]["run_id"]), "trained-saved-portfolio-run")
+        saved_run = self.experiments.load_run("trained-saved-portfolio-run")
+        self.assertIsNotNone(saved_run)
+        self.assertEqual(saved_run["run"]["allocator_mode"], "saved_runs")
+
+    def test_joint_portfolio_training_job_persists_variant_metadata(self) -> None:
+        self.store.save_frame(
+            "asset_session_features",
+            pd.DataFrame(
+                [
+                    {
+                        "asset_symbol": "SPY",
+                        "signal_session_date": pd.Timestamp("2025-02-03"),
+                        "next_session_date": pd.Timestamp("2025-02-04"),
+                        "post_count": 2,
+                        "target_available": True,
+                        "target_next_session_return": 0.01,
+                    },
+                    {
+                        "asset_symbol": "QQQ",
+                        "signal_session_date": pd.Timestamp("2025-02-03"),
+                        "next_session_date": pd.Timestamp("2025-02-04"),
+                        "post_count": 1,
+                        "target_available": True,
+                        "target_next_session_return": 0.02,
+                    },
+                ],
+            ),
+        )
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                backtest_service=FakeBacktestService(),
+                run_model_training_jobs_inline=True,
+            ),
+        )
+        token = self._admin_token(client)
+
+        response = client.post(
+            "/api/models/jobs",
+            json={
+                "workflow_mode": "joint_portfolio",
+                "run_name": "Joint Console Test",
+                "selected_symbols": ["SPY", "QQQ"],
+                "feature_version": "asset-v1",
+                "fallback_mode": "SPY",
+                "topology_variants": ["per_asset"],
+                "model_families": ["ridge"],
+                "narrative_feature_modes": ["baseline"],
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        jobs = self.store.read_frame("model_training_jobs")
+        self.assertEqual(str(jobs.iloc[-1]["status"]), "success")
+        self.assertEqual(str(jobs.iloc[-1]["workflow_mode"]), "joint_portfolio")
+        self.assertEqual(str(jobs.iloc[-1]["run_id"]), "trained-joint-portfolio-run")
+        self.assertIn("QQQ", str(jobs.iloc[-1]["selected_symbols"]))
+        saved_run = self.experiments.load_run("trained-joint-portfolio-run")
+        self.assertIsNotNone(saved_run)
+        self.assertEqual(saved_run["run"]["deployment_variant"], "per_asset_baseline")
+        self.assertFalse(saved_run["variant_summary"].empty)
+
+    def test_model_training_rejects_overlapping_lock(self) -> None:
+        token = self._admin_token()
+        lock_fd = acquire_refresh_lock(self.settings)
+        self.assertIsNotNone(lock_fd)
+        try:
+            response = self.client.post(
+                "/api/models/jobs",
+                json={"workflow_mode": "single_asset", "run_name": "Blocked"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        finally:
+            release_refresh_lock(self.settings, lock_fd)
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("already running", str(response.json()["detail"]))
+
+    def test_model_training_failed_job_persists_error_status(self) -> None:
+        self._save_research_frames(include_x=False)
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                feature_service=FakeFeatureService(),
+                backtest_service=FakeBacktestService(fail=True),
+                run_model_training_jobs_inline=True,
+            ),
+        )
+        token = self._admin_token(client)
+
+        response = client.post(
+            "/api/models/jobs",
+            json={
+                "workflow_mode": "single_asset",
+                "run_name": "Failing Console Test",
+                "target_asset": "SPY",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        job_id = response.json()["job_id"]
+        status = client.get(f"/api/models/jobs/{job_id}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(status.status_code, 200)
+        self.assertEqual(status.json()["job"]["status"], "error")
+        self.assertIn("fake model training failed", status.json()["job"]["error_message"])
+        jobs = self.store.read_frame("model_training_jobs")
+        self.assertEqual(str(jobs.iloc[-1]["status"]), "error")
 
     def test_runs_and_live_current_handle_empty_live_config(self) -> None:
         self._save_run_record()

--- a/trump_workbench/api.py
+++ b/trump_workbench/api.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from .access import verify_admin_password
+from .backtesting import BacktestService
 from .config import AppSettings
 from .dataset_admin import (
     UploadedCsv,
@@ -35,6 +36,12 @@ from .live_ops import (
 )
 from .market import MarketDataService
 from .modeling import ModelService
+from .model_training import (
+    ModelTrainingRequest,
+    build_model_training_payload,
+    ensure_model_training_jobs_frame,
+    submit_model_training_job,
+)
 from .paper_trading import (
     PaperTradingService,
     ensure_paper_benchmark_curve_frame,
@@ -80,6 +87,53 @@ class WatchlistSaveRequest(BaseModel):
     reset: bool = False
 
 
+class ModelTrainingJobRequest(BaseModel):
+    workflow_mode: str
+    run_name: str = ""
+    target_asset: str = "SPY"
+    feature_version: str = ""
+    llm_enabled: bool = False
+    train_window: int = 90
+    validation_window: int = 30
+    test_window: int = 30
+    step_size: int = 30
+    transaction_cost_bps: float = 2.0
+    ridge_alpha: float = 1.0
+    threshold_grid: str | list[float] = "0,0.001,0.0025,0.005"
+    minimum_signal_grid: str | list[int] = "1,2,3"
+    account_weight_grid: str | list[float] = "0.5,1.0,1.5"
+    fallback_mode: str = "SPY"
+    component_run_ids: list[str] = []
+    selected_symbols: list[str] = []
+    topology_variants: list[str] = []
+    model_families: list[str] = []
+    narrative_feature_modes: list[str] = []
+
+    def to_training_request(self) -> ModelTrainingRequest:
+        return ModelTrainingRequest(
+            workflow_mode=self.workflow_mode,
+            run_name=self.run_name,
+            target_asset=self.target_asset,
+            feature_version=self.feature_version,
+            llm_enabled=self.llm_enabled,
+            train_window=self.train_window,
+            validation_window=self.validation_window,
+            test_window=self.test_window,
+            step_size=self.step_size,
+            transaction_cost_bps=self.transaction_cost_bps,
+            ridge_alpha=self.ridge_alpha,
+            threshold_grid=self.threshold_grid,
+            minimum_signal_grid=self.minimum_signal_grid,
+            account_weight_grid=self.account_weight_grid,
+            fallback_mode=self.fallback_mode,
+            component_run_ids=tuple(self.component_run_ids),
+            selected_symbols=tuple(self.selected_symbols),
+            topology_variants=tuple(self.topology_variants),
+            model_families=tuple(self.model_families),
+            narrative_feature_modes=tuple(self.narrative_feature_modes),
+        )
+
+
 def _json_safe(value: Any) -> Any:
     if isinstance(value, pd.Timestamp):
         return None if pd.isna(value) else value.isoformat()
@@ -114,7 +168,9 @@ def create_app(
     discovery_service: DiscoveryService | None = None,
     feature_service: FeatureService | None = None,
     health_service: DataHealthService | None = None,
+    backtest_service: BacktestService | None = None,
     run_refresh_jobs_inline: bool = False,
+    run_model_training_jobs_inline: bool = False,
 ) -> FastAPI:
     settings = settings or AppSettings()
     store = store or DuckDBStore(settings)
@@ -126,6 +182,7 @@ def create_app(
     ingestion_service = ingestion_service or IngestionService()
     market_service = market_service or MarketDataService()
     feature_service = feature_service or FeatureService(enrichment_service)
+    backtest_service = backtest_service or BacktestService(model_service)
     paper_service = PaperTradingService(store)
     performance_service = PerformanceObservatoryService(store)
 
@@ -138,6 +195,7 @@ def create_app(
     app.state.store = store
     app.state.admin_tokens = {}
     app.state.run_refresh_jobs_inline = bool(run_refresh_jobs_inline)
+    app.state.run_model_training_jobs_inline = bool(run_model_training_jobs_inline)
 
     if settings.api_cors_origins:
         app.add_middleware(
@@ -373,6 +431,52 @@ def create_app(
     @app.get("/api/datasets/jobs/{job_id}")
     def dataset_refresh_job(job_id: str) -> dict[str, Any]:
         jobs = ensure_refresh_jobs_frame(store.read_frame("dataset_refresh_jobs"))
+        current = jobs.loc[jobs["job_id"].astype(str) == str(job_id)].copy()
+        return _json_safe(
+            {
+                "job_id": job_id,
+                "found": not current.empty,
+                "job": _frame_records(current.tail(1))[0] if not current.empty else None,
+                "recent_jobs": _frame_records(jobs.tail(10)),
+            },
+        )
+
+    @app.get("/api/models/training")
+    def model_training() -> dict[str, Any]:
+        return _json_safe(
+            build_model_training_payload(
+                store=store,
+                experiment_store=experiment_store,
+            ),
+        )
+
+    @app.post("/api/models/jobs")
+    def start_model_training_job(
+        request: ModelTrainingJobRequest,
+        _admin: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        job_id, errors = submit_model_training_job(
+            store=store,
+            experiment_store=experiment_store,
+            feature_service=feature_service,
+            backtest_service=backtest_service,
+            request=request.to_training_request(),
+            run_inline=bool(app.state.run_model_training_jobs_inline),
+        )
+        if errors:
+            status_code = 409 if any("already running" in error for error in errors) else 400
+            raise HTTPException(status_code=status_code, detail=errors)
+        payload = build_model_training_payload(
+            store=store,
+            experiment_store=experiment_store,
+            active_job_id=job_id,
+        )
+        payload["job_id"] = job_id
+        return _json_safe(payload)
+
+    @app.get("/api/models/jobs/{job_id}")
+    def model_training_job(job_id: str) -> dict[str, Any]:
+        jobs = ensure_model_training_jobs_frame(store.read_frame("model_training_jobs"))
         current = jobs.loc[jobs["job_id"].astype(str) == str(job_id)].copy()
         return _json_safe(
             {

--- a/trump_workbench/explanations.py
+++ b/trump_workbench/explanations.py
@@ -43,19 +43,25 @@ ACCOUNT_ATTRIBUTION_COLUMNS = [
 ]
 
 
+def _series_or_default(frame: pd.DataFrame, column: str, default: object) -> pd.Series:
+    if column in frame.columns:
+        return frame[column]
+    return pd.Series([default] * len(frame), index=frame.index)
+
+
 def build_post_attribution(mapped_posts: pd.DataFrame) -> pd.DataFrame:
     if mapped_posts.empty:
         return pd.DataFrame(columns=POST_ATTRIBUTION_COLUMNS)
 
     posts = mapped_posts.copy()
     posts["signal_session_date"] = pd.to_datetime(posts["session_date"], errors="coerce")
-    posts["engagement_score"] = pd.to_numeric(posts.get("engagement_score", 0.0), errors="coerce").fillna(0.0)
-    posts["sentiment_score"] = pd.to_numeric(posts.get("sentiment_score", 0.0), errors="coerce").fillna(0.0)
-    posts["tracked_discovery_score"] = pd.to_numeric(posts.get("tracked_discovery_score", 0.0), errors="coerce").fillna(0.0)
-    posts["is_active_tracked_account"] = posts.get("is_active_tracked_account", False).fillna(False).astype(bool)
-    posts["author_is_trump"] = posts.get("author_is_trump", False).fillna(False).astype(bool)
-    posts["mentions_trump"] = posts.get("mentions_trump", False).fillna(False).astype(bool)
-    posts["tracked_account_status"] = posts.get("tracked_account_status", "none").fillna("none")
+    posts["engagement_score"] = pd.to_numeric(_series_or_default(posts, "engagement_score", 0.0), errors="coerce").fillna(0.0)
+    posts["sentiment_score"] = pd.to_numeric(_series_or_default(posts, "sentiment_score", 0.0), errors="coerce").fillna(0.0)
+    posts["tracked_discovery_score"] = pd.to_numeric(_series_or_default(posts, "tracked_discovery_score", 0.0), errors="coerce").fillna(0.0)
+    posts["is_active_tracked_account"] = _series_or_default(posts, "is_active_tracked_account", False).fillna(False).astype(bool)
+    posts["author_is_trump"] = _series_or_default(posts, "author_is_trump", False).fillna(False).astype(bool)
+    posts["mentions_trump"] = _series_or_default(posts, "mentions_trump", False).fillna(False).astype(bool)
+    posts["tracked_account_status"] = _series_or_default(posts, "tracked_account_status", "none").fillna("none")
 
     posts["author_weight"] = (
         1.0
@@ -106,4 +112,3 @@ def build_account_attribution(post_attribution: pd.DataFrame) -> pd.DataFrame:
         ["signal_session_date", "abs_net_post_signal", "post_count"],
         ascending=[True, False, False],
     ).reset_index(drop=True)
-

--- a/trump_workbench/model_training.py
+++ b/trump_workbench/model_training.py
@@ -1,0 +1,675 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import threading
+import uuid
+from typing import Any
+
+import pandas as pd
+
+from .backtesting import BacktestService
+from .contracts import ModelRunConfig, PortfolioRunConfig
+from .experiments import ExperimentStore
+from .explanations import build_account_attribution, build_post_attribution
+from .features import FeatureService
+from .market import normalize_symbols
+from .modeling import NARRATIVE_FEATURE_MODES, SUPPORTED_PORTFOLIO_MODEL_FAMILIES
+from .scheduler import acquire_refresh_lock, release_refresh_lock
+from .storage import DuckDBStore
+
+MODEL_TRAINING_JOB_COLUMNS = [
+    "job_id",
+    "workflow_mode",
+    "status",
+    "started_at",
+    "completed_at",
+    "error_message",
+    "run_id",
+    "run_name",
+    "run_type",
+    "allocator_mode",
+    "target_asset",
+    "selected_symbols",
+    "summary",
+]
+
+VALID_MODEL_WORKFLOWS = {"single_asset", "saved_run_portfolio", "joint_portfolio"}
+
+
+@dataclass(frozen=True)
+class ModelTrainingRequest:
+    workflow_mode: str
+    run_name: str = ""
+    target_asset: str = "SPY"
+    feature_version: str = ""
+    llm_enabled: bool = False
+    train_window: int = 90
+    validation_window: int = 30
+    test_window: int = 30
+    step_size: int = 30
+    transaction_cost_bps: float = 2.0
+    ridge_alpha: float = 1.0
+    threshold_grid: str | list[float] = "0,0.001,0.0025,0.005"
+    minimum_signal_grid: str | list[int] = "1,2,3"
+    account_weight_grid: str | list[float] = "0.5,1.0,1.5"
+    fallback_mode: str = "SPY"
+    component_run_ids: tuple[str, ...] = ()
+    selected_symbols: tuple[str, ...] = ()
+    topology_variants: tuple[str, ...] = ()
+    model_families: tuple[str, ...] = ()
+    narrative_feature_modes: tuple[str, ...] = ()
+
+
+def ensure_model_training_jobs_frame(frame: pd.DataFrame | None) -> pd.DataFrame:
+    if frame is None or frame.empty:
+        return pd.DataFrame(columns=MODEL_TRAINING_JOB_COLUMNS)
+    out = frame.copy()
+    for column in MODEL_TRAINING_JOB_COLUMNS:
+        if column not in out.columns:
+            out[column] = pd.NA
+    out["started_at"] = pd.to_datetime(out["started_at"], errors="coerce", utc=True)
+    out["completed_at"] = pd.to_datetime(out["completed_at"], errors="coerce", utc=True)
+    for column in ["job_id", "workflow_mode", "status", "error_message", "run_id", "run_name", "run_type", "allocator_mode", "target_asset", "selected_symbols", "summary"]:
+        out[column] = out[column].fillna("").astype(str)
+    return out[MODEL_TRAINING_JOB_COLUMNS].copy()
+
+
+def _frame_records(frame: pd.DataFrame, limit: int | None = None) -> list[dict[str, Any]]:
+    if frame.empty:
+        return []
+    out = frame.copy()
+    if limit is not None:
+        out = out.tail(max(0, int(limit)))
+    return out.to_dict(orient="records")
+
+
+def _json_summary(payload: dict[str, Any] | None = None) -> str:
+    return json.dumps(payload or {}, default=str, sort_keys=True)
+
+
+def _parse_grid(value: str | list[Any] | tuple[Any, ...], cast: type[float] | type[int]) -> tuple[Any, ...]:
+    if isinstance(value, (list, tuple)):
+        parts = [item for item in value if item is not None and str(item).strip() != ""]
+    else:
+        parts = [part.strip() for part in str(value or "").split(",") if part.strip()]
+    if not parts:
+        raise ValueError("Grid values cannot be empty.")
+    if cast is int:
+        return tuple(int(part) for part in parts)
+    return tuple(float(part) for part in parts)
+
+
+def _job_row(
+    *,
+    job_id: str,
+    workflow_mode: str,
+    status: str,
+    started_at: pd.Timestamp,
+    completed_at: pd.Timestamp | pd.NaT = pd.NaT,
+    error_message: str = "",
+    run_id: str = "",
+    run_name: str = "",
+    run_type: str = "",
+    allocator_mode: str = "",
+    target_asset: str = "",
+    selected_symbols: list[str] | tuple[str, ...] | str = "",
+    summary: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    symbols = selected_symbols if isinstance(selected_symbols, str) else ",".join(str(symbol).upper() for symbol in selected_symbols)
+    return pd.DataFrame(
+        [
+            {
+                "job_id": str(job_id),
+                "workflow_mode": str(workflow_mode),
+                "status": str(status),
+                "started_at": pd.Timestamp(started_at),
+                "completed_at": completed_at,
+                "error_message": str(error_message or ""),
+                "run_id": str(run_id or ""),
+                "run_name": str(run_name or ""),
+                "run_type": str(run_type or ""),
+                "allocator_mode": str(allocator_mode or ""),
+                "target_asset": str(target_asset or ""),
+                "selected_symbols": symbols,
+                "summary": _json_summary(summary),
+            },
+        ],
+        columns=MODEL_TRAINING_JOB_COLUMNS,
+    )
+
+
+def save_model_training_job(store: DuckDBStore, row: pd.DataFrame) -> pd.DataFrame:
+    current = ensure_model_training_jobs_frame(store.read_frame("model_training_jobs"))
+    combined = pd.concat([current, ensure_model_training_jobs_frame(row)], ignore_index=True)
+    combined = combined.drop_duplicates(subset=["job_id"], keep="last").reset_index(drop=True)
+    store.save_frame(
+        "model_training_jobs",
+        combined,
+        metadata={
+            "row_count": int(len(combined)),
+            "latest_status": str(combined.iloc[-1]["status"]) if not combined.empty else "",
+        },
+    )
+    return combined
+
+
+def _target_asset_options(store: DuckDBStore) -> list[dict[str, str]]:
+    asset_universe = store.read_frame("asset_universe")
+    if asset_universe.empty or "symbol" not in asset_universe.columns:
+        return [{"symbol": "SPY", "label": "SPY"}]
+    symbols = normalize_symbols(asset_universe["symbol"].astype(str).tolist())
+    ordered = ["SPY", *[symbol for symbol in symbols if symbol != "SPY"]]
+    rows: list[dict[str, str]] = []
+    for symbol in ordered:
+        match = asset_universe.loc[asset_universe["symbol"].astype(str).str.upper() == symbol]
+        display_name = str(match.iloc[0].get("display_name", symbol) or symbol) if not match.empty else symbol
+        rows.append({"symbol": symbol, "label": f"{symbol} - {display_name}" if display_name != symbol else symbol})
+    return rows
+
+
+def _normalize_runs_frame(runs: pd.DataFrame) -> pd.DataFrame:
+    normalized = runs.copy()
+    if normalized.empty:
+        return normalized
+    if "target_asset" not in normalized.columns:
+        normalized["target_asset"] = "SPY"
+    normalized["target_asset"] = normalized["target_asset"].fillna("SPY").replace("", "SPY").astype(str).str.upper()
+    if "run_type" not in normalized.columns:
+        normalized["run_type"] = "asset_model"
+    normalized["run_type"] = normalized["run_type"].fillna("asset_model").replace("", "asset_model").astype(str)
+    if "allocator_mode" not in normalized.columns:
+        normalized["allocator_mode"] = ""
+    normalized["allocator_mode"] = normalized["allocator_mode"].fillna("").astype(str)
+    return normalized
+
+
+def _run_options(runs: pd.DataFrame) -> list[dict[str, Any]]:
+    normalized = _normalize_runs_frame(runs)
+    if normalized.empty:
+        return []
+    rows: list[dict[str, Any]] = []
+    for _, row in normalized.iterrows():
+        metrics = row.get("metrics_json") or {}
+        selected = row.get("selected_params_json") or {}
+        rows.append(
+            {
+                "run_id": str(row.get("run_id", "") or ""),
+                "run_name": str(row.get("run_name", "") or ""),
+                "target_asset": str(row.get("target_asset", "SPY") or "SPY").upper(),
+                "run_type": str(row.get("run_type", "asset_model") or "asset_model"),
+                "allocator_mode": str(row.get("allocator_mode", "") or ""),
+                "created_at": row.get("created_at"),
+                "robust_score": float(metrics.get("robust_score", 0.0) or 0.0),
+                "total_return": float(metrics.get("total_return", 0.0) or 0.0),
+                "deployment_variant": str(selected.get("deployment_variant", "") or ""),
+            },
+        )
+    return rows
+
+
+def build_model_training_payload(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    active_job_id: str = "",
+) -> dict[str, Any]:
+    posts = store.read_frame("normalized_posts")
+    spy = store.read_frame("spy_daily")
+    asset_session_features = store.read_frame("asset_session_features")
+    runs = _normalize_runs_frame(experiment_store.list_runs())
+    jobs = ensure_model_training_jobs_frame(store.read_frame("model_training_jobs"))
+
+    feature_versions = ["asset-v1"]
+    available_symbols: list[str] = []
+    if not asset_session_features.empty:
+        if "feature_version" in asset_session_features.columns:
+            feature_versions = sorted(asset_session_features["feature_version"].dropna().astype(str).unique().tolist()) or feature_versions
+        if "asset_symbol" in asset_session_features.columns:
+            available_symbols = sorted(asset_session_features["asset_symbol"].dropna().astype(str).str.upper().unique().tolist())
+            if "SPY" in available_symbols:
+                available_symbols = ["SPY", *[symbol for symbol in available_symbols if symbol != "SPY"]]
+
+    run_options = _run_options(runs)
+    asset_model_runs = [row for row in run_options if row["run_type"] == "asset_model"]
+    spy_runs = [row for row in asset_model_runs if row["target_asset"] == "SPY"]
+    readiness = {
+        "single_asset": [] if not posts.empty and not spy.empty else ["Refresh datasets first so normalized posts and SPY market data are available."],
+        "saved_run_portfolio": [] if spy_runs else ["Save at least one SPY asset-model run before building a saved-run portfolio allocator."],
+        "joint_portfolio": [] if not asset_session_features.empty else ["Refresh datasets first so asset-session features are available."],
+    }
+    latest_active = jobs.loc[jobs["status"].isin(["queued", "running"])].tail(1)
+    return {
+        "admin": {
+            "write_requires_unlock": True,
+        },
+        "status": {
+            "ready": not any(readiness.values()),
+            "active_job_id": str(active_job_id or (latest_active.iloc[0]["job_id"] if not latest_active.empty else "")),
+            "readiness_errors": readiness,
+        },
+        "defaults": {
+            "single_asset": {
+                "run_name": "baseline-research-run",
+                "target_asset": "SPY",
+                "feature_version": "v1",
+                "threshold_grid": "0,0.001,0.0025,0.005",
+                "minimum_signal_grid": "1,2,3",
+                "account_weight_grid": "0.5,1.0,1.5",
+            },
+            "saved_run_portfolio": {"run_name": "portfolio-allocator-run", "fallback_mode": "SPY"},
+            "joint_portfolio": {
+                "run_name": "joint-portfolio-run",
+                "fallback_mode": "SPY",
+                "feature_version": feature_versions[0],
+                "selected_symbols": [symbol for symbol in ["SPY", "QQQ", "NVDA"] if symbol in available_symbols] or available_symbols[:3],
+                "topology_variants": ["per_asset", "pooled"],
+                "model_families": ["ridge", "elastic_net", "hist_gradient_boosting_regressor"],
+                "narrative_feature_modes": ["baseline"],
+            },
+        },
+        "asset_options": _target_asset_options(store),
+        "feature_versions": feature_versions,
+        "asset_session_symbols": available_symbols,
+        "narrative_feature_modes": list(NARRATIVE_FEATURE_MODES),
+        "model_families": list(SUPPORTED_PORTFOLIO_MODEL_FAMILIES),
+        "topology_variants": ["per_asset", "pooled"],
+        "run_options": run_options,
+        "asset_model_runs": asset_model_runs,
+        "recent_jobs": _frame_records(jobs, limit=50),
+    }
+
+
+def build_model_target_bundle(
+    *,
+    store: DuckDBStore,
+    feature_service: FeatureService,
+    posts: pd.DataFrame,
+    spy_market: pd.DataFrame,
+    tracked_accounts: pd.DataFrame,
+    llm_enabled: bool,
+    target_asset: str,
+    feature_version: str | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    normalized_target = str(target_asset).upper()
+    resolved_feature_version = feature_version or ("v1" if normalized_target == "SPY" else "asset-v1")
+    asset_universe = store.read_frame("asset_universe")
+    asset_daily = store.read_frame("asset_daily")
+    prepared_posts = feature_service.prepare_session_posts(
+        posts=posts,
+        market_calendar=spy_market,
+        tracked_accounts=tracked_accounts,
+        llm_enabled=llm_enabled,
+    )
+
+    if normalized_target == "SPY":
+        feature_rows = feature_service.build_session_dataset(
+            posts=posts,
+            spy_market=spy_market,
+            tracked_accounts=tracked_accounts,
+            feature_version=resolved_feature_version,
+            llm_enabled=llm_enabled,
+            prepared_posts=prepared_posts,
+        )
+        feature_rows["target_asset"] = "SPY"
+        feature_rows["target_asset_display_name"] = "SPDR S&P 500 ETF Trust"
+        return feature_rows.reset_index(drop=True), prepared_posts.reset_index(drop=True)
+
+    if asset_universe.empty or asset_daily.empty:
+        raise RuntimeError("Refresh datasets first so non-SPY target assets have market and universe data available.")
+
+    asset_post_mappings = feature_service.build_asset_post_mappings(
+        prepared_posts=prepared_posts,
+        asset_universe=asset_universe,
+        llm_enabled=llm_enabled,
+    )
+    asset_feature_rows = feature_service.build_asset_session_dataset(
+        asset_post_mappings=asset_post_mappings,
+        asset_market=asset_daily,
+        feature_version=resolved_feature_version,
+        llm_enabled=llm_enabled,
+        asset_universe=asset_universe,
+    )
+    feature_rows = asset_feature_rows.loc[
+        asset_feature_rows["asset_symbol"].astype(str).str.upper() == normalized_target
+    ].copy()
+    if feature_rows.empty:
+        raise RuntimeError(f"No session feature rows were available for target asset `{normalized_target}`.")
+    asset_rows = asset_universe.loc[asset_universe["symbol"].astype(str).str.upper() == normalized_target]
+    display_name = str(asset_rows.iloc[0].get("display_name", normalized_target)) if not asset_rows.empty else normalized_target
+    feature_rows["target_asset"] = normalized_target
+    feature_rows["target_asset_display_name"] = display_name
+    attribution_posts = asset_post_mappings.loc[
+        asset_post_mappings["asset_symbol"].astype(str).str.upper() == normalized_target
+    ].copy()
+    attribution_posts["target_asset"] = normalized_target
+    return feature_rows.reset_index(drop=True), attribution_posts.reset_index(drop=True)
+
+
+def _save_single_asset_run(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    feature_service: FeatureService,
+    backtest_service: BacktestService,
+    request: ModelTrainingRequest,
+) -> tuple[str, dict[str, Any]]:
+    posts = store.read_frame("normalized_posts")
+    spy = store.read_frame("spy_daily")
+    tracked_accounts = store.read_frame("tracked_accounts")
+    if posts.empty or spy.empty:
+        raise RuntimeError("Refresh datasets first so the modeling pipeline has normalized posts and SPY market data.")
+    target_asset = str(request.target_asset or "SPY").upper()
+    feature_version = request.feature_version or ("v1" if target_asset == "SPY" else "asset-v1")
+    feature_rows, attribution_posts = build_model_target_bundle(
+        store=store,
+        feature_service=feature_service,
+        posts=posts,
+        spy_market=spy,
+        tracked_accounts=tracked_accounts,
+        llm_enabled=bool(request.llm_enabled),
+        target_asset=target_asset,
+        feature_version=feature_version,
+    )
+    store.save_frame(
+        "session_features_latest",
+        feature_rows,
+        metadata={
+            "llm_enabled": bool(request.llm_enabled),
+            "row_count": int(len(feature_rows)),
+            "target_asset": target_asset,
+            "feature_version": feature_version,
+        },
+    )
+    config = ModelRunConfig(
+        run_name=request.run_name or "baseline-research-run",
+        target_asset=target_asset,
+        feature_version=feature_version,
+        llm_enabled=bool(request.llm_enabled),
+        train_window=int(request.train_window),
+        validation_window=int(request.validation_window),
+        test_window=int(request.test_window),
+        step_size=int(request.step_size),
+        threshold_grid=_parse_grid(request.threshold_grid, float),
+        minimum_signal_grid=_parse_grid(request.minimum_signal_grid, int),
+        account_weight_grid=_parse_grid(request.account_weight_grid, float),
+        ridge_alpha=float(request.ridge_alpha),
+        transaction_cost_bps=float(request.transaction_cost_bps),
+    )
+    run, artifacts = backtest_service.run_walk_forward(config, feature_rows)
+    post_attribution = build_post_attribution(attribution_posts)
+    account_attribution = build_account_attribution(post_attribution)
+    predicted_sessions = {
+        session_date
+        for session_date in pd.to_datetime(
+            artifacts["predictions"].get("signal_session_date", pd.Series(dtype="datetime64[ns]")),
+            errors="coerce",
+        ).dropna().dt.normalize().tolist()
+    }
+    if predicted_sessions and not post_attribution.empty:
+        post_attribution = post_attribution.loc[
+            pd.to_datetime(post_attribution["signal_session_date"], errors="coerce").dt.normalize().isin(predicted_sessions)
+        ].reset_index(drop=True)
+    if predicted_sessions and not account_attribution.empty:
+        account_attribution = account_attribution.loc[
+            pd.to_datetime(account_attribution["signal_session_date"], errors="coerce").dt.normalize().isin(predicted_sessions)
+        ].reset_index(drop=True)
+    experiment_store.save_run(
+        run=run,
+        config=artifacts["config"],
+        trades=artifacts["trades"],
+        predictions=artifacts["predictions"],
+        windows=artifacts["windows"],
+        importance=artifacts["importance"],
+        model_artifact=artifacts["model_artifact"],
+        feature_contributions=artifacts["feature_contributions"],
+        post_attribution=post_attribution,
+        account_attribution=account_attribution,
+        benchmarks=artifacts["benchmarks"],
+        diagnostics=artifacts["diagnostics"],
+        benchmark_curves=artifacts["benchmark_curves"],
+        leakage_audit=artifacts["leakage_audit"],
+    )
+    return run.run_id, {"run": run.to_dict(), "metrics": run.metrics}
+
+
+def _asset_for_bundle(run_id: str, bundle: dict[str, Any]) -> str:
+    return str(
+        (bundle.get("config") or {}).get("target_asset")
+        or (bundle.get("run") or {}).get("target_asset")
+        or run_id,
+    ).upper()
+
+
+def _save_saved_run_portfolio(
+    *,
+    experiment_store: ExperimentStore,
+    backtest_service: BacktestService,
+    request: ModelTrainingRequest,
+) -> tuple[str, dict[str, Any]]:
+    component_ids = [str(run_id) for run_id in request.component_run_ids if str(run_id)]
+    if not component_ids:
+        raise RuntimeError("Select at least one saved SPY run before building a portfolio allocator.")
+    component_bundles = {
+        run_id: bundle
+        for run_id in component_ids
+        if (bundle := experiment_store.load_run(run_id)) is not None
+    }
+    missing = [run_id for run_id in component_ids if run_id not in component_bundles]
+    if missing:
+        raise RuntimeError(f"Component runs are missing: {', '.join(missing)}")
+    assets = [_asset_for_bundle(run_id, bundle) for run_id, bundle in component_bundles.items()]
+    if "SPY" not in assets:
+        raise RuntimeError("A saved-run portfolio allocator requires exactly one SPY component run.")
+    if len(assets) != len(set(assets)):
+        raise RuntimeError("A saved-run portfolio allocator can include at most one run per asset.")
+    portfolio_config = PortfolioRunConfig(
+        run_name=request.run_name or "portfolio-allocator-run",
+        allocator_mode="saved_runs",
+        fallback_mode=str(request.fallback_mode or "SPY").upper(),
+        transaction_cost_bps=float(request.transaction_cost_bps),
+        component_run_ids=tuple(component_ids),
+        universe_symbols=tuple(assets),
+    )
+    run, artifacts = backtest_service.run_saved_run_allocator(portfolio_config, component_bundles)
+    experiment_store.save_portfolio_run(
+        run=run,
+        config=artifacts["config"],
+        trades=artifacts["trades"],
+        decision_history=artifacts["predictions"],
+        candidate_predictions=artifacts["candidate_predictions"],
+        component_summary=artifacts["windows"],
+        benchmarks=artifacts["benchmarks"],
+        benchmark_curves=artifacts["benchmark_curves"],
+        diagnostics=artifacts["diagnostics"],
+        leakage_audit=artifacts["leakage_audit"],
+    )
+    return run.run_id, {"run": run.to_dict(), "metrics": run.metrics, "selected_symbols": assets}
+
+
+def _save_joint_portfolio(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    backtest_service: BacktestService,
+    request: ModelTrainingRequest,
+) -> tuple[str, dict[str, Any]]:
+    asset_session_features = store.read_frame("asset_session_features")
+    if asset_session_features.empty:
+        raise RuntimeError("Refresh datasets first so the asset-session feature dataset is available.")
+    selected_symbols = normalize_symbols(list(request.selected_symbols))
+    if len(selected_symbols) < 2:
+        raise RuntimeError("Select at least two symbols for a joint portfolio run.")
+    fallback_mode = str(request.fallback_mode or "SPY").upper()
+    if fallback_mode == "SPY" and "SPY" not in selected_symbols:
+        raise RuntimeError("Include SPY in the selected symbols when fallback mode is SPY.")
+    topology_variants = tuple(str(value) for value in (request.topology_variants or ("per_asset", "pooled")))
+    model_families = tuple(str(value) for value in (request.model_families or SUPPORTED_PORTFOLIO_MODEL_FAMILIES))
+    narrative_modes = tuple(str(value) for value in (request.narrative_feature_modes or ("baseline",)))
+    if not topology_variants:
+        raise RuntimeError("Select at least one topology variant.")
+    if not model_families:
+        raise RuntimeError("Select at least one model family.")
+    if not narrative_modes:
+        raise RuntimeError("Select at least one narrative feature mode.")
+    portfolio_config = PortfolioRunConfig(
+        run_name=request.run_name or "joint-portfolio-run",
+        allocator_mode="joint_model",
+        fallback_mode=fallback_mode,
+        transaction_cost_bps=float(request.transaction_cost_bps),
+        universe_symbols=tuple(selected_symbols),
+        selected_symbols=tuple(selected_symbols),
+        llm_enabled=bool(request.llm_enabled),
+        feature_version=request.feature_version or "asset-v1",
+        train_window=int(request.train_window),
+        validation_window=int(request.validation_window),
+        test_window=int(request.test_window),
+        step_size=int(request.step_size),
+        threshold_grid=_parse_grid(request.threshold_grid, float),
+        minimum_signal_grid=_parse_grid(request.minimum_signal_grid, int),
+        account_weight_grid=_parse_grid(request.account_weight_grid, float),
+        model_families=model_families,
+        topology_variants=topology_variants,
+        narrative_feature_modes=narrative_modes,
+    )
+    run, artifacts = backtest_service.run_joint_model_allocator(portfolio_config, asset_session_features)
+    experiment_store.save_portfolio_run(
+        run=run,
+        config=artifacts["config"],
+        trades=artifacts["trades"],
+        decision_history=artifacts["predictions"],
+        candidate_predictions=artifacts["candidate_predictions"],
+        component_summary=artifacts["windows"],
+        benchmarks=artifacts["benchmarks"],
+        benchmark_curves=artifacts["benchmark_curves"],
+        diagnostics=artifacts["diagnostics"],
+        leakage_audit=artifacts["leakage_audit"],
+        variant_summary=artifacts["variant_summary"],
+        portfolio_model_bundle=artifacts["portfolio_model_bundle"],
+        importance=artifacts["importance"],
+    )
+    return run.run_id, {"run": run.to_dict(), "metrics": run.metrics, "selected_symbols": selected_symbols}
+
+
+def run_model_training_job(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    feature_service: FeatureService,
+    backtest_service: BacktestService,
+    request: ModelTrainingRequest,
+    job_id: str,
+    lock_fd: int | None,
+) -> None:
+    started_at = pd.Timestamp.now(tz="UTC")
+    workflow_mode = str(request.workflow_mode or "").strip().lower()
+    try:
+        save_model_training_job(
+            store,
+            _job_row(job_id=job_id, workflow_mode=workflow_mode, status="running", started_at=started_at),
+        )
+        if workflow_mode == "single_asset":
+            run_id, summary = _save_single_asset_run(
+                store=store,
+                experiment_store=experiment_store,
+                feature_service=feature_service,
+                backtest_service=backtest_service,
+                request=request,
+            )
+        elif workflow_mode == "saved_run_portfolio":
+            run_id, summary = _save_saved_run_portfolio(
+                experiment_store=experiment_store,
+                backtest_service=backtest_service,
+                request=request,
+            )
+        elif workflow_mode == "joint_portfolio":
+            run_id, summary = _save_joint_portfolio(
+                store=store,
+                experiment_store=experiment_store,
+                backtest_service=backtest_service,
+                request=request,
+            )
+        else:
+            raise RuntimeError(f"Unsupported model training workflow: {request.workflow_mode}")
+
+        run_payload = summary.get("run", {}) if isinstance(summary, dict) else {}
+        save_model_training_job(
+            store,
+            _job_row(
+                job_id=job_id,
+                workflow_mode=workflow_mode,
+                status="success",
+                started_at=started_at,
+                completed_at=pd.Timestamp.now(tz="UTC"),
+                run_id=run_id,
+                run_name=str(run_payload.get("run_name", request.run_name) or request.run_name),
+                run_type=str(run_payload.get("run_type", "asset_model") or "asset_model"),
+                allocator_mode=str(run_payload.get("allocator_mode", "") or ""),
+                target_asset=str(run_payload.get("target_asset", request.target_asset) or request.target_asset),
+                selected_symbols=summary.get("selected_symbols", request.selected_symbols) if isinstance(summary, dict) else request.selected_symbols,
+                summary=summary,
+            ),
+        )
+    except Exception as exc:
+        save_model_training_job(
+            store,
+            _job_row(
+                job_id=job_id,
+                workflow_mode=workflow_mode,
+                status="error",
+                started_at=started_at,
+                completed_at=pd.Timestamp.now(tz="UTC"),
+                error_message=str(exc),
+                run_name=request.run_name,
+                target_asset=request.target_asset,
+                selected_symbols=request.selected_symbols,
+            ),
+        )
+    finally:
+        release_refresh_lock(store.settings, lock_fd)
+
+
+def submit_model_training_job(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    feature_service: FeatureService,
+    backtest_service: BacktestService,
+    request: ModelTrainingRequest,
+    run_inline: bool = False,
+) -> tuple[str, list[str]]:
+    workflow_mode = str(request.workflow_mode or "").strip().lower()
+    if workflow_mode not in VALID_MODEL_WORKFLOWS:
+        return "", [f"Unsupported model training workflow: {request.workflow_mode}"]
+
+    lock_fd = acquire_refresh_lock(store.settings)
+    if lock_fd is None:
+        return "", ["A dataset refresh, scheduler cycle, or model training job is already running."]
+
+    job_id = f"model-training-{pd.Timestamp.now(tz='UTC').strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    save_model_training_job(
+        store,
+        _job_row(
+            job_id=job_id,
+            workflow_mode=workflow_mode,
+            status="queued",
+            started_at=pd.Timestamp.now(tz="UTC"),
+            run_name=request.run_name,
+            target_asset=request.target_asset,
+            selected_symbols=request.selected_symbols,
+        ),
+    )
+    kwargs = {
+        "store": store,
+        "experiment_store": experiment_store,
+        "feature_service": feature_service,
+        "backtest_service": backtest_service,
+        "request": request,
+        "job_id": job_id,
+        "lock_fd": lock_fd,
+    }
+    if run_inline:
+        run_model_training_job(**kwargs)
+    else:
+        threading.Thread(target=run_model_training_job, kwargs=kwargs, daemon=True).start()
+    return job_id, []


### PR DESCRIPTION
## Summary
- Adds a persisted `model_training_jobs` workflow service for single-asset, saved-run portfolio, and joint portfolio training jobs.
- Adds protected FastAPI endpoints for model-training options, job submission, and job status.
- Adds a React `Model Training` console with admin unlock, workflow-specific forms, recent job status, and post-success navigation to Run Explorer / Live Ops.
- Adds API and Playwright coverage for job orchestration and UI behavior.
- Hardens post-attribution defaults when optional tracking columns are absent.

Closes #61.

## Validation
- `bash scripts/ci.sh`

Coverage: 92% total.