### PR TITLE
Migrate Historical Replay to React

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -363,6 +363,95 @@ const runComparisonPayload = {
   },
 };
 
+const replayPayload = {
+  ready: true,
+  message: "",
+  selected_run_id: "run-asset-1",
+  selected_session_date: "2025-03-03",
+  min_history_rows: 20,
+  run_options: [
+    {
+      run_id: "run-asset-1",
+      run_name: "SPY Baseline",
+      target_asset: "SPY",
+      run_type: "asset_model",
+      allocator_mode: "",
+      robust_score: 1.2,
+      total_return: 0.08,
+    },
+  ],
+  sessions: [
+    {
+      value: "2025-03-03",
+      label: "2025-03-03 | posts 3 | prior train rows 20",
+      signal_session_date: "2025-03-03T00:00:00",
+      post_count: 3,
+      history_rows_available: 20,
+    },
+    {
+      value: "2025-03-04",
+      label: "2025-03-04 | posts 2 | prior train rows 21",
+      signal_session_date: "2025-03-04T00:00:00",
+      post_count: 2,
+      history_rows_available: 21,
+    },
+  ],
+  summary: {
+    saved_run_count: 2,
+    asset_model_run_count: 1,
+    eligible_session_count: 2,
+  },
+};
+
+const replaySessionPayload = {
+  ready: true,
+  message: "",
+  run_id: "run-asset-1",
+  run_name: "SPY Baseline",
+  target_asset: "SPY",
+  signal_session_date: "2025-03-03T00:00:00",
+  metrics: {
+    target_asset: "SPY",
+    replay_session: "2025-03-03T00:00:00",
+    replay_score: 0.015,
+    replay_confidence: 0.72,
+    suggested_stance: "LONG SPY NEXT SESSION",
+    training_rows_used: 20,
+    history_start: "2025-01-01T00:00:00",
+    history_end: "2025-02-28T00:00:00",
+    actual_next_session_return: 0.004,
+    full_history_score: 0.02,
+    replay_vs_full_history_drift: -0.005,
+  },
+  metadata: {
+    template_run_id: "run-asset-1",
+    future_training_leakage: false,
+    full_history_comparison_available: true,
+    deployment_params: {
+      threshold: 0.001,
+      min_post_count: 1,
+      account_weight: 1,
+    },
+  },
+  prediction: [
+    {
+      signal_session_date: "2025-03-03",
+      expected_return_score: 0.015,
+      prediction_confidence: 0.72,
+      suggested_stance: "LONG SPY NEXT SESSION",
+      future_training_leakage: false,
+    },
+  ],
+  comparison_rows: [
+    { metric: "Replay score", value: 0.015 },
+    { metric: "Replay vs full-history drift", value: -0.005 },
+  ],
+  feature_importance: [{ feature_name: "post_count", coefficient: 0.4, abs_coefficient: 0.4 }],
+  feature_contributions: [{ feature_name: "post_count", feature_family: "activity", contribution: 0.01 }],
+  post_attribution: [{ author_handle: "realDonaldTrump", post_preview: "Replay market post", post_signal_score: 0.4 }],
+  account_attribution: [{ author_handle: "realDonaldTrump", post_count: 1, net_post_signal: 0.4 }],
+};
+
 const researchPayload = {
   ready: true,
   message: "",
@@ -814,6 +903,8 @@ async function mockApi(page: Page) {
   });
   await fulfillJson(page, "/api/runs/run-portfolio-1**", runDetailPayload);
   await fulfillJson(page, "/api/runs/compare**", runComparisonPayload);
+  await fulfillJson(page, "/api/replay**", replayPayload);
+  await fulfillJson(page, "/api/replay/session**", replaySessionPayload);
   await fulfillJson(page, "/api/research**", researchPayload);
   await fulfillJson(page, "/api/discovery", discoveryPayload);
   await fulfillJson(page, "/api/live/current", livePayload);
@@ -922,6 +1013,27 @@ test("shows the migrated run explorer with detail and comparison tables", async 
   await expect(page.getByRole("heading", { name: "Compare saved runs" })).toBeVisible();
   await expect(page.getByRole("cell", { name: "SPY Baseline" })).toBeVisible();
   await expect(page.getByText("run-asset-1: robust score")).toBeVisible();
+});
+
+test("shows historical replay metrics and attribution tables", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /Replay/ }).click();
+
+  await expect(page.getByRole("heading", { name: "Historical signal reconstruction" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Historical Replay Workspace" })).toBeVisible();
+  await expect(page.getByLabel("Replay template run")).toHaveValue("run-asset-1");
+  await expect(page.getByLabel("Historical signal session")).toHaveValue("2025-03-03");
+  await expect(page.getByText("LONG SPY NEXT SESSION").first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Full-history comparison" })).toBeVisible();
+  await expect(page.getByText("Drift context only")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Replay summary" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "Replay vs full-history drift" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Replay feature importance" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "post_count" }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Feature contributions" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Post attribution" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "realDonaldTrump" }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Account attribution" })).toBeVisible();
 });
 
 test("shows model training forms and submits an admin job", async ({ page }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import {
   type ModelTrainingWorkflow,
   type PlotlyFigure,
   type RecordRow,
+  type ReplaySessionPayload,
   type ResearchFilters,
 } from "./api";
 
@@ -22,13 +23,14 @@ const createPlotlyComponent = (
 ) as PlotComponentFactory;
 const Plot = createPlotlyComponent(Plotly);
 
-type PageKey = "overview" | "research" | "discovery" | "runs" | "models" | "data" | "live" | "paper";
+type PageKey = "overview" | "research" | "discovery" | "runs" | "replay" | "models" | "data" | "live" | "paper";
 
 const pages: Array<{ key: PageKey; label: string; deck: string }> = [
   { key: "overview", label: "Overview", deck: "API status and migration posture" },
   { key: "research", label: "Research", deck: "Sentiment, narratives, and export pack" },
   { key: "discovery", label: "Discovery", deck: "Tracked account ranking workspace" },
   { key: "runs", label: "Run Explorer", deck: "Saved model results and comparisons" },
+  { key: "replay", label: "Replay", deck: "Historical signal reconstruction" },
   { key: "models", label: "Model Training", deck: "Train and save model runs" },
   { key: "data", label: "Data Admin", deck: "Refresh jobs, watchlist, and data health" },
   { key: "live", label: "Live Ops", deck: "Operate deployed portfolio" },
@@ -910,6 +912,207 @@ function OverviewPage() {
         </div>
         <DataTable rows={runs.data?.runs ?? []} />
       </article>
+    </section>
+  );
+}
+
+function recordValue(value: unknown): string | number | boolean | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function deploymentParamRows(payload?: ReplaySessionPayload): RecordRow[] {
+  const params = payload?.metadata?.deployment_params;
+  if (!params || typeof params !== "object") {
+    return [];
+  }
+  return Object.entries(params as Record<string, unknown>).map(([parameter, value]) => ({
+    parameter,
+    value: recordValue(value),
+  }));
+}
+
+function ReplayPage() {
+  const [selectedRunId, setSelectedRunId] = useState("");
+  const [selectedSessionDate, setSelectedSessionDate] = useState("");
+  const [sessionRunId, setSessionRunId] = useState("");
+  const replay = useQuery({
+    queryKey: ["replay", selectedRunId],
+    queryFn: () => api.replay(selectedRunId || undefined),
+  });
+  const payload = replay.data;
+  const activeRunId = selectedRunId || payload?.selected_run_id || "";
+  const activeSessionDate = selectedSessionDate || payload?.selected_session_date || "";
+  const session = useQuery({
+    queryKey: ["replay-session", activeRunId, activeSessionDate],
+    queryFn: () => api.replaySession(activeRunId, activeSessionDate),
+    enabled: Boolean(payload?.ready && activeRunId && activeSessionDate),
+  });
+
+  useEffect(() => {
+    if (!selectedRunId && payload?.selected_run_id) {
+      setSelectedRunId(payload.selected_run_id);
+    }
+  }, [payload?.selected_run_id, selectedRunId]);
+
+  useEffect(() => {
+    if (!payload?.selected_session_date || !activeRunId) {
+      return;
+    }
+    if (sessionRunId !== activeRunId) {
+      setSelectedSessionDate(payload.selected_session_date);
+      setSessionRunId(activeRunId);
+    }
+  }, [activeRunId, payload?.selected_session_date, sessionRunId]);
+
+  if (replay.isLoading) {
+    return <LoadingBlock label="Loading historical replay workspace..." />;
+  }
+  if (replay.error) {
+    return <ErrorBlock error={replay.error} />;
+  }
+
+  const sessionPayload = session.data;
+  const replaySessionPayload =
+    sessionPayload?.ready && sessionPayload.metrics && sessionPayload.metadata ? sessionPayload : undefined;
+  const deploymentRows = deploymentParamRows(replaySessionPayload);
+  return (
+    <section className="page-grid">
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <div>
+            <h2>Historical Replay Workspace</h2>
+            <p>
+              Rebuild a historical signal using only earlier target-available rows, then compare it with the saved
+              full-history prediction for drift/debug context.
+            </p>
+          </div>
+          <StatusPill label={payload?.ready ? "Ready" : "Needs data"} tone={payload?.ready ? "ok" : "warn"} />
+        </div>
+        <div className="metric-grid">
+          <MetricCard label="Asset-model runs" value={payload?.summary.asset_model_run_count ?? 0} />
+          <MetricCard label="Eligible sessions" value={payload?.summary.eligible_session_count ?? 0} />
+          <MetricCard label="Minimum history rows" value={payload?.min_history_rows ?? 20} />
+          <MetricCard label="Selected run" value={activeRunId || "n/a"} />
+        </div>
+        {!payload?.ready ? <div className="empty-state">{payload?.message || "Historical replay is not ready yet."}</div> : null}
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Replay template run
+            <select
+              value={activeRunId}
+              disabled={!payload?.run_options.length}
+              onChange={(event) => {
+                setSelectedRunId(event.target.value);
+                setSelectedSessionDate("");
+                setSessionRunId("");
+              }}
+            >
+              {(payload?.run_options ?? []).map((row) => (
+                <option key={row.run_id} value={row.run_id}>
+                  {row.run_name || row.run_id} ({row.target_asset})
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Historical signal session
+            <select
+              value={activeSessionDate}
+              disabled={!payload?.sessions.length}
+              onChange={(event) => setSelectedSessionDate(event.target.value)}
+            >
+              {(payload?.sessions ?? []).map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </article>
+
+      {session.isLoading ? <LoadingBlock label="Rebuilding historical signal..." /> : null}
+      {session.error ? <ErrorBlock error={session.error} /> : null}
+      {sessionPayload && !sessionPayload.ready ? <div className="empty-state">{sessionPayload.message}</div> : null}
+      {sessionPayload?.ready && !replaySessionPayload ? (
+        <div className="empty-state">Historical replay returned an incomplete session payload.</div>
+      ) : null}
+      {replaySessionPayload ? (
+        <>
+          <div className="metric-grid">
+            <MetricCard label="Target asset" value={replaySessionPayload.metrics.target_asset} />
+            <MetricCard label="Replay session" value={replaySessionPayload.metrics.replay_session} />
+            <MetricCard label="Replay score" value={replaySessionPayload.metrics.replay_score} />
+            <MetricCard label="Confidence" value={replaySessionPayload.metrics.replay_confidence} />
+            <MetricCard label="Suggested stance" value={replaySessionPayload.metrics.suggested_stance} />
+            <MetricCard label="Training rows" value={replaySessionPayload.metrics.training_rows_used} />
+          </div>
+
+          {replaySessionPayload.metadata.full_history_comparison_available ? (
+            <article className="panel panel--wide">
+              <div className="panel-heading">
+                <h2>Full-history comparison</h2>
+                <StatusPill label="Drift context only" tone="warn" />
+              </div>
+              <p>
+                The full-history comparison uses a saved model view that may include future data relative to the replay
+                date. Use it only to inspect score drift, not as the historical decision.
+              </p>
+              <div className="metric-grid metric-grid--small">
+                <MetricCard label="Full-history score" value={replaySessionPayload.metrics.full_history_score} />
+                <MetricCard label="Replay drift" value={replaySessionPayload.metrics.replay_vs_full_history_drift} />
+                <MetricCard label="Actual next return" value={replaySessionPayload.metrics.actual_next_session_return} />
+              </div>
+            </article>
+          ) : null}
+
+          <article className="panel panel--wide chart-grid">
+            <div>
+              <h2>Replay summary</h2>
+              <DataTable rows={replaySessionPayload.comparison_rows} />
+            </div>
+            <div>
+              <h2>Deployment parameters</h2>
+              <DataTable rows={deploymentRows} emptyLabel="No deployment parameters were available." />
+            </div>
+          </article>
+
+          <article className="panel panel--wide chart-grid">
+            <div>
+              <h2>Replay prediction</h2>
+              <DataTable rows={replaySessionPayload.prediction} />
+            </div>
+            <div>
+              <h2>Replay feature importance</h2>
+              <DataTable rows={replaySessionPayload.feature_importance} />
+            </div>
+          </article>
+
+          <article className="panel panel--wide chart-grid">
+            <div>
+              <h2>Feature contributions</h2>
+              <DataTable rows={replaySessionPayload.feature_contributions} />
+            </div>
+            <div>
+              <h2>Post attribution</h2>
+              <DataTable rows={replaySessionPayload.post_attribution} />
+            </div>
+          </article>
+
+          <article className="panel panel--wide">
+            <div className="panel-heading">
+              <h2>Account attribution</h2>
+            </div>
+            <DataTable rows={replaySessionPayload.account_attribution} />
+          </article>
+        </>
+      ) : null}
     </section>
   );
 }
@@ -1975,6 +2178,7 @@ export function App() {
       {activePage === "research" ? <ResearchPage /> : null}
       {activePage === "discovery" ? <DiscoveryPage /> : null}
       {activePage === "runs" ? <RunExplorerPage /> : null}
+      {activePage === "replay" ? <ReplayPage /> : null}
       {activePage === "models" ? <ModelTrainingPage onNavigate={setActivePage} /> : null}
       {activePage === "data" ? <DataAdminPage /> : null}
       {activePage === "live" ? <LiveDecisionPage /> : null}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -188,6 +188,53 @@ export type RunComparisonPayload = {
   };
 };
 
+export type ReplayRunOption = {
+  run_id: string;
+  run_name: string;
+  target_asset: string;
+  run_type: string;
+  allocator_mode: string;
+  created_at?: string | null;
+  robust_score?: number;
+  total_return?: number;
+};
+
+export type ReplaySessionOption = {
+  value: string;
+  label: string;
+  signal_session_date: string;
+  post_count: number;
+  history_rows_available: number;
+};
+
+export type ReplayPayload = {
+  ready: boolean;
+  message: string;
+  selected_run_id: string;
+  selected_session_date: string;
+  min_history_rows: number;
+  run_options: ReplayRunOption[];
+  sessions: ReplaySessionOption[];
+  summary: RecordRow;
+};
+
+export type ReplaySessionPayload = {
+  ready: boolean;
+  message: string;
+  run_id: string;
+  run_name?: string;
+  target_asset?: string;
+  signal_session_date: string;
+  metrics: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  prediction: RecordRow[];
+  comparison_rows: RecordRow[];
+  feature_importance: RecordRow[];
+  feature_contributions: RecordRow[];
+  post_attribution: RecordRow[];
+  account_attribution: RecordRow[];
+};
+
 export type LivePayload = {
   configured: boolean;
   errors: string[];
@@ -456,6 +503,18 @@ export const api = {
     }
     const query = params.toString();
     return getJson<RunComparisonPayload>(`/api/runs/compare${query ? `?${query}` : ""}`);
+  },
+  replay: (runId?: string) => {
+    const params = new URLSearchParams();
+    if (runId) {
+      params.set("run_id", runId);
+    }
+    const query = params.toString();
+    return getJson<ReplayPayload>(`/api/replay${query ? `?${query}` : ""}`);
+  },
+  replaySession: (runId: string, signalSessionDate: string) => {
+    const params = new URLSearchParams({ run_id: runId, signal_session_date: signalSessionDate });
+    return getJson<ReplaySessionPayload>(`/api/replay/session?${params.toString()}`);
   },
   research: (filters?: ResearchFilters) => getJson<ResearchPayload>(`/api/research${researchQuery(filters)}`),
   researchExportUrl: (filters?: ResearchFilters) => `${API_BASE_URL}/api/research/export${researchQuery(filters)}`,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,6 +414,87 @@ class FakeBacktestService:
         }
 
 
+class FakeReplayFeatureService(FakeFeatureService):
+    def __init__(self) -> None:
+        self.session_dates = pd.bdate_range("2025-01-01", periods=30)
+
+    def prepare_session_posts(self, posts: pd.DataFrame, market_calendar: pd.DataFrame, tracked_accounts: pd.DataFrame, llm_enabled: bool) -> pd.DataFrame:
+        del market_calendar, tracked_accounts, llm_enabled
+        out = posts.copy()
+        out["session_date"] = pd.to_datetime(out["post_timestamp"], errors="coerce", utc=True).dt.tz_convert(None).dt.normalize()
+        return out
+
+    def build_session_dataset(
+        self,
+        posts: pd.DataFrame,
+        spy_market: pd.DataFrame,
+        tracked_accounts: pd.DataFrame,
+        feature_version: str,
+        llm_enabled: bool,
+        prepared_posts: pd.DataFrame | None = None,
+    ) -> pd.DataFrame:
+        del posts, spy_market, tracked_accounts, feature_version, llm_enabled, prepared_posts
+        return pd.DataFrame(
+            {
+                "signal_session_date": self.session_dates,
+                "next_session_date": self.session_dates + pd.offsets.BDay(1),
+                "post_count": [(idx % 4) + 1 for idx in range(len(self.session_dates))],
+                "sentiment_mean": [0.1 for _ in range(len(self.session_dates))],
+                "target_next_session_return": [0.002 for _ in range(len(self.session_dates))],
+                "target_available": [True for _ in range(len(self.session_dates))],
+            },
+        )
+
+
+class FakeReplayBacktestService(FakeBacktestService):
+    def build_historical_replay(
+        self,
+        run_config,
+        feature_rows: pd.DataFrame,
+        replay_session_date: pd.Timestamp,
+        deployment_params: dict[str, Any],
+    ) -> dict[str, Any]:
+        replay_date = pd.Timestamp(replay_session_date).normalize()
+        history = feature_rows.loc[pd.to_datetime(feature_rows["signal_session_date"]).dt.normalize() < replay_date].copy()
+        prediction = feature_rows.loc[
+            pd.to_datetime(feature_rows["signal_session_date"]).dt.normalize() == replay_date
+        ].head(1).copy()
+        prediction["expected_return_score"] = 0.015
+        prediction["prediction_confidence"] = 0.72
+        prediction["deployment_threshold"] = float(deployment_params.get("threshold", 0.001))
+        prediction["deployment_min_post_count"] = int(deployment_params.get("min_post_count", 1))
+        prediction["deployment_account_weight"] = float(deployment_params.get("account_weight", 1.0))
+        prediction["historical_replay"] = True
+        prediction["training_rows_used"] = int(len(history))
+        prediction["history_start"] = history["signal_session_date"].min()
+        prediction["history_end"] = history["signal_session_date"].max()
+        prediction["suggested_stance"] = f"LONG {run_config.target_asset.upper()} NEXT SESSION"
+        prediction["future_training_leakage"] = False
+        return {
+            "artifact": None,
+            "importance": pd.DataFrame({"feature_name": ["post_count"], "coefficient": [0.4], "abs_coefficient": [0.4]}),
+            "prediction": prediction.reset_index(drop=True),
+            "feature_contributions": pd.DataFrame(
+                {
+                    "signal_session_date": [replay_date],
+                    "feature_name": ["post_count"],
+                    "feature_family": ["activity"],
+                    "contribution": [0.01],
+                    "contribution_share": [1.0],
+                },
+            ),
+            "training_rows_used": int(len(history)),
+            "history_start": history["signal_session_date"].min(),
+            "history_end": history["signal_session_date"].max(),
+            "replay_session_date": replay_date,
+            "deployment_params": {
+                "threshold": float(deployment_params.get("threshold", 0.001)),
+                "min_post_count": int(deployment_params.get("min_post_count", 1)),
+                "account_weight": float(deployment_params.get("account_weight", 1.0)),
+            },
+        }
+
+
 class ApiContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -694,6 +775,125 @@ class ApiContractTests(unittest.TestCase):
                 "importance_path": "",
                 "model_path": "",
             },
+        )
+
+    def _save_replay_frames(self) -> None:
+        dates = pd.bdate_range("2025-01-01", periods=30)
+        self.store.save_frame(
+            "normalized_posts",
+            pd.DataFrame(
+                [
+                    {
+                        "source_platform": "Truth Social",
+                        "source_type": "truth_archive",
+                        "author_account_id": "truth-account",
+                        "author_handle": "realDonaldTrump",
+                        "author_display_name": "Donald Trump",
+                        "author_is_trump": True,
+                        "post_id": f"truth-replay-{idx}",
+                        "post_url": f"https://truthsocial.com/@realDonaldTrump/posts/replay-{idx}",
+                        "post_timestamp": pd.Timestamp(date, tz="UTC") + pd.Timedelta(hours=14),
+                        "raw_text": "Replay market post",
+                        "cleaned_text": "Replay market post",
+                        "is_reshare": False,
+                        "has_media": False,
+                        "replies_count": 0,
+                        "reblogs_count": 0,
+                        "favourites_count": 0,
+                        "mentions_trump": False,
+                        "source_provenance": "unit-test",
+                        "engagement_score": 10.0,
+                        "sentiment_score": 0.3,
+                        "sentiment_label": "positive",
+                    }
+                    for idx, date in enumerate(dates)
+                ],
+            ),
+        )
+        self.store.save_frame(
+            "spy_daily",
+            pd.DataFrame(
+                [
+                    {
+                        "trade_date": pd.Timestamp(date),
+                        "open": 100.0 + idx,
+                        "high": 101.0 + idx,
+                        "low": 99.0 + idx,
+                        "close": 100.5 + idx,
+                        "volume": 1000 + idx,
+                    }
+                    for idx, date in enumerate(dates)
+                ],
+            ),
+        )
+
+    def _save_replay_asset_run_artifacts(self, run_id: str = "replay-asset-run") -> None:
+        dates = pd.bdate_range("2025-01-01", periods=30)
+        self.experiments.save_run(
+            run=BacktestRun(
+                run_id=run_id,
+                run_name="Replay SPY model",
+                target_asset="SPY",
+                config_hash="replay-asset-hash",
+                train_window=20,
+                validation_window=5,
+                test_window=5,
+                metrics={"total_return": 0.05, "robust_score": 1.3, "max_drawdown": -0.02},
+                selected_params={"threshold": 0.001, "min_post_count": 1, "account_weight": 1.0},
+            ),
+            config={
+                "run_name": "Replay SPY model",
+                "target_asset": "SPY",
+                "feature_version": "v1",
+                "llm_enabled": False,
+                "train_window": 20,
+                "validation_window": 5,
+                "test_window": 5,
+                "threshold_grid": [0.0, 0.001],
+                "minimum_signal_grid": [1],
+                "account_weight_grid": [1.0],
+                "transaction_cost_bps": 2.0,
+            },
+            trades=pd.DataFrame(
+                {
+                    "signal_session_date": dates,
+                    "next_session_date": dates + pd.offsets.BDay(1),
+                    "trade_taken": [True] * len(dates),
+                    "net_return": [0.002] * len(dates),
+                    "equity_curve": [1.0 + idx * 0.002 for idx in range(len(dates))],
+                },
+            ),
+            predictions=pd.DataFrame(
+                {
+                    "signal_session_date": dates,
+                    "next_session_date": dates + pd.offsets.BDay(1),
+                    "expected_return_score": [0.02] * len(dates),
+                    "prediction_confidence": [0.8] * len(dates),
+                    "post_count": [2] * len(dates),
+                    "target_next_session_return": [0.002] * len(dates),
+                    "suggested_stance": ["LONG SPY NEXT SESSION"] * len(dates),
+                },
+            ),
+            windows=pd.DataFrame({"window_id": [1], "train_start": [dates[0]]}),
+            importance=pd.DataFrame({"feature_name": ["post_count"], "coefficient": [0.4], "abs_coefficient": [0.4]}),
+            model_artifact={
+                "model_version": "replay-model",
+                "feature_names": ["post_count"],
+                "intercept": 0.0,
+                "coefficients": [0.4],
+                "means": [1.0],
+                "stds": [1.0],
+                "residual_std": 0.01,
+                "train_rows": 30,
+                "metadata": {"run_type": "asset_model", "target_asset": "SPY"},
+            },
+            feature_contributions=pd.DataFrame(),
+            post_attribution=pd.DataFrame(),
+            account_attribution=pd.DataFrame(),
+            benchmarks=pd.DataFrame({"benchmark_name": ["strategy"], "total_return": [0.05]}),
+            diagnostics=pd.DataFrame({"expected_return_score": [0.02], "actual_next_session_return": [0.002]}),
+            benchmark_curves=pd.DataFrame({"next_session_date": [dates[-1]], "strategy": [1.05]}),
+            leakage_audit={"overall_pass": True},
         )
 
     def _save_asset_run_artifacts(self, run_id: str = "asset-run-1") -> None:
@@ -1816,6 +2016,116 @@ class ApiContractTests(unittest.TestCase):
         self.assertGreaterEqual(len(payload["feature_diffs"]), 2)
         self.assertGreaterEqual(len(payload["benchmark_deltas"]), 1)
         self.assertTrue(any("portfolio-run-1" in note for note in payload["change_notes"]))
+
+    def test_replay_endpoint_returns_empty_and_portfolio_only_states(self) -> None:
+        empty = self.client.get("/api/replay")
+        self._save_portfolio_run_artifacts()
+        portfolio_only = self.client.get("/api/replay")
+
+        self.assertEqual(empty.status_code, 200)
+        self.assertFalse(empty.json()["ready"])
+        self.assertIn("Save at least one asset-model run", empty.json()["message"])
+        self.assertEqual(portfolio_only.status_code, 200)
+        self.assertFalse(portfolio_only.json()["ready"])
+        self.assertIn("asset-model runs only", portfolio_only.json()["message"])
+
+    def test_replay_endpoint_requires_datasets_after_asset_run_exists(self) -> None:
+        self._save_replay_asset_run_artifacts()
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                feature_service=FakeReplayFeatureService(),
+                backtest_service=FakeReplayBacktestService(),
+            ),
+        )
+
+        response = client.get("/api/replay")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["ready"])
+        self.assertIn("Refresh datasets first", response.json()["message"])
+
+    def test_replay_endpoint_returns_asset_model_sessions(self) -> None:
+        self._save_replay_frames()
+        self._save_replay_asset_run_artifacts()
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                feature_service=FakeReplayFeatureService(),
+                backtest_service=FakeReplayBacktestService(),
+            ),
+        )
+
+        response = client.get("/api/replay")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ready"])
+        self.assertEqual(payload["selected_run_id"], "replay-asset-run")
+        self.assertEqual(payload["summary"]["asset_model_run_count"], 1)
+        self.assertGreaterEqual(payload["summary"]["eligible_session_count"], 1)
+        self.assertIn("prior train rows", payload["sessions"][0]["label"])
+
+    def test_replay_session_endpoint_returns_replay_audit_payload(self) -> None:
+        self._save_replay_frames()
+        self._save_replay_asset_run_artifacts()
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                feature_service=FakeReplayFeatureService(),
+                backtest_service=FakeReplayBacktestService(),
+            ),
+        )
+        selected_session = client.get("/api/replay").json()["selected_session_date"]
+
+        response = client.get(
+            "/api/replay/session",
+            params={"run_id": "replay-asset-run", "signal_session_date": selected_session},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ready"])
+        self.assertEqual(payload["target_asset"], "SPY")
+        self.assertEqual(payload["metrics"]["replay_score"], 0.015)
+        self.assertFalse(payload["metadata"]["future_training_leakage"])
+        self.assertTrue(payload["metadata"]["full_history_comparison_available"])
+        self.assertIn("Replay vs full-history drift", {row["metric"] for row in payload["comparison_rows"]})
+        self.assertEqual(payload["feature_importance"][0]["feature_name"], "post_count")
+        self.assertEqual(payload["feature_contributions"][0]["feature_name"], "post_count")
+        self.assertEqual(payload["post_attribution"][0]["author_handle"], "realDonaldTrump")
+        self.assertEqual(payload["account_attribution"][0]["author_handle"], "realDonaldTrump")
+
+    def test_replay_session_endpoint_rejects_invalid_and_ineligible_sessions(self) -> None:
+        self._save_replay_frames()
+        self._save_replay_asset_run_artifacts()
+        client = TestClient(
+            create_app(
+                settings=self.settings,
+                store=self.store,
+                feature_service=FakeReplayFeatureService(),
+                backtest_service=FakeReplayBacktestService(),
+            ),
+        )
+
+        invalid = client.get(
+            "/api/replay/session",
+            params={"run_id": "missing-run", "signal_session_date": "2025-01-31"},
+        )
+        ineligible = client.get(
+            "/api/replay/session",
+            params={"run_id": "replay-asset-run", "signal_session_date": "2025-01-02"},
+        )
+
+        self.assertEqual(invalid.status_code, 200)
+        self.assertFalse(invalid.json()["ready"])
+        self.assertIn("unavailable", invalid.json()["message"])
+        self.assertEqual(ineligible.status_code, 200)
+        self.assertFalse(ineligible.json()["ready"])
+        self.assertIn("not eligible", ineligible.json()["message"])
 
     def test_paper_and_performance_endpoints_return_portfolio_slices(self) -> None:
         self._save_paper_frames()

--- a/trump_workbench/api.py
+++ b/trump_workbench/api.py
@@ -26,6 +26,7 @@ from .enrichment import LLMEnrichmentService
 from .experiments import ExperimentStore
 from .features import FeatureService
 from .health import DataHealthService, build_health_summary, build_health_trend_frame, ensure_refresh_history_frame
+from .historical_replay import build_historical_replay_payload, build_historical_replay_session_payload
 from .ingestion import IngestionService
 from .live_monitor import build_live_portfolio_run_state, validate_live_monitor_config
 from .live_ops import (
@@ -517,6 +518,30 @@ def create_app(
             run_id,
             variant_name=variant_name,
             session_date=session_date,
+        )
+
+    @app.get("/api/replay")
+    def replay(run_id: str | None = None) -> dict[str, Any]:
+        return _json_safe(
+            build_historical_replay_payload(
+                store=store,
+                experiment_store=experiment_store,
+                feature_service=feature_service,
+                run_id=run_id,
+            ),
+        )
+
+    @app.get("/api/replay/session")
+    def replay_session(run_id: str, signal_session_date: str) -> dict[str, Any]:
+        return _json_safe(
+            build_historical_replay_session_payload(
+                store=store,
+                experiment_store=experiment_store,
+                feature_service=feature_service,
+                backtest_service=backtest_service,
+                run_id=run_id,
+                signal_session_date=signal_session_date,
+            ),
         )
 
     @app.get("/api/live/current")

--- a/trump_workbench/historical_replay.py
+++ b/trump_workbench/historical_replay.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .backtesting import BacktestService
+from .contracts import ModelRunConfig
+from .experiments import ExperimentStore
+from .explanations import build_account_attribution, build_post_attribution
+from .features import FeatureService
+from .model_training import build_model_target_bundle
+from .storage import DuckDBStore
+
+REPLAY_MIN_HISTORY_ROWS = 20
+
+
+def _normalize_session_date(value: Any) -> pd.Timestamp | None:
+    if value is None or pd.isna(value):
+        return None
+    try:
+        return pd.Timestamp(value).normalize()
+    except Exception:
+        return None
+
+
+def _filter_for_session(frame: pd.DataFrame, session_date: pd.Timestamp | None, column: str = "signal_session_date") -> pd.DataFrame:
+    if frame.empty or session_date is None or column not in frame.columns:
+        return pd.DataFrame(columns=frame.columns)
+    dates = pd.to_datetime(frame[column], errors="coerce").dt.normalize()
+    return frame.loc[dates == session_date].copy()
+
+
+def _frame_records(frame: pd.DataFrame, limit: int | None = None) -> list[dict[str, Any]]:
+    if frame.empty:
+        return []
+    out = frame.copy()
+    if limit is not None:
+        out = out.head(max(0, int(limit)))
+    return out.to_dict(orient="records")
+
+
+def _bundle_to_run_config(run_bundle: dict[str, Any]) -> ModelRunConfig:
+    config = run_bundle.get("config", {}) or {}
+    run_meta = run_bundle.get("run", {}) or {}
+    return ModelRunConfig(
+        run_name=str(config.get("run_name") or run_meta.get("run_name") or "historical-replay"),
+        target_asset=str(config.get("target_asset") or run_meta.get("target_asset") or "SPY"),
+        feature_version=str(config.get("feature_version", "v1")),
+        llm_enabled=bool(config.get("llm_enabled", False)),
+        train_window=int(config.get("train_window", 90) or 90),
+        validation_window=int(config.get("validation_window", 30) or 30),
+        test_window=int(config.get("test_window", 30) or 30),
+        step_size=int(config.get("step_size", 30) or 30),
+        threshold_grid=tuple(float(value) for value in config.get("threshold_grid", [0.0, 0.001, 0.0025, 0.005])),
+        minimum_signal_grid=tuple(int(value) for value in config.get("minimum_signal_grid", [1, 2, 3])),
+        account_weight_grid=tuple(float(value) for value in config.get("account_weight_grid", [0.5, 1.0, 1.5])),
+        ridge_alpha=float(config.get("ridge_alpha", 1.0) or 1.0),
+        transaction_cost_bps=float(config.get("transaction_cost_bps", 2.0) or 2.0),
+        start_date=config.get("start_date"),
+        end_date=config.get("end_date"),
+        notes=str(config.get("notes", "")),
+    )
+
+
+def _eligible_replay_sessions(feature_rows: pd.DataFrame, min_history_rows: int = REPLAY_MIN_HISTORY_ROWS) -> pd.DataFrame:
+    if feature_rows.empty:
+        return pd.DataFrame()
+    eligible = feature_rows.sort_values("signal_session_date").reset_index(drop=True).copy()
+    if "target_available" not in eligible.columns:
+        eligible["target_available"] = False
+    eligible["history_rows_available"] = eligible["target_available"].fillna(False).astype(int).cumsum().shift(fill_value=0)
+    eligible = eligible.loc[eligible["history_rows_available"] >= min_history_rows].copy()
+    return eligible.reset_index(drop=True)
+
+
+def _replay_option_label(row: pd.Series) -> str:
+    session_date = pd.Timestamp(row["signal_session_date"])
+    return (
+        f"{session_date:%Y-%m-%d} | posts {int(row.get('post_count', 0))} | "
+        f"prior train rows {int(row.get('history_rows_available', 0))}"
+    )
+
+
+def _build_replay_comparison_frame(replay_row: pd.Series, full_history_row: pd.Series | None) -> pd.DataFrame:
+    rows = [
+        {"metric": "Replay score", "value": float(replay_row.get("expected_return_score", 0.0))},
+        {"metric": "Replay confidence", "value": float(replay_row.get("prediction_confidence", 0.0))},
+        {"metric": "Replay threshold", "value": float(replay_row.get("deployment_threshold", 0.0))},
+        {"metric": "Replay min post count", "value": int(replay_row.get("deployment_min_post_count", 1))},
+        {"metric": "Training rows used", "value": int(replay_row.get("training_rows_used", 0))},
+    ]
+    actual = replay_row.get("target_next_session_return")
+    if pd.notna(actual):
+        rows.append({"metric": "Actual next-session return", "value": float(actual)})
+    if full_history_row is not None:
+        full_score = float(full_history_row.get("expected_return_score", 0.0) or 0.0)
+        replay_score = float(replay_row.get("expected_return_score", 0.0) or 0.0)
+        rows.extend(
+            [
+                {"metric": "Full-history score", "value": full_score},
+                {"metric": "Replay vs full-history drift", "value": replay_score - full_score},
+                {"metric": "Full-history confidence", "value": float(full_history_row.get("prediction_confidence", 0.0) or 0.0)},
+            ],
+        )
+    return pd.DataFrame(rows)
+
+
+def _run_options(runs: pd.DataFrame) -> list[dict[str, Any]]:
+    if runs.empty:
+        return []
+    out = runs.copy()
+    if "run_type" not in out.columns:
+        out["run_type"] = "asset_model"
+    out["run_type"] = out["run_type"].fillna("asset_model").replace("", "asset_model")
+    if "allocator_mode" not in out.columns:
+        out["allocator_mode"] = ""
+    rows: list[dict[str, Any]] = []
+    for _, row in out.iterrows():
+        metrics = row.get("metrics_json") or {}
+        rows.append(
+            {
+                "run_id": str(row.get("run_id", "") or ""),
+                "run_name": str(row.get("run_name", "") or ""),
+                "target_asset": str(row.get("target_asset", "SPY") or "SPY").upper(),
+                "run_type": str(row.get("run_type", "asset_model") or "asset_model"),
+                "allocator_mode": str(row.get("allocator_mode", "") or ""),
+                "created_at": row.get("created_at"),
+                "robust_score": float(metrics.get("robust_score", 0.0) or 0.0),
+                "total_return": float(metrics.get("total_return", 0.0) or 0.0),
+            },
+        )
+    return rows
+
+
+def _asset_model_run_options(runs: pd.DataFrame) -> list[dict[str, Any]]:
+    return [row for row in _run_options(runs) if row["run_type"] == "asset_model"]
+
+
+def _empty_replay_payload(message: str, *, runs: pd.DataFrame, selected_run_id: str = "") -> dict[str, Any]:
+    asset_runs = _asset_model_run_options(runs)
+    return {
+        "ready": False,
+        "message": message,
+        "selected_run_id": selected_run_id,
+        "selected_session_date": "",
+        "min_history_rows": REPLAY_MIN_HISTORY_ROWS,
+        "run_options": asset_runs,
+        "sessions": [],
+        "summary": {
+            "saved_run_count": int(len(runs)),
+            "asset_model_run_count": int(len(asset_runs)),
+            "eligible_session_count": 0,
+        },
+    }
+
+
+def _select_asset_run(runs: pd.DataFrame, run_id: str | None) -> tuple[str, str | None]:
+    asset_runs = _asset_model_run_options(runs)
+    if not asset_runs:
+        return "", "Historical replay currently supports asset-model runs only."
+    asset_run_ids = {row["run_id"] for row in asset_runs}
+    if run_id:
+        if run_id not in asset_run_ids:
+            return "", "Selected replay run is unavailable or is not an asset-model run."
+        return run_id, None
+    return str(asset_runs[0]["run_id"]), None
+
+
+def _build_feature_rows_for_run(
+    *,
+    store: DuckDBStore,
+    feature_service: FeatureService,
+    run_bundle: dict[str, Any],
+) -> tuple[ModelRunConfig, pd.DataFrame, pd.DataFrame]:
+    posts = store.read_frame("normalized_posts")
+    spy = store.read_frame("spy_daily")
+    tracked_accounts = store.read_frame("tracked_accounts")
+    if posts.empty or spy.empty:
+        raise RuntimeError("Refresh datasets first so replay can rebuild historical features.")
+    run_config = _bundle_to_run_config(run_bundle)
+    feature_rows, attribution_posts = build_model_target_bundle(
+        store=store,
+        feature_service=feature_service,
+        posts=posts,
+        spy_market=spy,
+        tracked_accounts=tracked_accounts,
+        llm_enabled=run_config.llm_enabled,
+        target_asset=run_config.target_asset,
+        feature_version=run_config.feature_version,
+    )
+    if run_config.start_date:
+        feature_rows = feature_rows.loc[feature_rows["signal_session_date"] >= pd.Timestamp(run_config.start_date)].copy()
+    if run_config.end_date:
+        feature_rows = feature_rows.loc[feature_rows["signal_session_date"] <= pd.Timestamp(run_config.end_date)].copy()
+    return run_config, feature_rows.reset_index(drop=True), attribution_posts.reset_index(drop=True)
+
+
+def build_historical_replay_payload(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    feature_service: FeatureService,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    runs = experiment_store.list_runs()
+    if runs.empty:
+        return _empty_replay_payload("Save at least one asset-model run first so Historical Replay has a template configuration to follow.", runs=runs)
+
+    selected_run_id, selection_error = _select_asset_run(runs, run_id)
+    if selection_error:
+        return _empty_replay_payload(selection_error, runs=runs, selected_run_id=selected_run_id)
+
+    loaded = experiment_store.load_run(selected_run_id)
+    if loaded is None:
+        return _empty_replay_payload("The selected replay template could not be loaded.", runs=runs, selected_run_id=selected_run_id)
+
+    try:
+        _, feature_rows, _ = _build_feature_rows_for_run(
+            store=store,
+            feature_service=feature_service,
+            run_bundle=loaded,
+        )
+    except RuntimeError as exc:
+        return _empty_replay_payload(str(exc), runs=runs, selected_run_id=selected_run_id)
+
+    eligible_sessions = _eligible_replay_sessions(feature_rows)
+    if eligible_sessions.empty:
+        return _empty_replay_payload(
+            "No replay sessions are eligible yet. Historical replay needs at least 20 earlier target-available sessions.",
+            runs=runs,
+            selected_run_id=selected_run_id,
+        )
+
+    replay_choices = eligible_sessions.sort_values("signal_session_date", ascending=False).reset_index(drop=True)
+    sessions = []
+    for _, row in replay_choices.iterrows():
+        session_date = pd.Timestamp(row["signal_session_date"]).normalize()
+        sessions.append(
+            {
+                "value": f"{session_date:%Y-%m-%d}",
+                "label": _replay_option_label(row),
+                "signal_session_date": session_date,
+                "post_count": int(row.get("post_count", 0) or 0),
+                "history_rows_available": int(row.get("history_rows_available", 0) or 0),
+            },
+        )
+
+    asset_runs = _asset_model_run_options(runs)
+    return {
+        "ready": True,
+        "message": "",
+        "selected_run_id": selected_run_id,
+        "selected_session_date": str(sessions[0]["value"]) if sessions else "",
+        "min_history_rows": REPLAY_MIN_HISTORY_ROWS,
+        "run_options": asset_runs,
+        "sessions": sessions,
+        "summary": {
+            "saved_run_count": int(len(runs)),
+            "asset_model_run_count": int(len(asset_runs)),
+            "eligible_session_count": int(len(sessions)),
+        },
+    }
+
+
+def build_historical_replay_session_payload(
+    *,
+    store: DuckDBStore,
+    experiment_store: ExperimentStore,
+    feature_service: FeatureService,
+    backtest_service: BacktestService,
+    run_id: str,
+    signal_session_date: str,
+) -> dict[str, Any]:
+    runs = experiment_store.list_runs()
+    selected_run_id, selection_error = _select_asset_run(runs, run_id)
+    if selection_error:
+        return {"ready": False, "message": selection_error, "run_id": run_id, "signal_session_date": signal_session_date}
+
+    loaded = experiment_store.load_run(selected_run_id)
+    if loaded is None:
+        return {"ready": False, "message": "The selected replay template could not be loaded.", "run_id": run_id, "signal_session_date": signal_session_date}
+
+    try:
+        run_config, feature_rows, attribution_posts = _build_feature_rows_for_run(
+            store=store,
+            feature_service=feature_service,
+            run_bundle=loaded,
+        )
+    except RuntimeError as exc:
+        return {"ready": False, "message": str(exc), "run_id": run_id, "signal_session_date": signal_session_date}
+
+    replay_date = _normalize_session_date(signal_session_date)
+    eligible_sessions = _eligible_replay_sessions(feature_rows)
+    eligible_dates = pd.to_datetime(eligible_sessions.get("signal_session_date", pd.Series(dtype="datetime64[ns]")), errors="coerce").dt.normalize()
+    if replay_date is None or replay_date not in set(eligible_dates.dropna().tolist()):
+        return {
+            "ready": False,
+            "message": "Selected replay session is not eligible. Historical replay needs at least 20 earlier target-available sessions.",
+            "run_id": run_id,
+            "signal_session_date": signal_session_date,
+        }
+
+    try:
+        replay = backtest_service.build_historical_replay(
+            run_config=run_config,
+            feature_rows=feature_rows,
+            replay_session_date=replay_date,
+            deployment_params=loaded["selected_params"],
+        )
+    except RuntimeError as exc:
+        return {"ready": False, "message": str(exc), "run_id": run_id, "signal_session_date": signal_session_date}
+
+    replay_prediction = replay["prediction"].iloc[0]
+    replay_feature_contributions = replay["feature_contributions"]
+    if "session_date" in attribution_posts.columns:
+        session_post_source = attribution_posts.loc[
+            pd.to_datetime(attribution_posts["session_date"], errors="coerce").dt.normalize() == replay_date
+        ].copy()
+    else:
+        session_post_source = pd.DataFrame()
+    session_post_attribution = build_post_attribution(session_post_source)
+    session_account_attribution = build_account_attribution(session_post_attribution)
+
+    full_history_match = _filter_for_session(loaded["predictions"], replay_date)
+    full_history_row = full_history_match.iloc[0] if not full_history_match.empty else None
+    comparison_frame = _build_replay_comparison_frame(replay_prediction, full_history_row)
+
+    prediction_records = _frame_records(replay["prediction"])
+    prediction_record = prediction_records[0] if prediction_records else {}
+    return {
+        "ready": True,
+        "message": "",
+        "run_id": selected_run_id,
+        "run_name": str((loaded.get("run") or {}).get("run_name", selected_run_id)),
+        "target_asset": str(run_config.target_asset).upper(),
+        "signal_session_date": replay_date,
+        "metrics": {
+            "target_asset": str(run_config.target_asset).upper(),
+            "replay_session": replay_date,
+            "replay_score": float(replay_prediction.get("expected_return_score", 0.0) or 0.0),
+            "replay_confidence": float(replay_prediction.get("prediction_confidence", 0.0) or 0.0),
+            "suggested_stance": str(replay_prediction.get("suggested_stance", "")),
+            "training_rows_used": int(replay.get("training_rows_used", 0) or 0),
+            "history_start": replay.get("history_start"),
+            "history_end": replay.get("history_end"),
+            "actual_next_session_return": replay_prediction.get("target_next_session_return"),
+            "full_history_score": None if full_history_row is None else float(full_history_row.get("expected_return_score", 0.0) or 0.0),
+            "replay_vs_full_history_drift": None
+            if full_history_row is None
+            else float(replay_prediction.get("expected_return_score", 0.0) or 0.0) - float(full_history_row.get("expected_return_score", 0.0) or 0.0),
+        },
+        "metadata": {
+            "template_run_id": selected_run_id,
+            "history_start": replay.get("history_start"),
+            "history_end": replay.get("history_end"),
+            "training_rows_used": int(replay.get("training_rows_used", 0) or 0),
+            "deployment_params": replay.get("deployment_params", {}),
+            "future_training_leakage": bool(prediction_record.get("future_training_leakage", False)),
+            "full_history_comparison_available": full_history_row is not None,
+        },
+        "prediction": prediction_records,
+        "comparison_rows": _frame_records(comparison_frame),
+        "feature_importance": _frame_records(replay["importance"], limit=25),
+        "feature_contributions": _frame_records(replay_feature_contributions),
+        "post_attribution": _frame_records(session_post_attribution),
+        "account_attribution": _frame_records(session_account_attribution),
+    }

--- a/trump_workbench/ui.py
+++ b/trump_workbench/ui.py
@@ -37,6 +37,12 @@ from .health import (
     ensure_refresh_history_frame,
     make_refresh_history_frame,
 )
+from .historical_replay import (
+    _build_replay_comparison_frame,
+    _bundle_to_run_config,
+    _eligible_replay_sessions,
+    _replay_option_label,
+)
 from .ingestion import IngestionService, TruthSocialArchiveAdapter, XCsvAdapter
 from .market import MarketDataService, build_asset_universe, build_watchlist_frame, normalize_symbols
 from .modeling import (
@@ -2506,70 +2512,6 @@ def _summarize_run_changes(base_run_id: str, run_bundles: dict[str, dict[str, An
             parts.append(f"{len(omitted_vs_base)} removed features ({', '.join(omitted_vs_base[:3])})")
         notes.append(f"`{run_id}`: " + "; ".join(parts) + ".")
     return notes
-
-
-def _bundle_to_run_config(run_bundle: dict[str, Any]) -> ModelRunConfig:
-    config = run_bundle.get("config", {}) or {}
-    run_meta = run_bundle.get("run", {}) or {}
-    return ModelRunConfig(
-        run_name=str(config.get("run_name") or run_meta.get("run_name") or "historical-replay"),
-        target_asset=str(config.get("target_asset") or run_meta.get("target_asset") or "SPY"),
-        feature_version=str(config.get("feature_version", "v1")),
-        llm_enabled=bool(config.get("llm_enabled", False)),
-        train_window=int(config.get("train_window", 90) or 90),
-        validation_window=int(config.get("validation_window", 30) or 30),
-        test_window=int(config.get("test_window", 30) or 30),
-        step_size=int(config.get("step_size", 30) or 30),
-        threshold_grid=tuple(float(value) for value in config.get("threshold_grid", [0.0, 0.001, 0.0025, 0.005])),
-        minimum_signal_grid=tuple(int(value) for value in config.get("minimum_signal_grid", [1, 2, 3])),
-        account_weight_grid=tuple(float(value) for value in config.get("account_weight_grid", [0.5, 1.0, 1.5])),
-        ridge_alpha=float(config.get("ridge_alpha", 1.0) or 1.0),
-        transaction_cost_bps=float(config.get("transaction_cost_bps", 2.0) or 2.0),
-        start_date=config.get("start_date"),
-        end_date=config.get("end_date"),
-        notes=str(config.get("notes", "")),
-    )
-
-
-def _eligible_replay_sessions(feature_rows: pd.DataFrame, min_history_rows: int = 20) -> pd.DataFrame:
-    if feature_rows.empty:
-        return pd.DataFrame()
-    eligible = feature_rows.sort_values("signal_session_date").reset_index(drop=True).copy()
-    eligible["history_rows_available"] = eligible["target_available"].fillna(False).astype(int).cumsum().shift(fill_value=0)
-    eligible = eligible.loc[eligible["history_rows_available"] >= min_history_rows].copy()
-    return eligible.reset_index(drop=True)
-
-
-def _replay_option_label(row: pd.Series) -> str:
-    session_date = pd.Timestamp(row["signal_session_date"])
-    return (
-        f"{session_date:%Y-%m-%d} | posts {int(row.get('post_count', 0))} | "
-        f"prior train rows {int(row.get('history_rows_available', 0))}"
-    )
-
-
-def _build_replay_comparison_frame(replay_row: pd.Series, full_history_row: pd.Series | None) -> pd.DataFrame:
-    rows = [
-        {"metric": "Replay score", "value": float(replay_row.get("expected_return_score", 0.0))},
-        {"metric": "Replay confidence", "value": float(replay_row.get("prediction_confidence", 0.0))},
-        {"metric": "Replay threshold", "value": float(replay_row.get("deployment_threshold", 0.0))},
-        {"metric": "Replay min post count", "value": int(replay_row.get("deployment_min_post_count", 1))},
-        {"metric": "Training rows used", "value": int(replay_row.get("training_rows_used", 0))},
-    ]
-    actual = replay_row.get("target_next_session_return")
-    if pd.notna(actual):
-        rows.append({"metric": "Actual next-session return", "value": float(actual)})
-    if full_history_row is not None:
-        full_score = float(full_history_row.get("expected_return_score", 0.0) or 0.0)
-        replay_score = float(replay_row.get("expected_return_score", 0.0) or 0.0)
-        rows.extend(
-            [
-                {"metric": "Full-history score", "value": full_score},
-                {"metric": "Replay vs full-history drift", "value": replay_score - full_score},
-                {"metric": "Full-history confidence", "value": float(full_history_row.get("prediction_confidence", 0.0) or 0.0)},
-            ],
-        )
-    return pd.DataFrame(rows)
 
 
 def render_models_view(


### PR DESCRIPTION
## Summary
- Add a shared historical replay backend module for asset-model replay payloads and reuse those helpers from Streamlit.
- Add read-only FastAPI replay endpoints for run/session options and historical signal reconstruction.
- Add a React `Replay` tab with run/session selectors, replay metrics, leakage/drift context, and attribution tables.
- Cover replay API behavior and the React workspace with backend and Playwright tests.

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `npm run build --prefix frontend`
- `npm run test:ui --prefix frontend`
- `bash scripts/ci.sh`

Closes #63