### PR TITLE
Migrate Discovery Admin Overrides to React

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -673,6 +673,11 @@ const discoveryPayload = {
     x_post_count: 12,
   },
   latest_ranked_at: "2026-04-17T00:00:00",
+  admin: {
+    mode: "public",
+    writes_enabled: true,
+    write_disabled_reason: "",
+  },
   summary: {
     post_count: 54,
     x_candidate_post_count: 12,
@@ -739,15 +744,50 @@ const discoveryPayload = {
       suppressed_by_override: true,
     },
   ],
+  override_account_options: [
+    {
+      account_id: "acct-macro",
+      handle: "macroalpha",
+      display_name: "Macro Alpha",
+      source_platform: "X",
+      status: "active",
+      source: "latest_ranking",
+      label: "@macroalpha - Macro Alpha",
+    },
+    {
+      account_id: "acct-policy",
+      handle: "policywatch",
+      display_name: "Policy Watch",
+      source_platform: "X",
+      status: "pinned",
+      source: "latest_ranking",
+      label: "@policywatch - Policy Watch",
+    },
+    {
+      account_id: "acct-muted",
+      handle: "muted",
+      display_name: "Muted Account",
+      source_platform: "X",
+      status: "excluded",
+      source: "latest_ranking",
+      label: "@muted - Muted Account",
+    },
+  ],
   override_history: [
     {
+      override_id: "override-pin",
+      account_id: "acct-policy",
       handle: "policywatch",
       action: "pin",
+      effective_from: "2026-04-01T00:00:00",
       note: "Always inspect",
     },
     {
+      override_id: "override-suppress",
+      account_id: "acct-muted",
       handle: "muted",
       action: "suppress",
+      effective_from: "2026-04-10T00:00:00",
       note: "Low quality",
     },
   ],
@@ -983,6 +1023,16 @@ async function mockApi(page: Page) {
   await fulfillJson(page, "/api/research**", researchPayload);
   await fulfillJson(page, "/api/research/assets**", researchAssetPayload);
   await fulfillJson(page, "/api/discovery", discoveryPayload);
+  await fulfillJson(page, "/api/discovery/overrides", discoveryPayload);
+  await fulfillJson(page, "/api/discovery/overrides/**", {
+    ...discoveryPayload,
+    summary: {
+      ...discoveryPayload.summary,
+      override_count: 1,
+      suppress_override_count: 0,
+    },
+    override_history: discoveryPayload.override_history.slice(0, 1),
+  });
   await fulfillJson(page, "/api/live/current", livePayload);
   await fulfillJson(page, "/api/live/ops", liveOpsPayload);
   await fulfillJson(page, "/api/admin/session", { token: "admin-token", token_type: "bearer", expires_at: "2026-04-20T20:00:00Z", expires_in_seconds: 43200, mode: "public" });
@@ -1068,8 +1118,19 @@ test("shows the migrated discovery workspace with rankings and overrides", async
 
   await expect(page.getByRole("heading", { name: "Tracked account ranking workspace" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Discovery workspace" })).toBeVisible();
-  await expect(page.getByText("Manual pin/suppress override writes remain in Streamlit")).toBeVisible();
-  await expect(page.getByText("Discovery ranks non-Trump X accounts that mention Trump.", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Discovery admin overrides" })).toBeVisible();
+  await expect(page.getByText("Admins can now pin or suppress accounts from this")).toBeVisible();
+  await expect(page.getByText("Read-only until unlocked")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save discovery override" })).toBeDisabled();
+  await page.getByPlaceholder("Admin password").fill("secret");
+  await page.getByRole("button", { name: "Unlock admin writes" }).click();
+  await expect(page.getByText("Unlocked for this browser session")).toBeVisible();
+  await page.getByLabel("Override account").selectOption("acct-muted");
+  await page.getByLabel("Override action").selectOption("suppress");
+  await page.getByPlaceholder("Optional rationale").fill("Noisy duplicate account");
+  await page.getByRole("button", { name: "Save discovery override" }).click();
+  await page.getByLabel("Override to delete").selectOption("override-suppress");
+  await page.getByRole("button", { name: "Delete selected override" }).click();
   await expect(page.getByText("X candidate posts")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Top discovered accounts" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Active tracked accounts" })).toBeVisible();
@@ -1078,7 +1139,7 @@ test("shows the migrated discovery workspace with rankings and overrides", async
   await expect(page.getByRole("heading", { name: "Latest ranking snapshot" })).toBeVisible();
   await expect(page.getByRole("columnheader", { name: "suppressed by override" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Override history" })).toBeVisible();
-  await expect(page.getByRole("cell", { name: "suppress" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "pin", exact: true })).toBeVisible();
 });
 
 test("shows the migrated run explorer with detail and comparison tables", async ({ page }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import type { Data, Frame, Layout } from "plotly.js";
 import {
   api,
   type DatasetAdminPayload,
+  type DiscoveryOverrideRequest,
   type LiveOpsPayload,
   type ModelTrainingJobRequest,
   type ModelTrainingPayload,
@@ -621,7 +622,62 @@ function ResearchPage() {
 }
 
 function DiscoveryPage() {
+  const queryClient = useQueryClient();
   const discovery = useQuery({ queryKey: ["discovery"], queryFn: api.discovery });
+  const [adminToken, setAdminToken] = useState(() =>
+    typeof window === "undefined" ? "" : window.sessionStorage.getItem("allcaps_admin_token") ?? "",
+  );
+  const [password, setPassword] = useState("");
+  const [selectedAccountId, setSelectedAccountId] = useState("");
+  const [overrideAction, setOverrideAction] = useState<"pin" | "suppress">("pin");
+  const [effectiveFrom, setEffectiveFrom] = useState(() => new Date().toISOString().slice(0, 10));
+  const [effectiveTo, setEffectiveTo] = useState("");
+  const [overrideNote, setOverrideNote] = useState("");
+  const [selectedOverrideId, setSelectedOverrideId] = useState("");
+
+  const applyDiscoveryPayload = (payload: NonNullable<typeof discovery.data>) => {
+    queryClient.setQueryData(["discovery"], payload);
+  };
+  const unlock = useMutation({
+    mutationFn: () => api.adminSession(password),
+    onSuccess: (payload) => {
+      setAdminToken(payload.token);
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem("allcaps_admin_token", payload.token);
+      }
+      setPassword("");
+    },
+  });
+  const saveOverride = useMutation({
+    mutationFn: (request: DiscoveryOverrideRequest) => api.createDiscoveryOverride(request, adminToken),
+    onSuccess: (payload) => {
+      setOverrideNote("");
+      setEffectiveTo("");
+      applyDiscoveryPayload(payload);
+    },
+  });
+  const deleteOverride = useMutation({
+    mutationFn: (overrideId: string) => api.deleteDiscoveryOverride(overrideId, adminToken),
+    onSuccess: (payload) => {
+      setSelectedOverrideId("");
+      applyDiscoveryPayload(payload);
+    },
+  });
+
+  const payload = discovery.data;
+  const summary = payload?.summary ?? {};
+  const accountOptions = payload?.override_account_options ?? [];
+  const overrideRows = payload?.override_history ?? [];
+  const currentAccount = accountOptions.find((option) => option.account_id === selectedAccountId) ?? accountOptions[0];
+  const isUnlocked = Boolean(adminToken);
+  const writesEnabled = Boolean(payload?.admin.writes_enabled);
+  const mutationError = unlock.error ?? saveOverride.error ?? deleteOverride.error;
+
+  useEffect(() => {
+    if (!selectedAccountId && accountOptions[0]?.account_id) {
+      setSelectedAccountId(accountOptions[0].account_id);
+    }
+  }, [accountOptions, selectedAccountId]);
 
   if (discovery.isLoading) {
     return <LoadingBlock label="Loading discovery workspace..." />;
@@ -630,23 +686,161 @@ function DiscoveryPage() {
     return <ErrorBlock error={discovery.error} />;
   }
 
-  const payload = discovery.data;
-  const summary = payload?.summary ?? {};
   return (
     <section className="page-grid">
       <article className="panel panel--wide">
         <div className="panel-heading">
           <div>
-            <p className="eyebrow">Read-only migration slice</p>
+            <p className="eyebrow">Admin-enabled migration slice</p>
             <h2>Discovery workspace</h2>
           </div>
           <StatusPill label={payload?.ready ? "Rankings available" : "Guidance"} tone={payload?.ready ? "ok" : "warn"} />
         </div>
         <p>
-          Discovery ranks non-Trump X accounts that mention Trump. Manual pin/suppress override writes remain in Streamlit
-          for this migration slice.
+          Discovery ranks non-Trump X accounts that mention Trump. Admins can now pin or suppress accounts from this
+          web workspace; dataset refreshes still live in Data Admin.
         </p>
         {payload?.message ? <div className="empty-state">{payload.message}</div> : null}
+      </article>
+
+      <article className="panel panel--wide">
+        <div className="panel-heading">
+          <div>
+            <h2>Discovery admin overrides</h2>
+            <p>Pin strong accounts, suppress noisy accounts, or delete an existing manual override.</p>
+          </div>
+          <StatusPill label={isUnlocked ? "Admin unlocked" : "Read-only"} tone={isUnlocked ? "ok" : "warn"} />
+        </div>
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Admin unlock
+            <input
+              type="password"
+              placeholder={payload?.admin.mode === "private" ? "Private mode: password optional" : "Admin password"}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          <label>
+            Session status
+            <button
+              className="action-button"
+              type="button"
+              aria-label={isUnlocked ? "Refresh admin token" : "Unlock admin writes"}
+              onClick={() => unlock.mutate()}
+              disabled={unlock.isPending}
+            >
+              {isUnlocked ? "Refresh admin token" : "Unlock admin writes"}
+            </button>
+          </label>
+          <label>
+            Write state
+            <span className="form-readout">{isUnlocked ? "Unlocked for this browser session" : "Read-only until unlocked"}</span>
+          </label>
+          <label>
+            Discovery writes
+            <span className="form-readout">{writesEnabled ? "Enabled for X mentions" : payload?.admin.write_disabled_reason || "Disabled"}</span>
+          </label>
+        </div>
+        {mutationError ? <ErrorBlock error={mutationError} /> : null}
+
+        <div className="filter-grid">
+          <label>
+            Account
+            <select
+              aria-label="Override account"
+              value={currentAccount?.account_id ?? ""}
+              onChange={(event) => setSelectedAccountId(event.target.value)}
+              disabled={!accountOptions.length}
+            >
+              {accountOptions.map((option) => (
+                <option key={option.account_id} value={option.account_id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Action
+            <select
+              aria-label="Override action"
+              value={overrideAction}
+              onChange={(event) => setOverrideAction(event.target.value === "suppress" ? "suppress" : "pin")}
+            >
+              <option value="pin">Pin</option>
+              <option value="suppress">Suppress</option>
+            </select>
+          </label>
+          <label>
+            Effective from
+            <input type="date" value={effectiveFrom} onChange={(event) => setEffectiveFrom(event.target.value)} />
+          </label>
+          <label>
+            Effective to
+            <input type="date" value={effectiveTo} onChange={(event) => setEffectiveTo(event.target.value)} />
+          </label>
+          <label>
+            Note
+            <input value={overrideNote} onChange={(event) => setOverrideNote(event.target.value)} placeholder="Optional rationale" />
+          </label>
+          <label>
+            Save override
+            <button
+              className="action-button"
+              type="button"
+              aria-label="Save discovery override"
+              disabled={!isUnlocked || !writesEnabled || !currentAccount || !effectiveFrom || saveOverride.isPending}
+              onClick={() => {
+                if (!currentAccount) {
+                  return;
+                }
+                saveOverride.mutate({
+                  account_id: currentAccount.account_id,
+                  handle: currentAccount.handle,
+                  display_name: currentAccount.display_name,
+                  source_platform: currentAccount.source_platform || "X",
+                  action: overrideAction,
+                  effective_from: effectiveFrom,
+                  effective_to: effectiveTo || undefined,
+                  note: overrideNote,
+                });
+              }}
+            >
+              Save {overrideAction} override
+            </button>
+          </label>
+        </div>
+
+        <div className="filter-grid filter-grid--compact">
+          <label>
+            Delete override
+            <select
+              aria-label="Override to delete"
+              value={selectedOverrideId}
+              onChange={(event) => setSelectedOverrideId(event.target.value)}
+              disabled={!overrideRows.length}
+            >
+              <option value="">Select override</option>
+              {overrideRows.map((row) => (
+                <option key={String(row.override_id ?? "")} value={String(row.override_id ?? "")}>
+                  {String(row.action ?? "")} | @{String(row.handle ?? row.account_id ?? "")} | {String(row.effective_from ?? "")}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Remove
+            <button
+              className="action-button action-button--secondary"
+              type="button"
+              aria-label="Delete selected override"
+              disabled={!isUnlocked || !selectedOverrideId || deleteOverride.isPending}
+              onClick={() => deleteOverride.mutate(selectedOverrideId)}
+            >
+              Delete selected override
+            </button>
+          </label>
+        </div>
       </article>
 
       <div className="metric-grid">

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -441,6 +441,11 @@ export type DiscoveryPayload = {
   message: string;
   source_mode: StatusPayload["source_mode"];
   latest_ranked_at: string | null;
+  admin: {
+    mode: "public" | "private";
+    writes_enabled: boolean;
+    write_disabled_reason: string;
+  };
   summary: RecordRow;
   charts: {
     top_discovered_accounts?: PlotlyFigure;
@@ -448,8 +453,28 @@ export type DiscoveryPayload = {
   };
   active_accounts: RecordRow[];
   latest_rankings: RecordRow[];
+  override_account_options: Array<{
+    account_id: string;
+    handle: string;
+    display_name: string;
+    source_platform: string;
+    status: string;
+    source: string;
+    label: string;
+  }>;
   override_history: RecordRow[];
   recent_ranking_history: RecordRow[];
+};
+
+export type DiscoveryOverrideRequest = {
+  account_id: string;
+  handle?: string;
+  display_name?: string;
+  source_platform?: string;
+  action: "pin" | "suppress";
+  effective_from: string;
+  effective_to?: string;
+  note?: string;
 };
 
 function researchQuery(filters: ResearchFilters = {}): string {
@@ -488,6 +513,28 @@ async function postJson<T>(path: string, payload: unknown = {}, token?: string):
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`;
+    try {
+      const body = (await response.json()) as { detail?: unknown };
+      if (body.detail) {
+        detail = Array.isArray(body.detail) ? body.detail.join("; ") : String(body.detail);
+      }
+    } catch {
+      // Keep the HTTP status fallback when the response is not JSON.
+    }
+    throw new Error(`API request failed: ${detail}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function deleteJson<T>(path: string, token?: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "DELETE",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
   });
   if (!response.ok) {
     let detail = `${response.status} ${response.statusText}`;
@@ -584,6 +631,10 @@ export const api = {
   researchAssets: (filters?: ResearchAssetFilters) => getJson<ResearchAssetPayload>(`/api/research/assets${researchQuery(filters)}`),
   researchExportUrl: (filters?: ResearchFilters) => `${API_BASE_URL}/api/research/export${researchQuery(filters)}`,
   discovery: () => getJson<DiscoveryPayload>("/api/discovery"),
+  createDiscoveryOverride: (request: DiscoveryOverrideRequest, token: string) =>
+    postJson<DiscoveryPayload>("/api/discovery/overrides", request, token),
+  deleteDiscoveryOverride: (overrideId: string, token: string) =>
+    deleteJson<DiscoveryPayload>(`/api/discovery/overrides/${encodeURIComponent(overrideId)}`, token),
   live: () => getJson<LivePayload>("/api/live/current"),
   liveOps: () => getJson<LiveOpsPayload>("/api/live/ops"),
   saveLiveConfig: (request: LiveConfigSaveRequest, token: string) => postJson<LiveOpsPayload>("/api/live/config", request, token),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1648,6 +1648,8 @@ class ApiContractTests(unittest.TestCase):
         self.assertEqual(payload["source_mode"]["mode"], "unknown")
         self.assertEqual(payload["active_accounts"], [])
         self.assertEqual(payload["latest_rankings"], [])
+        self.assertFalse(payload["admin"]["writes_enabled"])
+        self.assertEqual(payload["override_account_options"], [])
         self.assertIn("top_discovered_accounts", payload["charts"])
 
     def test_discovery_endpoint_explains_truth_only_mode(self) -> None:
@@ -1661,6 +1663,8 @@ class ApiContractTests(unittest.TestCase):
         self.assertEqual(payload["source_mode"]["mode"], "truth_only")
         self.assertIn("Discovery ranks non-Trump X accounts", payload["message"])
         self.assertEqual(payload["summary"]["x_candidate_post_count"], 0)
+        self.assertFalse(payload["admin"]["writes_enabled"])
+        self.assertIn("Truth Social-only", payload["admin"]["write_disabled_reason"])
 
     def test_discovery_endpoint_returns_rankings_active_accounts_and_overrides(self) -> None:
         self._save_discovery_frames()
@@ -1680,8 +1684,141 @@ class ApiContractTests(unittest.TestCase):
         self.assertEqual(payload["latest_rankings"][0]["discovery_score"], 12.0)
         self.assertEqual({row["handle"] for row in payload["active_accounts"]}, {"macroalpha", "policywatch"})
         self.assertEqual({row["action"] for row in payload["override_history"]}, {"pin", "suppress"})
+        self.assertTrue(payload["admin"]["writes_enabled"])
+        self.assertEqual(
+            {row["account_id"] for row in payload["override_account_options"]},
+            {"acct-macro", "acct-policy", "acct-muted"},
+        )
         self.assertGreaterEqual(len(payload["recent_ranking_history"]), 1)
         self.assertIsNotNone(payload["latest_ranked_at"])
+
+    def test_discovery_override_create_requires_admin_and_valid_payload(self) -> None:
+        self._save_research_frames(include_x=True)
+
+        unauthorized = self.client.post(
+            "/api/discovery/overrides",
+            json={
+                "account_id": "acct-macro",
+                "handle": "macroalpha",
+                "display_name": "Macro Alpha",
+                "source_platform": "X",
+                "action": "pin",
+                "effective_from": "2025-02-03",
+            },
+        )
+        self.assertEqual(unauthorized.status_code, 401)
+
+        token = self._admin_token()
+        invalid = self.client.post(
+            "/api/discovery/overrides",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "account_id": "",
+                "action": "mute",
+                "effective_from": "not-a-date",
+                "effective_to": "2025-02-01",
+            },
+        )
+        self.assertEqual(invalid.status_code, 400)
+
+    def test_discovery_override_pin_persists_and_recomputes_discovery(self) -> None:
+        self._save_research_frames(include_x=True)
+        token = self._admin_token()
+
+        response = self.client.post(
+            "/api/discovery/overrides",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "account_id": "acct-macro",
+                "handle": "macroalpha",
+                "display_name": "Macro Alpha",
+                "source_platform": "X",
+                "action": "pin",
+                "effective_from": "2025-02-03",
+                "note": "Important account",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["summary"]["pin_override_count"], 1)
+        self.assertEqual(payload["active_accounts"][0]["status"], "pinned")
+        self.assertEqual(payload["latest_rankings"][0]["selected_status"], "pinned")
+        self.assertFalse(self.store.read_frame("manual_account_overrides").empty)
+        self.assertFalse(self.store.read_frame("tracked_accounts").empty)
+        self.assertFalse(self.store.read_frame("account_rankings").empty)
+
+    def test_discovery_override_suppress_removes_account_from_active_accounts(self) -> None:
+        self._save_research_frames(include_x=True)
+        token = self._admin_token()
+
+        response = self.client.post(
+            "/api/discovery/overrides",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "account_id": "acct-macro",
+                "handle": "macroalpha",
+                "display_name": "Macro Alpha",
+                "source_platform": "X",
+                "action": "suppress",
+                "effective_from": "2025-02-03",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["summary"]["suppress_override_count"], 1)
+        self.assertEqual(payload["active_accounts"], [])
+        self.assertTrue(payload["latest_rankings"][0]["suppressed_by_override"])
+        self.assertEqual(payload["latest_rankings"][0]["selected_status"], "excluded")
+
+    def test_discovery_override_delete_recomputes_derived_frames(self) -> None:
+        self._save_discovery_frames()
+        token = self._admin_token()
+        payload = self.client.get("/api/discovery").json()
+        pin_override_id = next(row["override_id"] for row in payload["override_history"] if row["action"] == "pin")
+
+        unauthorized = self.client.delete(f"/api/discovery/overrides/{pin_override_id}")
+        self.assertEqual(unauthorized.status_code, 401)
+
+        response = self.client.delete(
+            f"/api/discovery/overrides/{pin_override_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        updated = response.json()
+        self.assertEqual(updated["summary"]["pin_override_count"], 0)
+        self.assertNotIn("acct-policy", {row["account_id"] for row in updated["active_accounts"]})
+        self.assertNotIn(pin_override_id, set(self.store.read_frame("manual_account_overrides")["override_id"].astype(str)))
+
+    def test_discovery_override_write_rejects_empty_and_truth_only_data(self) -> None:
+        token = self._admin_token()
+        request = {
+            "account_id": "acct-macro",
+            "handle": "macroalpha",
+            "display_name": "Macro Alpha",
+            "source_platform": "X",
+            "action": "pin",
+            "effective_from": "2025-02-03",
+        }
+
+        empty_response = self.client.post(
+            "/api/discovery/overrides",
+            headers={"Authorization": f"Bearer {token}"},
+            json=request,
+        )
+        self.assertEqual(empty_response.status_code, 400)
+        self.assertIn("Refresh datasets", empty_response.json()["detail"])
+
+        self._save_truth_posts()
+        truth_response = self.client.post(
+            "/api/discovery/overrides",
+            headers={"Authorization": f"Bearer {token}"},
+            json=request,
+        )
+        self.assertEqual(truth_response.status_code, 400)
+        self.assertIn("non-Trump X mention data", truth_response.json()["detail"])
 
     def test_discovery_endpoint_handles_schema_less_ranking_history(self) -> None:
         self._save_research_frames(include_x=True)

--- a/trump_workbench/api.py
+++ b/trump_workbench/api.py
@@ -21,6 +21,12 @@ from .dataset_admin import (
     submit_refresh_job,
 )
 from .discovery import DiscoveryService
+from .discovery_admin import (
+    DiscoveryAdminError,
+    DiscoveryOverrideMutation,
+    create_discovery_override,
+    delete_discovery_override,
+)
 from .discovery_workspace import build_discovery_workspace
 from .enrichment import LLMEnrichmentService
 from .experiments import ExperimentStore
@@ -72,6 +78,29 @@ ADMIN_TOKEN_TTL_SECONDS = 12 * 60 * 60
 
 class AdminSessionRequest(BaseModel):
     password: str = ""
+
+
+class DiscoveryOverrideRequest(BaseModel):
+    account_id: str
+    handle: str = ""
+    display_name: str = ""
+    source_platform: str = "X"
+    action: str
+    effective_from: str
+    effective_to: str | None = None
+    note: str = ""
+
+    def to_mutation(self) -> DiscoveryOverrideMutation:
+        return DiscoveryOverrideMutation(
+            account_id=self.account_id,
+            handle=self.handle,
+            display_name=self.display_name,
+            source_platform=self.source_platform,
+            action=self.action,
+            effective_from=self.effective_from,
+            effective_to=self.effective_to,
+            note=self.note,
+        )
 
 
 class LiveConfigSaveRequest(BaseModel):
@@ -204,7 +233,7 @@ def create_app(
             CORSMiddleware,
             allow_origins=list(settings.api_cors_origins),
             allow_credentials=False,
-            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
             allow_headers=["Authorization", "Content-Type"],
         )
 
@@ -390,7 +419,39 @@ def create_app(
 
     @app.get("/api/discovery")
     def discovery() -> dict[str, Any]:
-        return _json_safe(build_discovery_workspace(store, discovery_service=discovery_service))
+        return _json_safe(build_discovery_workspace(store, discovery_service=discovery_service, settings=settings))
+
+    @app.post("/api/discovery/overrides")
+    def create_discovery_override_endpoint(
+        request: DiscoveryOverrideRequest,
+        _: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        try:
+            create_discovery_override(
+                settings=settings,
+                store=store,
+                discovery_service=discovery_service,
+                request=request.to_mutation(),
+            )
+        except DiscoveryAdminError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return _json_safe(build_discovery_workspace(store, discovery_service=discovery_service, settings=settings))
+
+    @app.delete("/api/discovery/overrides/{override_id}")
+    def delete_discovery_override_endpoint(
+        override_id: str,
+        _: None = Depends(require_admin),
+    ) -> dict[str, Any]:
+        try:
+            delete_discovery_override(
+                settings=settings,
+                store=store,
+                discovery_service=discovery_service,
+                override_id=override_id,
+            )
+        except DiscoveryAdminError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return _json_safe(build_discovery_workspace(store, discovery_service=discovery_service, settings=settings))
 
     @app.get("/api/datasets/health")
     def dataset_health() -> dict[str, Any]:

--- a/trump_workbench/discovery_admin.py
+++ b/trump_workbench/discovery_admin.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from .config import AppSettings
+from .contracts import MANUAL_OVERRIDE_COLUMNS
+from .discovery import DiscoveryService
+from .storage import DuckDBStore
+
+
+class DiscoveryAdminError(ValueError):
+    """Raised when a Discovery override mutation request is invalid."""
+
+
+@dataclass(frozen=True)
+class DiscoveryOverrideMutation:
+    account_id: str
+    handle: str = ""
+    display_name: str = ""
+    source_platform: str = "X"
+    action: str = "pin"
+    effective_from: str = ""
+    effective_to: str | None = None
+    note: str = ""
+
+
+def _normalized_posts_for_discovery(store: DuckDBStore, settings: AppSettings) -> pd.DataFrame:
+    posts = store.read_frame("normalized_posts")
+    if posts.empty:
+        raise DiscoveryAdminError("Refresh datasets first so Discovery overrides have stored posts to evaluate.")
+
+    out = posts.copy()
+    for column, default in {
+        "source_platform": "",
+        "mentions_trump": False,
+        "author_is_trump": False,
+        "author_account_id": "",
+        "author_handle": "",
+        "author_display_name": "",
+        "post_id": "",
+        "engagement_score": 0.0,
+        "sentiment_score": 0.0,
+    }.items():
+        if column not in out.columns:
+            out[column] = default
+    if "post_timestamp" not in out.columns:
+        raise DiscoveryAdminError("Stored posts are missing post timestamps; refresh datasets before managing Discovery overrides.")
+    out["post_timestamp"] = pd.to_datetime(out["post_timestamp"], errors="coerce", utc=True).dt.tz_convert(settings.timezone)
+    out = out.dropna(subset=["post_timestamp"]).copy()
+    if out.empty:
+        raise DiscoveryAdminError("Stored posts do not contain valid timestamps; refresh datasets before managing Discovery overrides.")
+    out["source_platform"] = out["source_platform"].fillna("").astype(str)
+    out["mentions_trump"] = out["mentions_trump"].fillna(False).astype(bool)
+    out["author_is_trump"] = out["author_is_trump"].fillna(False).astype(bool)
+    return out
+
+
+def _x_candidate_posts(posts: pd.DataFrame) -> pd.DataFrame:
+    return posts.loc[
+        (posts["source_platform"] == "X")
+        & posts["mentions_trump"]
+        & (~posts["author_is_trump"])
+    ].copy()
+
+
+def _parse_effective_date(value: str | None, field_name: str) -> pd.Timestamp:
+    timestamp = pd.to_datetime(value, errors="coerce")
+    if pd.isna(timestamp):
+        raise DiscoveryAdminError(f"{field_name} must be a valid date.")
+    return pd.Timestamp(timestamp).normalize()
+
+
+def _validate_override_request(request: DiscoveryOverrideMutation) -> tuple[str, str, pd.Timestamp, pd.Timestamp | None]:
+    account_id = str(request.account_id or "").strip()
+    if not account_id:
+        raise DiscoveryAdminError("account_id is required.")
+    action = str(request.action or "").strip().lower()
+    if action not in {"pin", "suppress"}:
+        raise DiscoveryAdminError("action must be either pin or suppress.")
+    effective_from = _parse_effective_date(request.effective_from, "effective_from")
+    effective_to = _parse_effective_date(request.effective_to, "effective_to") if request.effective_to else None
+    if effective_to is not None and effective_to <= effective_from:
+        raise DiscoveryAdminError("effective_to must be after effective_from.")
+    return account_id, action, effective_from, effective_to
+
+
+def _load_overrides(store: DuckDBStore, discovery_service: DiscoveryService) -> pd.DataFrame:
+    overrides = discovery_service.normalize_manual_overrides(store.read_frame("manual_account_overrides"))
+    if overrides.empty:
+        return pd.DataFrame(columns=MANUAL_OVERRIDE_COLUMNS)
+    return overrides
+
+
+def recompute_discovery_frames(
+    *,
+    settings: AppSettings,
+    store: DuckDBStore,
+    discovery_service: DiscoveryService,
+    posts: pd.DataFrame | None = None,
+    overrides: pd.DataFrame | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    discovery_posts = posts if posts is not None else _normalized_posts_for_discovery(store, settings)
+    normalized_overrides = discovery_service.normalize_manual_overrides(overrides if overrides is not None else store.read_frame("manual_account_overrides"))
+    as_of = pd.to_datetime(discovery_posts["post_timestamp"], errors="coerce").dropna().max()
+    if pd.isna(as_of):
+        raise DiscoveryAdminError("Stored posts do not contain valid timestamps; refresh datasets before managing Discovery overrides.")
+    tracked_accounts, rankings = discovery_service.refresh_accounts(
+        posts=discovery_posts,
+        existing_accounts=store.read_frame("tracked_accounts"),
+        as_of=pd.Timestamp(as_of),
+        manual_overrides=normalized_overrides,
+    )
+    store.save_frame("manual_account_overrides", normalized_overrides, metadata={"row_count": int(len(normalized_overrides))})
+    store.save_frame("tracked_accounts", tracked_accounts, metadata={"row_count": int(len(tracked_accounts))})
+    store.save_frame("account_rankings", rankings, metadata={"row_count": int(len(rankings))})
+    return tracked_accounts, rankings
+
+
+def create_discovery_override(
+    *,
+    settings: AppSettings,
+    store: DuckDBStore,
+    discovery_service: DiscoveryService,
+    request: DiscoveryOverrideMutation,
+) -> None:
+    posts = _normalized_posts_for_discovery(store, settings)
+    if _x_candidate_posts(posts).empty:
+        raise DiscoveryAdminError("Discovery overrides require non-Trump X mention data.")
+    account_id, action, effective_from, effective_to = _validate_override_request(request)
+    overrides = _load_overrides(store, discovery_service)
+    updated = discovery_service.add_manual_override(
+        overrides=overrides,
+        account_id=account_id,
+        handle=str(request.handle or "").strip(),
+        display_name=str(request.display_name or "").strip(),
+        action=action,
+        effective_from=effective_from,
+        effective_to=effective_to,
+        note=str(request.note or "").strip(),
+        source_platform=str(request.source_platform or "X").strip() or "X",
+    )
+    recompute_discovery_frames(
+        settings=settings,
+        store=store,
+        discovery_service=discovery_service,
+        posts=posts,
+        overrides=updated,
+    )
+
+
+def delete_discovery_override(
+    *,
+    settings: AppSettings,
+    store: DuckDBStore,
+    discovery_service: DiscoveryService,
+    override_id: str,
+) -> None:
+    normalized_override_id = str(override_id or "").strip()
+    if not normalized_override_id:
+        raise DiscoveryAdminError("override_id is required.")
+    posts = _normalized_posts_for_discovery(store, settings)
+    overrides = _load_overrides(store, discovery_service)
+    if overrides.empty or normalized_override_id not in set(overrides["override_id"].astype(str)):
+        raise DiscoveryAdminError("Override was not found.")
+    updated = discovery_service.remove_manual_override(overrides, normalized_override_id)
+    recompute_discovery_frames(
+        settings=settings,
+        store=store,
+        discovery_service=discovery_service,
+        posts=posts,
+        overrides=updated,
+    )

--- a/trump_workbench/discovery_workspace.py
+++ b/trump_workbench/discovery_workspace.py
@@ -5,6 +5,7 @@ from typing import Any
 import pandas as pd
 import plotly.graph_objects as go
 
+from .config import AppSettings
 from .contracts import MANUAL_OVERRIDE_COLUMNS, RANKING_HISTORY_COLUMNS, TRACKED_ACCOUNT_COLUMNS
 from .discovery import DiscoveryService
 from .research_workspace import _figure_json, _frame_records, detect_source_mode
@@ -133,6 +134,82 @@ def _ranking_trend_chart(ranking_history: pd.DataFrame) -> dict[str, Any]:
     return _figure_json(fig)
 
 
+def _add_override_option(
+    rows: list[dict[str, Any]],
+    seen: set[str],
+    *,
+    account_id: Any,
+    handle: Any,
+    display_name: Any,
+    source_platform: Any,
+    status: Any,
+    source: str,
+) -> None:
+    normalized_account_id = str(account_id or "").strip()
+    if not normalized_account_id or normalized_account_id in seen:
+        return
+    seen.add(normalized_account_id)
+    normalized_handle = str(handle or "").strip()
+    normalized_display_name = str(display_name or "").strip()
+    label_parts = [f"@{normalized_handle}" if normalized_handle else normalized_account_id]
+    if normalized_display_name:
+        label_parts.append(normalized_display_name)
+    rows.append(
+        {
+            "account_id": normalized_account_id,
+            "handle": normalized_handle,
+            "display_name": normalized_display_name,
+            "source_platform": str(source_platform or "X").strip() or "X",
+            "status": str(status or "").strip(),
+            "source": source,
+            "label": " - ".join(label_parts),
+        },
+    )
+
+
+def _override_account_options(
+    latest_rankings: pd.DataFrame,
+    active_accounts: pd.DataFrame,
+    overrides: pd.DataFrame,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for _, row in latest_rankings.iterrows():
+        _add_override_option(
+            rows,
+            seen,
+            account_id=row.get("author_account_id"),
+            handle=row.get("author_handle"),
+            display_name=row.get("author_display_name"),
+            source_platform=row.get("source_platform", "X"),
+            status=row.get("selected_status", ""),
+            source="latest_ranking",
+        )
+    for _, row in active_accounts.iterrows():
+        _add_override_option(
+            rows,
+            seen,
+            account_id=row.get("account_id"),
+            handle=row.get("handle"),
+            display_name=row.get("display_name"),
+            source_platform=row.get("source_platform", "X"),
+            status=row.get("status", ""),
+            source="active_account",
+        )
+    for _, row in overrides.iterrows():
+        _add_override_option(
+            rows,
+            seen,
+            account_id=row.get("account_id"),
+            handle=row.get("handle"),
+            display_name=row.get("display_name"),
+            source_platform=row.get("source_platform", "X"),
+            status=row.get("action", ""),
+            source="override_history",
+        )
+    return rows
+
+
 def _message(posts: pd.DataFrame, source_mode: dict[str, Any], x_candidates: pd.DataFrame, latest_rankings: pd.DataFrame) -> str:
     if posts.empty:
         return "Refresh datasets first so Discovery can inspect X mention data."
@@ -149,7 +226,11 @@ def _message(posts: pd.DataFrame, source_mode: dict[str, Any], x_candidates: pd.
     return ""
 
 
-def build_discovery_workspace(store: DuckDBStore, discovery_service: DiscoveryService | None = None) -> dict[str, Any]:
+def build_discovery_workspace(
+    store: DuckDBStore,
+    discovery_service: DiscoveryService | None = None,
+    settings: AppSettings | None = None,
+) -> dict[str, Any]:
     discovery_service = discovery_service or DiscoveryService()
     posts = store.read_frame("normalized_posts")
     tracked_accounts = store.read_frame("tracked_accounts")
@@ -169,6 +250,13 @@ def build_discovery_workspace(store: DuckDBStore, discovery_service: DiscoverySe
     )
     selected_status = latest_rankings["selected_status"].fillna("").astype(str) if "selected_status" in latest_rankings.columns else pd.Series(dtype=str)
     override_actions = overrides["action"].fillna("").astype(str) if "action" in overrides.columns else pd.Series(dtype=str)
+    write_disabled_reason = ""
+    if posts.empty:
+        write_disabled_reason = "Refresh datasets first so Discovery overrides have stored posts to evaluate."
+    elif source_mode.get("mode") == "truth_only":
+        write_disabled_reason = "Discovery overrides require non-Trump X mention data; Truth Social-only analysis does not need account discovery."
+    elif x_candidates.empty:
+        write_disabled_reason = "Load X mention rows before managing Discovery account overrides."
 
     summary = {
         "post_count": int(len(posts)),
@@ -188,6 +276,11 @@ def build_discovery_workspace(store: DuckDBStore, discovery_service: DiscoverySe
         "message": message,
         "source_mode": source_mode,
         "latest_ranked_at": latest_ranked_at,
+        "admin": {
+            "mode": "public" if settings is not None and settings.public_mode else "private",
+            "writes_enabled": bool(write_disabled_reason == ""),
+            "write_disabled_reason": write_disabled_reason,
+        },
         "summary": summary,
         "charts": {
             "top_discovered_accounts": _top_accounts_chart(latest_rankings),
@@ -195,6 +288,7 @@ def build_discovery_workspace(store: DuckDBStore, discovery_service: DiscoverySe
         },
         "active_accounts": _frame_records(active_accounts.head(TABLE_LIMIT)),
         "latest_rankings": _frame_records(latest_rankings.head(TABLE_LIMIT)),
+        "override_account_options": _override_account_options(latest_rankings, active_accounts, overrides),
         "override_history": _frame_records(overrides.head(TABLE_LIMIT) if not overrides.empty else pd.DataFrame(columns=MANUAL_OVERRIDE_COLUMNS)),
         "recent_ranking_history": _frame_records(recent_history.head(TABLE_LIMIT)),
     }


### PR DESCRIPTION
## Summary
- Add protected FastAPI endpoints for creating and deleting Discovery manual overrides from the React app.
- Recompute `tracked_accounts` and `account_rankings` immediately from stored posts after override mutations, without running ingestion or market refresh.
- Extend the React Discovery page with admin unlock, pin/suppress controls, override deletion, disabled-state guidance, and updated Playwright coverage.

## Validation
- `.venv/bin/python -m py_compile app.py trump_workbench/*.py tests/*.py`
- `.venv/bin/python -m unittest discover -s tests -v`
- `npm run build --prefix frontend`
- `npm run test:ui --prefix frontend`
- `bash scripts/ci.sh`