### PR TITLE
Add frontend coverage baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ htmlcov/
 .workbench/
 docker-state/
 frontend/dist/
+frontend/coverage/
 frontend/node_modules/
 frontend/playwright-report/
 frontend/test-results/

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ npm exec --prefix frontend playwright install chromium
 npm run test:ui --prefix frontend
 ```
 
+Run measured React unit/component coverage:
+
+```bash
+npm run test:coverage --prefix frontend
+```
+
+The frontend coverage gate requires at least 90% statements, functions, and lines. Branch coverage is tracked with a lower ratchet because V8 counts many JSX optional-render fallbacks as branches; raise it as branch-focused tests are added.
+
 The React app opens as a tabbed workbench with these primary sections:
 
 - `Overview`
@@ -546,6 +554,12 @@ Run the React browser UI tests:
 ```bash
 npm exec --prefix frontend playwright install chromium
 npm run test:ui --prefix frontend
+```
+
+Run the React unit/component coverage gate:
+
+```bash
+npm run test:coverage --prefix frontend
 ```
 
 Run the same checks as GitHub Actions:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,14 +16,78 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/plotly.js-dist-min": "^2.3.4",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/react-plotly.js": "^2.6.4",
         "@vitejs/plugin-react": "^5.1.2",
+        "@vitest/coverage-v8": "^4.1.5",
+        "jsdom": "^29.0.2",
         "typescript": "^5.9.3",
-        "vite": "^8.0.8"
+        "vite": "^8.0.8",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -259,6 +323,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -307,6 +381,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@choojs/findup": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
@@ -318,6 +415,146 @@
       },
       "bin": {
         "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -352,6 +589,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -921,6 +1176,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.99.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
@@ -945,6 +1207,96 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@turf/area": {
@@ -1035,6 +1387,14 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1079,6 +1439,31 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -1202,6 +1587,150 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -1220,6 +1749,41 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-bounds": {
@@ -1256,6 +1820,35 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
@@ -1277,6 +1870,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-search-bounds": {
@@ -1381,6 +1984,16 @@
       "peer": true,
       "dependencies": {
         "element-size": "^1.1.1"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/clamp": {
@@ -1592,6 +2205,27 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
@@ -1769,6 +2403,20 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1787,6 +2435,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/defined": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
@@ -1795,6 +2450,16 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-kerning": {
@@ -1813,6 +2478,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/draw-svg-path": {
       "version": "1.0.0",
@@ -1896,6 +2569,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -1905,6 +2591,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es5-ext": {
       "version": "0.10.64",
@@ -2034,6 +2727,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2063,6 +2766,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ext": {
@@ -2527,6 +3240,16 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-hover": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
@@ -2559,6 +3282,26 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -2593,6 +3336,16 @@
       ],
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -2684,6 +3437,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-string-blank": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
@@ -2715,11 +3475,101 @@
         "node": ">=18"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3061,6 +3911,68 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/map-limit": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
@@ -3226,6 +4138,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3382,6 +4311,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3423,12 +4363,32 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pbf": {
       "version": "3.3.0",
@@ -3643,6 +4603,30 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/probe-image-size": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
@@ -3679,6 +4663,16 @@
       "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/quickselect": {
       "version": "2.0.0",
@@ -3777,6 +4771,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regl": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.1.tgz",
@@ -3854,6 +4862,16 @@
         "pick-by-alias": "^1.2.0",
         "raf": "^3.4.1",
         "regl-scatter2d": "^3.2.3"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -3981,6 +4999,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4003,6 +5034,13 @@
       "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signum": {
       "version": "1.0.0",
@@ -4041,6 +5079,13 @@
         "node": "*"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/static-eval": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
@@ -4050,6 +5095,13 @@
       "dependencies": {
         "escodegen": "^2.1.0"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-parser": {
       "version": "0.3.1",
@@ -4112,6 +5164,19 @@
         "parenthesis": "^3.1.5"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strongly-connected-components": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
@@ -4142,6 +5207,19 @@
       "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -4200,6 +5278,13 @@
         "svg-path-bounds": "^1.0.1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -4211,12 +5296,29 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -4241,6 +5343,36 @@
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-float32": {
       "version": "1.1.0",
@@ -4272,6 +5404,32 @@
         "topo2geo": "bin/topo2geo",
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -4317,6 +5475,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unquote": {
@@ -4449,6 +5617,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vt-pbf": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
@@ -4459,6 +5717,19 @@
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/weak-map": {
@@ -4478,6 +5749,41 @@
         "get-canvas-context": "^1.0.1"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -4492,6 +5798,23 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/world-calendars": {
@@ -4510,6 +5833,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "dev": "vite --host 127.0.0.1",
     "build": "tsc -b && vite build",
     "preview": "vite preview --host 127.0.0.1",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:ui": "playwright test",
     "test:ui:headed": "playwright test --headed"
   },
@@ -19,12 +21,18 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/plotly.js-dist-min": "^2.3.4",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/react-plotly.js": "^2.6.4",
     "@vitejs/plugin-react": "^5.1.2",
+    "@vitest/coverage-v8": "^4.1.5",
+    "jsdom": "^29.0.2",
     "typescript": "^5.9.3",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,10 +14,18 @@ import {
   type ModelTrainingWorkflow,
   type PlotlyFigure,
   type RecordRow,
-  type ReplaySessionPayload,
   type ResearchAssetFilters,
   type ResearchFilters,
 } from "./api";
+import {
+  deploymentParamRows,
+  formatValue,
+  modelRunLabel,
+  modelWorkflowLabel,
+  parseModelJobSummary,
+  parseSymbolList,
+  selectedOptions,
+} from "./appUtils";
 
 type PlotComponentFactory = (plotly: unknown) => ComponentType<Record<string, unknown>>;
 const createPlotlyComponent = (
@@ -39,19 +47,6 @@ const pages: Array<{ key: PageKey; label: string; deck: string }> = [
   { key: "paper", label: "Paper + Performance", deck: "Portfolio audit and drift" },
 ];
 
-function formatValue(value: unknown): string {
-  if (value === null || value === undefined || value === "") {
-    return "n/a";
-  }
-  if (typeof value === "number") {
-    if (Math.abs(value) < 1 && value !== 0) {
-      return `${(value * 100).toFixed(2)}%`;
-    }
-    return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(4);
-  }
-  return String(value);
-}
-
 function StatusPill({ label, tone = "neutral" }: { label: string; tone?: "neutral" | "ok" | "warn" | "severe" }) {
   return <span className={`status-pill status-pill--${tone}`}>{label}</span>;
 }
@@ -72,12 +67,6 @@ function MetricCard({ label, value, caption }: { label: string; value: unknown; 
       {caption ? <small>{caption}</small> : null}
     </article>
   );
-}
-
-function selectedOptions(options: HTMLCollectionOf<HTMLOptionElement>): string[] {
-  return Array.from(options)
-    .filter((option) => option.selected)
-    .map((option) => option.value);
 }
 
 function PlotlyChart({ figure, title }: { figure?: PlotlyFigure; title: string }) {
@@ -138,13 +127,6 @@ function DataTable({ rows, emptyLabel = "No rows returned yet." }: { rows: Recor
       </table>
     </div>
   );
-}
-
-function parseSymbolList(value: string): string[] {
-  return value
-    .split(/[\s,]+/)
-    .map((item) => item.trim().toUpperCase())
-    .filter(Boolean);
 }
 
 function ResearchPage() {
@@ -1299,27 +1281,6 @@ function OverviewPage() {
   );
 }
 
-function recordValue(value: unknown): string | number | boolean | null {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return value;
-  }
-  return JSON.stringify(value);
-}
-
-function deploymentParamRows(payload?: ReplaySessionPayload): RecordRow[] {
-  const params = payload?.metadata?.deployment_params;
-  if (!params || typeof params !== "object") {
-    return [];
-  }
-  return Object.entries(params as Record<string, unknown>).map(([parameter, value]) => ({
-    parameter,
-    value: recordValue(value),
-  }));
-}
-
 function ReplayPage() {
   const [selectedRunId, setSelectedRunId] = useState("");
   const [selectedSessionDate, setSelectedSessionDate] = useState("");
@@ -1498,38 +1459,6 @@ function ReplayPage() {
       ) : null}
     </section>
   );
-}
-
-function modelRunLabel(row: RecordRow): string {
-  const runName = String(row.run_name ?? row.run_id ?? "");
-  const asset = String(row.target_asset ?? "");
-  const score = row.robust_score !== undefined && row.robust_score !== null ? ` | robust ${formatValue(row.robust_score)}` : "";
-  return `${asset} | ${runName}${score}`;
-}
-
-function modelWorkflowLabel(mode: ModelTrainingWorkflow): string {
-  if (mode === "single_asset") {
-    return "Single Asset";
-  }
-  if (mode === "saved_run_portfolio") {
-    return "Saved-Run Portfolio";
-  }
-  return "Joint Portfolio";
-}
-
-function parseModelJobSummary(job: RecordRow | undefined): Record<string, unknown> {
-  const summary = job?.summary;
-  if (!summary) {
-    return {};
-  }
-  if (typeof summary === "object") {
-    return summary as Record<string, unknown>;
-  }
-  try {
-    return JSON.parse(String(summary)) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
 }
 
 function ModelTrainingPage({ onNavigate }: { onNavigate: (page: PageKey) => void }) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -641,5 +641,5 @@ export const api = {
   captureLive: (token: string) => postJson<LiveOpsPayload>("/api/live/capture", {}, token),
   paperCurrentAction: (request: PaperCurrentActionRequest, token: string) => postJson<LiveOpsPayload>("/api/paper/current", request, token),
   paperPortfolios: () => getJson<PaperPortfoliosPayload>("/api/paper/portfolios"),
-  performance: (paperPortfolioId: string) => getJson<PerformancePayload>(`/api/performance/${paperPortfolioId}`),
+  performance: (paperPortfolioId: string) => getJson<PerformancePayload>(`/api/performance/${encodeURIComponent(paperPortfolioId)}`),
 };

--- a/frontend/src/appUtils.ts
+++ b/frontend/src/appUtils.ts
@@ -1,0 +1,80 @@
+import type { ReplaySessionPayload, RecordRow } from "./api";
+
+export function formatValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") {
+    return "n/a";
+  }
+  if (typeof value === "number") {
+    if (Math.abs(value) < 1 && value !== 0) {
+      return `${(value * 100).toFixed(2)}%`;
+    }
+    return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(4);
+  }
+  return String(value);
+}
+
+export function selectedOptions(options: HTMLCollectionOf<HTMLOptionElement>): string[] {
+  return Array.from(options)
+    .filter((option) => option.selected)
+    .map((option) => option.value);
+}
+
+export function parseSymbolList(value: string): string[] {
+  return value
+    .split(/[\s,]+/)
+    .map((item) => item.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+export function recordValue(value: unknown): string | number | boolean | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+export function deploymentParamRows(payload?: ReplaySessionPayload): RecordRow[] {
+  const params = payload?.metadata?.deployment_params;
+  if (!params || typeof params !== "object") {
+    return [];
+  }
+  return Object.entries(params as Record<string, unknown>).map(([parameter, value]) => ({
+    parameter,
+    value: recordValue(value),
+  }));
+}
+
+export function modelRunLabel(row: RecordRow): string {
+  const runName = String(row.run_name ?? row.run_id ?? "");
+  const asset = String(row.target_asset ?? "");
+  const score = row.robust_score !== undefined && row.robust_score !== null ? ` | robust ${formatValue(row.robust_score)}` : "";
+  return `${asset} | ${runName}${score}`;
+}
+
+export function modelWorkflowLabel(mode: "single_asset" | "saved_run_portfolio" | "joint_portfolio"): string {
+  if (mode === "single_asset") {
+    return "Single Asset";
+  }
+  if (mode === "saved_run_portfolio") {
+    return "Saved-Run Portfolio";
+  }
+  return "Joint Portfolio";
+}
+
+export function parseModelJobSummary(job: RecordRow | undefined): Record<string, unknown> {
+  const summary = job?.summary;
+  if (!summary) {
+    return {};
+  }
+  if (typeof summary === "object") {
+    return summary as Record<string, unknown>;
+  }
+  try {
+    return JSON.parse(String(summary)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,0 +1,692 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { App } from "../src/App";
+
+vi.mock("plotly.js-dist-min", () => ({ default: {} }));
+vi.mock("react-plotly.js/factory", () => ({
+  default: () =>
+    function MockPlot() {
+      return <div data-testid="plotly-chart" />;
+    },
+}));
+
+const figure = {
+  data: [{ x: ["2025-01-03"], y: [1], type: "scatter" }],
+  layout: { title: { text: "Chart" } },
+};
+
+const statusPayload = {
+  title: "AllCaps",
+  mode: "private",
+  state_root: "/tmp/allcaps",
+  db_path: "/tmp/allcaps/workbench.duckdb",
+  source_mode: { mode: "truth_only", truth_post_count: 42, x_post_count: 0 },
+  missing_core_datasets: [],
+  dataset_count: 12,
+};
+
+const runsPayload = {
+  count: 2,
+  runs: [
+    {
+      run_id: "run-portfolio-1",
+      run_name: "Portfolio Alpha",
+      run_type: "portfolio_allocator",
+      allocator_mode: "joint_model",
+      target_asset: "PORTFOLIO",
+      total_return: 0.12,
+      robust_score: 0.4,
+    },
+    {
+      run_id: "run-asset-1",
+      run_name: "SPY Baseline",
+      run_type: "asset_model",
+      allocator_mode: "",
+      target_asset: "SPY",
+      robust_score: 0.2,
+    },
+  ],
+};
+
+const runsPayloadExtended = {
+  count: 3,
+  runs: [
+    ...runsPayload.runs,
+    {
+      run_id: "run-asset-2",
+      run_name: "QQQ Baseline",
+      run_type: "asset_model",
+      allocator_mode: "",
+      target_asset: "QQQ",
+      robust_score: 0.15,
+    },
+  ],
+};
+
+const healthPayload = {
+  summary: {
+    overall_severity: "warn",
+    severe_count: 0,
+    warn_count: 1,
+    last_refresh_status: "success",
+    last_refresh_mode: "full",
+  },
+  latest: [{ scope_kind: "dataset", scope_key: "asset_intraday", check_name: "freshness_hours", severity: "warn" }],
+  trend: [{ generated_at: "2025-01-03T12:00:00Z", warn_count: 1, severe_count: 0 }],
+  refresh_history: [{ refresh_id: "refresh-1", refresh_mode: "full", status: "success" }],
+  registry: [{ dataset: "normalized_posts", row_count: 42 }],
+};
+
+const datasetAdminPayload = {
+  ...healthPayload,
+  admin: { mode: "private", write_requires_unlock: true },
+  status: {
+    operating_mode: "Truth Social-only",
+    source_mode: statusPayload.source_mode,
+    state_root: statusPayload.state_root,
+    db_path: statusPayload.db_path,
+    scheduler_enabled: false,
+    missing_core_datasets: [],
+    missing_core_dataset_count: 0,
+    last_refresh: { status: "success" },
+    active_job_id: "",
+  },
+  watchlist_symbols: ["NVDA", "QQQ"],
+  asset_universe: [{ symbol: "NVDA", source: "watchlist" }],
+  source_manifests: [{ source_name: "truth_archive", status: "success" }],
+  asset_market_manifest: [{ symbol: "NVDA", status: "success" }],
+  refresh_jobs: [{ job_id: "dataset-refresh-1", refresh_mode: "full", status: "success" }],
+};
+
+const datasetAdminAfterRefresh = {
+  ...datasetAdminPayload,
+  job_id: "dataset-refresh-2",
+  refresh_jobs: [
+    { job_id: "dataset-refresh-2", refresh_mode: "full", status: "success" },
+    ...datasetAdminPayload.refresh_jobs,
+  ],
+};
+
+const researchPayload = {
+  ready: true,
+  message: "",
+  source_mode: statusPayload.source_mode,
+  filters: {
+    date_start: "2025-01-01",
+    date_end: "2025-01-31",
+    platforms: ["Truth Social"],
+    include_reshares: false,
+    tracked_only: false,
+    trump_authored_only: true,
+    keyword: "",
+    scale_markers: true,
+    narrative_platforms: ["Truth Social"],
+  },
+  headline_metrics: { sessions_with_posts: 2, posts_in_view: 3, truth_posts: 3, mean_sentiment: 0.2 },
+  charts: {
+    social_activity: figure,
+    narrative_frequency: figure,
+    narrative_returns: figure,
+    narrative_asset_heatmap: figure,
+  },
+  session_rows: [{ signal_session_date: "2025-01-03", author_handle: "realDonaldTrump", post_count: 2 }],
+  post_rows: [{ post_id: "post-1", author_handle: "realDonaldTrump", text: "Markets" }],
+  narrative_filter_options: {
+    topics: ["All", "markets"],
+    policy_buckets: ["All", "trade"],
+    stances: ["All", "positive"],
+    urgency_bands: ["All", "high"],
+    assets: ["All", "SPY"],
+    platforms: ["Truth Social"],
+    tracked_scopes: ["All posts", "Tracked only"],
+    bucket_fields: [{ value: "semantic_topic", label: "Topic" }],
+  },
+  narrative_metrics: { narrative_tagged_posts: 3, narrative_sessions: 2, cache_hit_rate: 1, providers_used: 1 },
+  provider_summary: [{ semantic_provider: "heuristic-fallback", row_count: 3 }],
+  narrative_frequency: [{ semantic_topic: "markets", post_count: 3 }],
+  narrative_returns: [{ semantic_topic: "markets", next_return: 0.01 }],
+  narrative_asset_heatmap: [{ asset_symbol: "SPY", semantic_topic: "markets", post_count: 2 }],
+  narrative_posts: [{ post_id: "post-1", semantic_topic: "markets" }],
+  narrative_events: [{ signal_session_date: "2025-01-03", semantic_topic: "markets" }],
+  export_filename: "research-pack.zip",
+};
+
+const researchAssetPayload = {
+  ready: true,
+  message: "",
+  source_mode: statusPayload.source_mode,
+  filters: researchPayload.filters,
+  controls: {
+    selected_asset: "NVDA",
+    comparison_mode: "normalized",
+    benchmark_symbol: "QQQ",
+    pre_sessions: 3,
+    post_sessions: 5,
+    before_minutes: 120,
+    after_minutes: 240,
+    intraday_session_date: "2025-01-03",
+    intraday_anchor_post_id: "post-1",
+  },
+  asset_options: [{ symbol: "NVDA", label: "NVDA", source: "watchlist", is_watchlist: true, has_daily: true }],
+  benchmark_options: ["None", "QQQ"],
+  headline_metrics: { sessions_in_range: 2, asset_move: 0.03, mapped_post_count: 2, intraday_bars: 10 },
+  charts: { overlay: figure, event_study: figure, intraday: figure },
+  asset_session_rows: [{ signal_session_date: "2025-01-03", asset_symbol: "NVDA" }],
+  mapped_post_rows: [{ post_id: "post-1", match_reasons: "semantic_primary_asset" }],
+  event_study_rows: [{ relative_session: 0, asset_symbol: "NVDA" }],
+  intraday_anchor_options: [{ anchor_id: "post-1", session_date: "2025-01-03", label: "Trump post", post_timestamp: "2025-01-03T14:00:00Z" }],
+  intraday_coverage_rows: [{ symbol: "NVDA", bars: 10 }],
+  intraday_window_rows: [{ timestamp: "2025-01-03T14:00:00Z", symbol: "NVDA", close: 101 }],
+  empty_states: {},
+};
+
+const discoveryPayload = {
+  ready: true,
+  message: "Rankings available",
+  source_mode: { mode: "truth_plus_x", truth_post_count: 42, x_post_count: 10 },
+  latest_ranked_at: "2025-01-03T12:00:00Z",
+  admin: { mode: "private", writes_enabled: true, write_disabled_reason: "" },
+  summary: { x_candidate_post_count: 10, active_account_count: 2, latest_ranking_count: 2, override_count: 2 },
+  charts: { top_discovered_accounts: figure, ranking_history: figure },
+  active_accounts: [{ account_id: "acct-1", handle: "macroalpha" }],
+  latest_rankings: [{ account_id: "acct-1", handle: "macroalpha", discovery_score: 0.9, suppressed_by_override: false }],
+  override_account_options: [
+    { account_id: "acct-1", handle: "macroalpha", display_name: "Macro Alpha", source_platform: "X", status: "candidate", source: "ranking", label: "@macroalpha" },
+    { account_id: "acct-muted", handle: "policywatch", display_name: "Policy Watch", source_platform: "X", status: "candidate", source: "ranking", label: "@policywatch" },
+  ],
+  override_history: [{ override_id: "override-pin", account_id: "acct-1", handle: "macroalpha", action: "pin", effective_from: "2025-01-01" }],
+  recent_ranking_history: [{ ranked_at: "2025-01-03T12:00:00Z", handle: "macroalpha", discovery_score: 0.9 }],
+};
+
+const runDetailPayload = {
+  found: true,
+  run_id: "run-portfolio-1",
+  errors: [],
+  run: { run_id: "run-portfolio-1", run_name: "Portfolio Alpha" },
+  settings: {
+    run_type: "portfolio_allocator",
+    target_asset: "PORTFOLIO",
+    deployment_variant: "per_asset_hybrid",
+    deployment_narrative_feature_mode: "hybrid",
+    allocator_mode: "joint_model",
+  },
+  metrics: { total_return: 0.12, robust_score: 0.4, max_drawdown: -0.03 },
+  selected_params: {},
+  model_artifact: { feature_count: 12 },
+  charts: { equity: figure, benchmarks: figure, diagnostics: figure },
+  tables: {
+    variant_summary: [{ variant_name: "per_asset_hybrid", topology: "per_asset", narrative_feature_mode: "hybrid", deployment_winner: true }],
+    narrative_lift: [{ narrative_feature_mode: "hybrid", robust_score_lift: 0.1 }],
+    feature_family_summary: [{ feature_family: "semantic", contribution_abs_sum: 1.2 }],
+    feature_importance: [{ feature: "post_count", importance: 0.5 }],
+    diagnostics: [{ metric: "miss", value: 1 }],
+    trades: [{ asset_symbol: "QQQ", net_return: 0.01 }],
+  },
+  row_counts: { trades: 3 },
+  session_options: [{ value: "2025-01-03", label: "2025-01-03" }],
+  selected_session: {
+    decision: [{ winning_asset: "QQQ", stance: "LONG" }],
+    prediction: [{ asset_symbol: "QQQ" }],
+    candidates: [{ asset_symbol: "QQQ", expected_return_score: 0.03 }],
+    feature_contributions: [{ feature: "semantic_score", contribution: 0.1 }],
+    post_attribution: [{ author_handle: "realDonaldTrump", text: "Markets" }],
+    account_attribution: [{ author_handle: "macroalpha", contribution: 0.2 }],
+  },
+  leakage_audit: {},
+};
+
+const runComparisonPayload = {
+  ready: true,
+  base_run_id: "run-portfolio-1",
+  run_ids: ["run-portfolio-1", "run-asset-1"],
+  missing_run_ids: [],
+  scorecard: [{ run_name: "SPY Baseline", total_return: 0.04 }],
+  setting_diffs: [{ setting: "fallback_mode", run_value: "SPY" }],
+  feature_diffs: [{ feature: "semantic_score", status: "added" }],
+  benchmark_deltas: [{ benchmark: "SPY", delta: 0.02 }],
+  change_notes: ["run-asset-1: robust score changed"],
+  charts: { equity: figure },
+};
+
+const replayPayload = {
+  ready: true,
+  message: "",
+  selected_run_id: "run-asset-1",
+  selected_session_date: "2025-03-03",
+  min_history_rows: 20,
+  run_options: [
+    { run_id: "run-asset-1", run_name: "SPY Baseline", target_asset: "SPY", run_type: "asset_model", allocator_mode: "" },
+    { run_id: "run-asset-2", run_name: "QQQ Baseline", target_asset: "QQQ", run_type: "asset_model", allocator_mode: "" },
+  ],
+  sessions: [
+    { value: "2025-03-03", label: "2025-03-03", signal_session_date: "2025-03-03", post_count: 3, history_rows_available: 30 },
+    { value: "2025-03-04", label: "2025-03-04", signal_session_date: "2025-03-04", post_count: 4, history_rows_available: 31 },
+  ],
+  summary: { asset_model_run_count: 1, eligible_session_count: 1 },
+};
+
+const replaySessionPayload = {
+  ready: true,
+  message: "",
+  run_id: "run-asset-1",
+  run_name: "SPY Baseline",
+  target_asset: "SPY",
+  signal_session_date: "2025-03-03",
+  metrics: {
+    target_asset: "SPY",
+    replay_session: "2025-03-03",
+    replay_score: 0.02,
+    replay_confidence: 0.7,
+    suggested_stance: "LONG SPY NEXT SESSION",
+    training_rows_used: 30,
+    full_history_score: 0.021,
+    replay_vs_full_history_drift: 0.001,
+    actual_next_session_return: 0.005,
+  },
+  metadata: { full_history_comparison_available: true, deployment_params: { threshold: 0.01, min_post_count: 2 } },
+  prediction: [{ signal_session_date: "2025-03-03", expected_return_score: 0.02 }],
+  comparison_rows: [{ check: "Replay vs full-history drift", value: 0.001 }],
+  feature_importance: [{ feature: "post_count", importance: 0.5 }],
+  feature_contributions: [{ feature: "sentiment", contribution: 0.1 }],
+  post_attribution: [{ author_handle: "realDonaldTrump", text: "Post" }],
+  account_attribution: [{ author_handle: "realDonaldTrump", contribution: 0.3 }],
+};
+
+const modelTrainingPayload = {
+  admin: { write_requires_unlock: true },
+  status: { ready: true, active_job_id: "", readiness_errors: { single_asset: [], saved_run_portfolio: [], joint_portfolio: [] } },
+  defaults: { single_asset: {}, saved_run_portfolio: {}, joint_portfolio: { feature_version: "asset-v1", selected_symbols: ["SPY", "QQQ", "NVDA"] } },
+  asset_options: [{ symbol: "SPY", label: "SPY" }, { symbol: "QQQ", label: "QQQ" }],
+  feature_versions: ["asset-v1"],
+  asset_session_symbols: ["SPY", "QQQ", "NVDA"],
+  narrative_feature_modes: ["baseline", "hybrid"],
+  model_families: ["ridge", "elastic_net"],
+  topology_variants: ["per_asset", "pooled"],
+  run_options: runsPayloadExtended.runs,
+  asset_model_runs: [
+    { run_id: "run-asset-1", run_name: "SPY Baseline", target_asset: "SPY", robust_score: 0.2 },
+    { run_id: "run-asset-2", run_name: "QQQ Baseline", target_asset: "QQQ", robust_score: 0.15 },
+  ],
+  recent_jobs: [{ job_id: "model-training-1", workflow_mode: "joint_portfolio", status: "success", run_id: "run-portfolio-1", summary: JSON.stringify({ metrics: { total_return: 0.12 } }) }],
+};
+
+const modelTrainingStartedPayload = {
+  ...modelTrainingPayload,
+  job_id: "model-training-2",
+  recent_jobs: [{ job_id: "model-training-2", workflow_mode: "joint_portfolio", status: "success", run_id: "run-portfolio-2", summary: JSON.stringify({ metrics: { total_return: 0.2 } }) }],
+};
+
+const liveOpsPayload = {
+  configured: true,
+  errors: [],
+  warnings: [],
+  decision: { winning_asset: "QQQ", decision_source: "eligible", winner_score: 0.03, eligible_asset_count: 2 },
+  board: [{ asset_symbol: "QQQ", qualifies: true, expected_return_score: 0.03 }, { asset_symbol: "SPY", qualifies: true, expected_return_score: 0.02 }],
+  admin: { mode: "private", write_requires_unlock: true, capture_scope: "stored_data_only" },
+  current_config: { portfolio_run_id: "run-portfolio-1", fallback_mode: "SPY" },
+  seeded_config: null,
+  run_options: [{ run_id: "run-portfolio-1", run_name: "Portfolio Alpha", deployment_variant: "per_asset_hybrid", selected_symbols: "SPY,QQQ" }],
+  asset_history: [{ generated_at: "2025-01-03T12:00:00Z", asset_symbol: "QQQ", expected_return_score: 0.03 }],
+  decision_history: [{ signal_session_date: "2025-01-03", winning_asset: "QQQ" }],
+  paper: {
+    current_config: { paper_portfolio_id: "paper-1" },
+    active_config: { paper_portfolio_id: "paper-1", enabled: true, starting_cash: 100000, transaction_cost_bps: 2 },
+    portfolios: [{ paper_portfolio_id: "paper-1", portfolio_run_name: "Portfolio Alpha", enabled: true }],
+    decision_journal: [{ paper_portfolio_id: "paper-1", status: "pending", winning_asset: "QQQ" }],
+    trade_ledger: [{ asset_symbol: "QQQ", net_return: 0.01 }],
+    equity_curve: [{ paper_portfolio_id: "paper-1", equity: 101000 }],
+    benchmark_curve: [{ paper_portfolio_id: "paper-1", equity: 100500 }],
+  },
+  capture_result: { persisted_assets: 2, persisted_decisions: 1, captured: 1, settled: 0, performance_persisted: true },
+};
+
+const portfoliosPayload = {
+  current_config: { paper_portfolio_id: "paper-1" },
+  portfolios: [
+    { paper_portfolio_id: "paper-1", portfolio_run_name: "Portfolio Alpha" },
+    { paper_portfolio_id: "paper 2", portfolio_run_name: "Portfolio Beta" },
+  ],
+};
+
+const performancePayload = {
+  persisted: true,
+  summary: { overall_severity: "ok", total_return: 0.01, alpha: 0.005, fallback_rate: 0.1 },
+  diagnostics: [{ metric_name: "score_outcome_correlation", severity: "warn", observed_value: 0.1 }],
+  equity_comparison: [],
+  rolling_returns: [],
+  score_outcomes: [],
+  score_buckets: [],
+  winner_distribution: [{ winning_asset: "QQQ", decision_count: 7 }],
+  drift: [],
+};
+
+function payloadFor(pathname: string, method = "GET") {
+  if (pathname === "/api/status") return statusPayload;
+  if (pathname === "/api/datasets/health") return healthPayload;
+  if (pathname === "/api/datasets/admin") return datasetAdminPayload;
+  if (pathname === "/api/datasets/watchlist") return datasetAdminPayload;
+  if (pathname === "/api/datasets/refresh") return datasetAdminAfterRefresh;
+  if (pathname === "/api/datasets/jobs/dataset-refresh-2") return { job_id: "dataset-refresh-2", found: true, job: datasetAdminAfterRefresh.refresh_jobs[0], recent_jobs: datasetAdminAfterRefresh.refresh_jobs };
+  if (pathname === "/api/runs") return runsPayloadExtended;
+  if (pathname === "/api/models/training") return modelTrainingPayload;
+  if (pathname === "/api/models/jobs") return modelTrainingStartedPayload;
+  if (pathname === "/api/models/jobs/model-training-2") return { job_id: "model-training-2", found: true, job: modelTrainingStartedPayload.recent_jobs[0], recent_jobs: modelTrainingStartedPayload.recent_jobs };
+  if (pathname === "/api/runs/run-portfolio-1") return runDetailPayload;
+  if (pathname === "/api/runs/run-asset-1") return { ...runDetailPayload, run_id: "run-asset-1", run: { run_id: "run-asset-1", run_name: "SPY Baseline" }, settings: { run_type: "asset_model", target_asset: "SPY" } };
+  if (pathname === "/api/runs/run-asset-2") return { ...runDetailPayload, run_id: "run-asset-2", run: { run_id: "run-asset-2", run_name: "QQQ Baseline" }, settings: { run_type: "asset_model", target_asset: "QQQ" } };
+  if (pathname === "/api/runs/compare") return runComparisonPayload;
+  if (pathname === "/api/replay") return replayPayload;
+  if (pathname === "/api/replay/session") return replaySessionPayload;
+  if (pathname === "/api/research/assets") return researchAssetPayload;
+  if (pathname === "/api/research") return researchPayload;
+  if (pathname === "/api/discovery") return discoveryPayload;
+  if (pathname === "/api/admin/session") return { token: "admin-token", token_type: "bearer", expires_at: "2026-04-21T12:00:00Z", expires_in_seconds: 43200, mode: "private" };
+  if (pathname === "/api/discovery/overrides" && method === "POST") return discoveryPayload;
+  if (pathname.startsWith("/api/discovery/overrides/") && method === "DELETE") return { ...discoveryPayload, override_history: [] };
+  if (pathname === "/api/live/current") return liveOpsPayload;
+  if (pathname === "/api/live/ops") return liveOpsPayload;
+  if (pathname === "/api/live/config") return liveOpsPayload;
+  if (pathname === "/api/live/capture") return liveOpsPayload;
+  if (pathname === "/api/paper/current") return liveOpsPayload;
+  if (pathname === "/api/paper/portfolios") return portfoliosPayload;
+  if (pathname === "/api/performance/paper-1") return performancePayload;
+  if (pathname === "/api/performance/paper%202") return { ...performancePayload, summary: { ...performancePayload.summary, total_return: 0.02 } };
+  return { error: `No fixture for ${method} ${pathname}` };
+}
+
+function installFetchMock() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const payload = payloadFor(url.pathname, method);
+    return new Response(JSON.stringify(payload), {
+      status: "error" in payload ? 404 : 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function renderApp() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>,
+  );
+}
+
+describe("App component", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    installFetchMock();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  test("renders every primary page from mocked API data", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    expect(await screen.findByRole("heading", { name: "Web-first decision workbench" })).toBeInTheDocument();
+    expect(await screen.findByText("truth_only (42 Truth, 0 X)")).toBeInTheDocument();
+    expect(screen.getByText("Portfolio Alpha")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /ResearchSentiment/ }));
+    expect(await screen.findByRole("heading", { name: "Research workspace" })).toBeInTheDocument();
+    expect(screen.getByText(/Truth Social-only mode is active/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Export research pack" })).toHaveAttribute("href", expect.stringContaining("/api/research/export"));
+    expect(await screen.findByRole("heading", { name: "Multi-asset comparison, event study, and intraday reaction" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /DiscoveryTracked/ }));
+    expect(await screen.findByRole("heading", { name: "Discovery workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Discovery admin overrides" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Run ExplorerSaved/ }));
+    expect(await screen.findByRole("heading", { name: "Run Explorer" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Variant comparison" })).toBeInTheDocument();
+    expect(screen.getByText("run-asset-1: robust score changed")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /ReplayHistorical/ }));
+    expect(await screen.findByRole("heading", { name: "Historical Replay Workspace" })).toBeInTheDocument();
+    expect(await screen.findByText("LONG SPY NEXT SESSION")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Model TrainingTrain/ }));
+    expect(await screen.findByRole("heading", { name: "Model Training Job Console" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Use Joint Portfolio workflow" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Data AdminRefresh/ }));
+    expect(await screen.findByRole("heading", { name: "Data Admin Console" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Watchlist controls" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Live OpsOperate/ }));
+    expect(await screen.findByRole("heading", { name: "Live Ops Console" })).toBeInTheDocument();
+    expect(screen.getByText("Stored-data capture only")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Paper \+ PerformancePortfolio/ }));
+    expect(await screen.findByRole("heading", { name: "Portfolio selector" })).toBeInTheDocument();
+    expect(await screen.findByText("score_outcome_correlation")).toBeInTheDocument();
+  });
+
+  test("supports admin mutations from React pages", async () => {
+    const user = userEvent.setup();
+    const fetchMock = installFetchMock();
+    renderApp();
+
+    await user.click(await screen.findByRole("button", { name: /Data AdminRefresh/ }));
+    await user.type(screen.getByPlaceholderText(/password/i), "secret");
+    await user.click(screen.getByRole("button", { name: "Unlock admin writes" }));
+    expect(await screen.findByText("Unlocked for this browser session")).toBeInTheDocument();
+    await user.clear(screen.getByLabelText("Watchlist symbols"));
+    await user.type(screen.getByLabelText("Watchlist symbols"), "NVDA, TSLA");
+    await user.click(screen.getByRole("button", { name: "Save watchlist" }));
+    await user.type(screen.getByLabelText("Remote X / mention CSV URL"), "https://example.invalid/mentions.csv");
+    await user.click(screen.getByRole("button", { name: "Start refresh job" }));
+    expect(await screen.findByRole("cell", { name: "dataset-refresh-2" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /DiscoveryTracked/ }));
+    await user.selectOptions(screen.getByLabelText("Override account"), "acct-muted");
+    await user.selectOptions(screen.getByLabelText("Override action"), "suppress");
+    await user.type(screen.getByPlaceholderText("Optional rationale"), "Noisy source");
+    await user.click(screen.getByRole("button", { name: "Save discovery override" }));
+    await user.selectOptions(screen.getByLabelText("Override to delete"), "override-pin");
+    await user.click(screen.getByRole("button", { name: "Delete selected override" }));
+    await waitFor(() => expect(screen.queryByText("override-pin")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /Model TrainingTrain/ }));
+    await user.click(screen.getByRole("button", { name: "Use Single Asset workflow" }));
+    expect(screen.getByRole("heading", { name: "Single Asset configuration" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Use Saved-Run Portfolio workflow" }));
+    expect(screen.getByRole("heading", { name: "Saved-Run Portfolio configuration" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Use Joint Portfolio workflow" }));
+    await user.click(screen.getByRole("button", { name: "Start model training job" }));
+    expect(await screen.findByRole("heading", { name: "Latest training result" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Live OpsOperate/ }));
+    await user.click(screen.getByRole("button", { name: "Save pinned portfolio run" }));
+    await user.click(screen.getByRole("button", { name: "Capture current board" }));
+    await user.click(screen.getByRole("button", { name: "Disable paper trading" }));
+
+    const requestedPaths = fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname);
+    expect(requestedPaths).toContain("/api/datasets/watchlist");
+    expect(requestedPaths).toContain("/api/datasets/refresh");
+    expect(requestedPaths).toContain("/api/discovery/overrides");
+    expect(requestedPaths).toContain("/api/models/jobs");
+    expect(requestedPaths).toContain("/api/live/config");
+    expect(requestedPaths).toContain("/api/live/capture");
+    expect(requestedPaths).toContain("/api/paper/current");
+  });
+
+  test("drives read-only research, run, replay, and performance controls", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(await screen.findByRole("button", { name: /ResearchSentiment/ }));
+    await user.clear(screen.getByLabelText("Start date"));
+    await user.type(screen.getByLabelText("Start date"), "2025-01-02");
+    await user.clear(screen.getByLabelText("End date"));
+    await user.type(screen.getByLabelText("End date"), "2025-01-30");
+    await user.selectOptions(screen.getByLabelText("Platforms"), ["Truth Social", "X"]);
+    await user.type(screen.getByPlaceholderText("Optional exact text filter"), "tariff");
+    await user.click(screen.getByLabelText("Trump-authored only"));
+    await user.click(screen.getByLabelText("Include reshares"));
+    await user.click(screen.getByLabelText("Trump + tracked only"));
+    await user.click(screen.getByLabelText("Scale activity"));
+    await user.selectOptions(screen.getByLabelText("Topic"), "markets");
+    await user.selectOptions(screen.getByLabelText("Policy bucket"), "trade");
+    await user.selectOptions(screen.getByLabelText("Stance"), "positive");
+    await user.selectOptions(screen.getByLabelText("Urgency"), "high");
+    await user.selectOptions(screen.getByLabelText("Asset target"), "SPY");
+    await user.selectOptions(screen.getByLabelText("Return bucket"), "semantic_topic");
+    await user.selectOptions(screen.getByLabelText("Narrative platforms"), ["Truth Social"]);
+    await user.selectOptions(screen.getByLabelText("Tracked scope"), "Tracked only");
+    await user.selectOptions(screen.getByLabelText("Selected asset"), "NVDA");
+    await user.selectOptions(screen.getByLabelText("Comparison mode"), "price");
+    await user.selectOptions(screen.getByLabelText("ETF baseline"), "QQQ");
+    await user.selectOptions(screen.getByLabelText("Intraday anchor"), "post-1");
+    await user.clear(screen.getByLabelText("Sessions before"));
+    await user.type(screen.getByLabelText("Sessions before"), "2");
+    await user.clear(screen.getByLabelText("Sessions after"));
+    await user.type(screen.getByLabelText("Sessions after"), "4");
+    await user.clear(screen.getByLabelText("Minutes before"));
+    await user.type(screen.getByLabelText("Minutes before"), "90");
+    await user.clear(screen.getByLabelText("Minutes after"));
+    await user.type(screen.getByLabelText("Minutes after"), "300");
+    expect(await screen.findByRole("heading", { name: "Intraday reaction" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Run ExplorerSaved/ }));
+    await user.selectOptions(await screen.findByLabelText("Run type"), "asset_model");
+    await user.selectOptions(screen.getByLabelText("Target asset"), "QQQ");
+    await user.type(screen.getByPlaceholderText("Run name, id, or asset"), "Baseline");
+    await user.selectOptions(screen.getByLabelText("Selected run"), "run-asset-2");
+    await user.selectOptions(screen.getByLabelText("Variant"), "per_asset_hybrid");
+    await user.selectOptions(screen.getByLabelText("Session inspector"), "2025-01-03");
+    await user.selectOptions(screen.getByLabelText("Compare runs"), ["run-portfolio-1", "run-asset-2"]);
+    await user.selectOptions(screen.getByLabelText("Base run"), "run-asset-2");
+    await waitFor(() => expect(screen.getAllByText("QQQ Baseline").length).toBeGreaterThan(0));
+
+    await user.click(screen.getByRole("button", { name: /ReplayHistorical/ }));
+    await user.selectOptions(await screen.findByLabelText("Replay template run"), "run-asset-2");
+    await user.selectOptions(screen.getByLabelText("Historical signal session"), "2025-03-04");
+    expect(await screen.findByText("LONG SPY NEXT SESSION")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Paper \+ PerformancePortfolio/ }));
+    await user.selectOptions(await screen.findByRole("combobox"), "paper 2");
+    expect(await screen.findByText("score_outcome_correlation")).toBeInTheDocument();
+  });
+
+  test("drives admin configuration controls across model, data, and live ops", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(await screen.findByRole("button", { name: /Model TrainingTrain/ }));
+    await user.type(screen.getByPlaceholderText("Admin password"), "secret");
+    await user.click(screen.getByRole("button", { name: "Unlock admin writes" }));
+    expect(await screen.findByText("Unlocked for this browser session")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Use Single Asset workflow" }));
+    await user.clear(screen.getByLabelText("Run name"));
+    await user.type(screen.getByLabelText("Run name"), "single-asset-smoke");
+    await user.selectOptions(screen.getByLabelText("Target asset"), "QQQ");
+    await user.selectOptions(screen.getByLabelText("Feature version"), "asset-v1");
+    await user.click(screen.getByLabelText("Use semantic rows"));
+    await user.clear(screen.getByLabelText("Train window"));
+    await user.type(screen.getByLabelText("Train window"), "100");
+    await user.clear(screen.getByLabelText("Validation window"));
+    await user.type(screen.getByLabelText("Validation window"), "35");
+    await user.clear(screen.getByLabelText("Test window"));
+    await user.type(screen.getByLabelText("Test window"), "40");
+    await user.clear(screen.getByLabelText("Step size"));
+    await user.type(screen.getByLabelText("Step size"), "20");
+    await user.clear(screen.getByLabelText("Transaction cost bps"));
+    await user.type(screen.getByLabelText("Transaction cost bps"), "3");
+    await user.clear(screen.getByLabelText("Ridge alpha"));
+    await user.type(screen.getByLabelText("Ridge alpha"), "2");
+    await user.clear(screen.getByLabelText("Threshold grid"));
+    await user.type(screen.getByLabelText("Threshold grid"), "0,0.01");
+    await user.clear(screen.getByLabelText("Min post grid"));
+    await user.type(screen.getByLabelText("Min post grid"), "1,3");
+    await user.clear(screen.getByLabelText("Account weight grid"));
+    await user.type(screen.getByLabelText("Account weight grid"), "1,2");
+
+    await user.click(screen.getByRole("button", { name: "Use Saved-Run Portfolio workflow" }));
+    await user.selectOptions(screen.getByLabelText("Component runs"), ["run-asset-1", "run-asset-2"]);
+    await user.selectOptions(screen.getByLabelText("Fallback mode"), "FLAT");
+    await user.click(screen.getByRole("button", { name: "Use Joint Portfolio workflow" }));
+    await user.clear(screen.getByLabelText("Selected symbols"));
+    await user.type(screen.getByLabelText("Selected symbols"), "SPY, QQQ");
+    await user.selectOptions(screen.getByLabelText("Topology variants"), ["pooled"]);
+    await user.selectOptions(screen.getByLabelText("Model families"), ["ridge"]);
+    await user.selectOptions(screen.getByLabelText("Narrative modes"), ["hybrid"]);
+    await user.click(screen.getByRole("button", { name: "Start model training job" }));
+    expect(await screen.findByText("run-portfolio-2")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Data AdminRefresh/ }));
+    await user.click(screen.getByRole("button", { name: "Reset watchlist" }));
+    await user.selectOptions(screen.getByLabelText("Refresh mode"), "full");
+    const file = new File(["author,text\nmacro,hello\n"], "mentions.csv", { type: "text/csv" });
+    await user.upload(screen.getByLabelText("CSV upload"), file);
+
+    await user.click(screen.getByRole("button", { name: /Live OpsOperate/ }));
+    await user.selectOptions(screen.getByLabelText("Pinned joint portfolio run"), "run-portfolio-1");
+    await user.selectOptions(screen.getByLabelText("Fallback mode"), "FLAT");
+    await user.clear(screen.getByLabelText("Starting cash"));
+    await user.type(screen.getByLabelText("Starting cash"), "125000");
+    await user.click(screen.getByRole("button", { name: "Enable paper trading" }));
+    await user.click(screen.getByRole("button", { name: "Archive current portfolio" }));
+    await user.clear(screen.getByLabelText("Reset cash"));
+    await user.type(screen.getByLabelText("Reset cash"), "90000");
+    await user.click(screen.getByRole("button", { name: "Reset portfolio" }));
+    await waitFor(() => expect(screen.getAllByText("paper-1").length).toBeGreaterThan(0));
+  });
+
+  test("shows empty and error states without crashing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const path = new URL(String(input)).pathname;
+        if (path === "/api/status") {
+          return new Response(JSON.stringify(statusPayload), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+        if (path === "/api/runs") {
+          return new Response(JSON.stringify({ count: 0, runs: [] }), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+        return new Response(JSON.stringify({ detail: "broken" }), { status: 500, statusText: "Server Error", headers: { "Content-Type": "application/json" } });
+      }),
+    );
+    const user = userEvent.setup();
+    renderApp();
+
+    expect(await screen.findByText("No rows returned yet.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Run ExplorerSaved/ }));
+    expect(await screen.findByText("No saved runs have been created yet. Train a model in the Model Training tab first, then return here.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /ResearchSentiment/ }));
+    expect(await screen.findByText("API request failed: 500 Server Error")).toBeInTheDocument();
+  });
+
+  test("renders a table empty state and limited columns", async () => {
+    renderApp();
+    const recentRunsHeading = await screen.findByRole("heading", { name: "Recent saved runs" });
+    const recentRuns = recentRunsHeading.closest("article");
+    expect(recentRuns).not.toBeNull();
+    expect(within(recentRuns as HTMLElement).getByRole("columnheader", { name: "run id" })).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { api } from "../src/api";
+
+type FetchCall = {
+  url: string;
+  init?: RequestInit;
+};
+
+const calls: FetchCall[] = [];
+
+function mockFetch(status = 200, body: unknown = { ok: true }, statusText = "OK") {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify(body), {
+      status,
+      statusText,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("frontend API client", () => {
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("builds GET URLs with encoded research filters", async () => {
+    mockFetch(200, { ready: true });
+
+    await api.research({
+      platforms: ["Truth Social", "X"],
+      keyword: "tariff rally",
+      include_reshares: false,
+      tracked_only: true,
+      narrative_platforms: ["Truth Social"],
+      narrative_topic: "",
+    });
+
+    const url = new URL(calls[0].url);
+    expect(url.pathname).toBe("/api/research");
+    expect(url.searchParams.getAll("platforms")).toEqual(["Truth Social", "X"]);
+    expect(url.searchParams.get("keyword")).toBe("tariff rally");
+    expect(url.searchParams.get("include_reshares")).toBe("false");
+    expect(url.searchParams.get("tracked_only")).toBe("true");
+    expect(url.searchParams.getAll("narrative_platforms")).toEqual(["Truth Social"]);
+    expect(url.searchParams.has("narrative_topic")).toBe(false);
+  });
+
+  test("builds read endpoint URLs with encoded path and query values", async () => {
+    mockFetch(200, { found: true });
+
+    await api.runDetail("run/with slash", { variantName: "per asset", sessionDate: "2025-01-03" });
+    await api.runComparison(["run-1", "run 2"], "run-1");
+    await api.replay("run 1");
+    await api.replaySession("run 1", "2025-01-03");
+    await api.performance("paper 1");
+
+    expect(calls[0].url).toContain("/api/runs/run%2Fwith%20slash");
+    expect(calls[0].url).toContain("variant_name=per+asset");
+    expect(calls[1].url).toContain("/api/runs/compare");
+    expect(calls[1].url).toContain("run_ids=run-1");
+    expect(calls[1].url).toContain("run_ids=run+2");
+    expect(calls[2].url).toContain("/api/replay?run_id=run+1");
+    expect(calls[3].url).toContain("/api/replay/session?run_id=run+1&signal_session_date=2025-01-03");
+    expect(calls[4].url).toContain("/api/performance/paper%201");
+  });
+
+  test("sends JSON writes with bearer tokens", async () => {
+    mockFetch(200, { token: "next" });
+
+    await api.adminSession("secret");
+    await api.saveWatchlist(["SPY", "QQQ"], false, "token-1");
+    await api.startModelTrainingJob({ workflow_mode: "joint_portfolio", selected_symbols: ["SPY"] }, "token-2");
+    await api.createDiscoveryOverride({ account_id: "acct-1", action: "pin", effective_from: "2025-01-01" }, "token-3");
+    await api.deleteDiscoveryOverride("override 1", "token-4");
+    await api.saveLiveConfig({ portfolio_run_id: "run-1", fallback_mode: "SPY" }, "token-5");
+    await api.captureLive("token-6");
+    await api.paperCurrentAction({ action: "reset", starting_cash: 100000 }, "token-7");
+
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ password: "secret" });
+    expect(calls[1].init?.headers).toMatchObject({ Authorization: "Bearer token-1" });
+    expect(JSON.parse(String(calls[1].init?.body))).toEqual({ symbols: ["SPY", "QQQ"], reset: false });
+    expect(calls[2].init?.headers).toMatchObject({ Authorization: "Bearer token-2" });
+    expect(calls[3].init?.headers).toMatchObject({ Authorization: "Bearer token-3" });
+    expect(calls[4].url).toContain("/api/discovery/overrides/override%201");
+    expect(calls[4].init?.method).toBe("DELETE");
+    expect(calls[5].init?.headers).toMatchObject({ Authorization: "Bearer token-5" });
+    expect(calls[6].init?.headers).toMatchObject({ Authorization: "Bearer token-6" });
+    expect(JSON.parse(String(calls[7].init?.body))).toEqual({ action: "reset", starting_cash: 100000 });
+  });
+
+  test("sends dataset refresh uploads as form data", async () => {
+    mockFetch(200, { job_id: "job-1" });
+    const file = new File(["author,text\nmacro,hello\n"], "mentions.csv", { type: "text/csv" });
+
+    await api.startDatasetRefresh({ refresh_mode: "full", remote_url: "https://example.invalid/data.csv", files: [file] }, "token");
+
+    expect(calls[0].init?.method).toBe("POST");
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer token" });
+    const body = calls[0].init?.body;
+    expect(body).toBeInstanceOf(FormData);
+    expect((body as FormData).get("refresh_mode")).toBe("full");
+    expect((body as FormData).get("remote_url")).toBe("https://example.invalid/data.csv");
+    expect((body as FormData).getAll("files")).toHaveLength(1);
+  });
+
+  test("surfaces JSON and non-JSON HTTP errors", async () => {
+    mockFetch(400, { detail: ["bad token", "missing field"] }, "Bad Request");
+    await expect(api.saveWatchlist([], false, "bad")).rejects.toThrow("bad token; missing field");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not-json", { status: 502, statusText: "Bad Gateway" })),
+    );
+    await expect(api.status()).rejects.toThrow("502 Bad Gateway");
+  });
+
+  test("surfaces delete and upload HTTP errors", async () => {
+    mockFetch(409, { detail: "override locked" }, "Conflict");
+    await expect(api.deleteDiscoveryOverride("override-1", "token")).rejects.toThrow("override locked");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not-json", { status: 503, statusText: "Unavailable" })),
+    );
+    await expect(api.deleteDiscoveryOverride("override-1", "token")).rejects.toThrow("503 Unavailable");
+
+    mockFetch(422, { detail: ["bad file", "bad mode"] }, "Unprocessable Entity");
+    await expect(api.startDatasetRefresh({ refresh_mode: "full" }, "token")).rejects.toThrow("bad file; bad mode");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not-json", { status: 504, statusText: "Gateway Timeout" })),
+    );
+    await expect(api.startDatasetRefresh({ refresh_mode: "full" }, "token")).rejects.toThrow("504 Gateway Timeout");
+  });
+
+  test("exposes common read helpers and export URL", async () => {
+    mockFetch(200, { ok: true });
+
+    await api.status();
+    await api.health();
+    await api.datasetAdmin();
+    await api.datasetRefreshJob("job 1");
+    await api.modelTraining();
+    await api.modelTrainingJob("model job");
+    await api.runs();
+    await api.researchAssets({ selected_asset: "NVDA", before_minutes: 120 });
+    await api.discovery();
+    await api.live();
+    await api.liveOps();
+    await api.paperPortfolios();
+
+    expect(calls.map((call) => new URL(call.url).pathname)).toEqual([
+      "/api/status",
+      "/api/datasets/health",
+      "/api/datasets/admin",
+      "/api/datasets/jobs/job%201",
+      "/api/models/training",
+      "/api/models/jobs/model%20job",
+      "/api/runs",
+      "/api/research/assets",
+      "/api/discovery",
+      "/api/live/current",
+      "/api/live/ops",
+      "/api/paper/portfolios",
+    ]);
+    expect(api.researchExportUrl({ platforms: ["Truth Social"], keyword: "jobs" })).toContain(
+      "/api/research/export?platforms=Truth+Social&keyword=jobs",
+    );
+  });
+});

--- a/frontend/tests/appUtils.test.ts
+++ b/frontend/tests/appUtils.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import {
+  deploymentParamRows,
+  formatValue,
+  modelRunLabel,
+  modelWorkflowLabel,
+  parseModelJobSummary,
+  parseSymbolList,
+  recordValue,
+  selectedOptions,
+} from "../src/appUtils";
+
+describe("app utility helpers", () => {
+  test("formats display values consistently", () => {
+    expect(formatValue(null)).toBe("n/a");
+    expect(formatValue(undefined)).toBe("n/a");
+    expect(formatValue("")).toBe("n/a");
+    expect(formatValue(0.1234)).toBe("12.34%");
+    expect(formatValue(12)).toBe("12");
+    expect(formatValue(12.34567)).toBe("12.3457");
+    expect(formatValue("SPY")).toBe("SPY");
+  });
+
+  test("parses symbols and selected DOM options", () => {
+    expect(parseSymbolList("spy, qqq\nnvda  tsla")).toEqual(["SPY", "QQQ", "NVDA", "TSLA"]);
+
+    const select = document.createElement("select");
+    select.multiple = true;
+    ["SPY", "QQQ", "NVDA"].forEach((value, index) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.selected = index !== 1;
+      select.append(option);
+    });
+
+    expect(selectedOptions(select.selectedOptions)).toEqual(["SPY", "NVDA"]);
+  });
+
+  test("normalizes replay deployment parameter rows", () => {
+    expect(recordValue(null)).toBeNull();
+    expect(recordValue(true)).toBe(true);
+    expect(recordValue({ fallback: "SPY" })).toBe('{"fallback":"SPY"}');
+    expect(deploymentParamRows()).toEqual([]);
+    expect(
+      deploymentParamRows({
+        ready: true,
+        message: "",
+        run_id: "run-1",
+        signal_session_date: "2025-01-03",
+        metadata: {
+          deployment_params: {
+            threshold: 0.01,
+            enabled: true,
+            nested: { min_post_count: 2 },
+          },
+        },
+        metrics: {},
+        prediction: [],
+        comparison_rows: [],
+        feature_importance: [],
+        feature_contributions: [],
+        post_attribution: [],
+        account_attribution: [],
+      }),
+    ).toEqual([
+      { parameter: "threshold", value: 0.01 },
+      { parameter: "enabled", value: true },
+      { parameter: "nested", value: '{"min_post_count":2}' },
+    ]);
+  });
+
+  test("labels model rows and workflow modes", () => {
+    expect(modelRunLabel({ run_id: "run-1", run_name: "Baseline", target_asset: "SPY", robust_score: 0.1234 })).toBe(
+      "SPY | Baseline | robust 12.34%",
+    );
+    expect(modelRunLabel({ run_id: "run-2" })).toBe(" | run-2");
+    expect(modelWorkflowLabel("single_asset")).toBe("Single Asset");
+    expect(modelWorkflowLabel("saved_run_portfolio")).toBe("Saved-Run Portfolio");
+    expect(modelWorkflowLabel("joint_portfolio")).toBe("Joint Portfolio");
+  });
+
+  test("parses model job summaries safely", () => {
+    expect(parseModelJobSummary(undefined)).toEqual({});
+    expect(parseModelJobSummary({ summary: { metrics: { total_return: 0.1 } } })).toEqual({ metrics: { total_return: 0.1 } });
+    expect(parseModelJobSummary({ summary: '{"run_id":"run-1"}' })).toEqual({ run_id: "run-1" });
+    expect(parseModelJobSummary({ summary: "{bad json" })).toEqual({});
+  });
+});

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,25 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./tests/setup.ts",
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
+    globals: false,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "html"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/main.tsx", "src/vite-env.d.ts"],
+        thresholds: {
+          statements: 90,
+          branches: 72,
+          functions: 90,
+          lines: 90,
+        },
+    },
+  },
+});

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -35,6 +35,8 @@ if [[ -f "$ROOT_DIR/frontend/package.json" ]]; then
     echo "==> Frontend build"
     npm ci --prefix "$ROOT_DIR/frontend"
     npm run build --prefix "$ROOT_DIR/frontend"
+    echo "==> Frontend unit tests with coverage"
+    npm run test:coverage --prefix "$ROOT_DIR/frontend"
     echo "==> Frontend UI tests"
     npm exec --prefix "$ROOT_DIR/frontend" playwright install chromium
     npm run test:ui --prefix "$ROOT_DIR/frontend"


### PR DESCRIPTION
Closes #69.

## Summary
- Add Vitest, V8 coverage, jsdom, and Testing Library for React unit/component coverage.
- Extract reusable frontend helpers into `frontend/src/appUtils.ts` and cover them directly.
- Add API client tests and React app component tests that exercise navigation, read-only workflows, admin mutations, and major form controls.
- Add `npm run test:coverage --prefix frontend` to CI and document the workflow in `README.md`.
- Fix `api.performance()` to URL-encode paper portfolio IDs discovered by the API tests.

## Coverage
Current frontend coverage from the new gate:
- Statements: 94.09%
- Lines: 93.85%
- Functions: 94.40%
- Branches: 72.66% ratchet

Branch coverage is intentionally tracked as a lower ratchet for now because V8 counts many JSX optional-render fallbacks as branches. Statements, lines, and functions are gated at 90%.

## Validation
- `npm run test:coverage --prefix frontend`
- `npm run build --prefix frontend`
- `npm run test:ui --prefix frontend`
- `bash scripts/ci.sh`