### PR TITLE
Fix React quick start API loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ npm run dev --prefix frontend
 
 Open [http://127.0.0.1:5173](http://127.0.0.1:5173).
 
+By default, Vite proxies `/api/*` requests to the local FastAPI server on `127.0.0.1:8000`. Leave `VITE_ALLCAPS_API_BASE_URL` unset unless your backend is running somewhere else.
+
 Fallback Streamlit shell:
 
 ```bash
@@ -134,6 +136,8 @@ Open:
 Optional frontend env var:
 
 - `VITE_ALLCAPS_API_BASE_URL=http://127.0.0.1:8000`
+
+Normally this is not required for local development because the Vite dev server proxies same-origin `/api/*` requests to FastAPI. If the React UI shows API load errors while the network tab shows HTTP 200 responses, confirm this variable is not pointing at the frontend dev server.
 
 The React app is mixed read/write. Public users can browse research, saved runs, replay, live history, paper history, and performance pages. Mutating Discovery, Data Admin, Model Training, Live Ops, and paper controls require an admin token from `/api/admin/session`.
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const testPort = process.env.ALLCAPS_FRONTEND_TEST_PORT ?? "5173";
+const testBaseUrl = `http://127.0.0.1:${testPort}`;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -9,13 +12,13 @@ export default defineConfig({
   },
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://127.0.0.1:5173",
+    baseURL: testBaseUrl,
     trace: "on-first-retry",
     serviceWorkers: "block",
   },
   webServer: {
-    command: "npm run dev -- --port 5173",
-    url: "http://127.0.0.1:5173",
+    command: `npm run dev -- --port ${testPort}`,
+    url: testBaseUrl,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,12 @@
-const API_BASE_URL = import.meta.env.VITE_ALLCAPS_API_BASE_URL ?? "http://127.0.0.1:8000";
+const API_BASE_URL = normalizeApiBaseUrl(import.meta.env.VITE_ALLCAPS_API_BASE_URL);
+
+function normalizeApiBaseUrl(value: unknown): string {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed || trimmed === "/" || trimmed === ".") {
+    return "";
+  }
+  return trimmed.replace(/\/+$/, "");
+}
 
 export type RecordRow = Record<string, string | number | boolean | null>;
 export type PlotlyFigure = {
@@ -497,12 +505,42 @@ function researchQuery(filters: ResearchFilters = {}): string {
   return query ? `?${query}` : "";
 }
 
+async function parseJsonResponse<T>(response: Response, path: string): Promise<T> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const text = await response.text();
+  if (!contentType.toLowerCase().includes("application/json")) {
+    const snippet = text.trim().replace(/\s+/g, " ").slice(0, 160);
+    throw new Error(
+      `API returned ${contentType || "non-JSON"} for ${path}. Check that the React app is pointing at the FastAPI backend, not the frontend dev server.${snippet ? ` Body starts with: ${snippet}` : ""}`,
+    );
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(`API returned invalid JSON for ${path}.`);
+  }
+}
+
+async function readErrorDetail(response: Response): Promise<string> {
+  const fallback = `${response.status} ${response.statusText}`;
+  try {
+    const body = await parseJsonResponse<{ detail?: unknown }>(response, response.url || "API request");
+    if (body.detail) {
+      return Array.isArray(body.detail) ? body.detail.join("; ") : String(body.detail);
+    }
+  } catch {
+    // Keep the HTTP status fallback when the error response is not JSON.
+  }
+  return fallback;
+}
+
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);
   if (!response.ok) {
-    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    const detail = await readErrorDetail(response);
+    throw new Error(`API request failed: ${detail}`);
   }
-  return response.json() as Promise<T>;
+  return parseJsonResponse<T>(response, path);
 }
 
 async function postJson<T>(path: string, payload: unknown = {}, token?: string): Promise<T> {
@@ -515,18 +553,10 @@ async function postJson<T>(path: string, payload: unknown = {}, token?: string):
     body: JSON.stringify(payload),
   });
   if (!response.ok) {
-    let detail = `${response.status} ${response.statusText}`;
-    try {
-      const body = (await response.json()) as { detail?: unknown };
-      if (body.detail) {
-        detail = Array.isArray(body.detail) ? body.detail.join("; ") : String(body.detail);
-      }
-    } catch {
-      // Keep the HTTP status fallback when the response is not JSON.
-    }
+    const detail = await readErrorDetail(response);
     throw new Error(`API request failed: ${detail}`);
   }
-  return response.json() as Promise<T>;
+  return parseJsonResponse<T>(response, path);
 }
 
 async function deleteJson<T>(path: string, token?: string): Promise<T> {
@@ -537,18 +567,10 @@ async function deleteJson<T>(path: string, token?: string): Promise<T> {
     },
   });
   if (!response.ok) {
-    let detail = `${response.status} ${response.statusText}`;
-    try {
-      const body = (await response.json()) as { detail?: unknown };
-      if (body.detail) {
-        detail = Array.isArray(body.detail) ? body.detail.join("; ") : String(body.detail);
-      }
-    } catch {
-      // Keep the HTTP status fallback when the response is not JSON.
-    }
+    const detail = await readErrorDetail(response);
     throw new Error(`API request failed: ${detail}`);
   }
-  return response.json() as Promise<T>;
+  return parseJsonResponse<T>(response, path);
 }
 
 async function postForm<T>(path: string, formData: FormData, token?: string): Promise<T> {
@@ -560,22 +582,14 @@ async function postForm<T>(path: string, formData: FormData, token?: string): Pr
     body: formData,
   });
   if (!response.ok) {
-    let detail = `${response.status} ${response.statusText}`;
-    try {
-      const body = (await response.json()) as { detail?: unknown };
-      if (body.detail) {
-        detail = Array.isArray(body.detail) ? body.detail.join("; ") : String(body.detail);
-      }
-    } catch {
-      // Keep the HTTP status fallback when the response is not JSON.
-    }
+    const detail = await readErrorDetail(response);
     throw new Error(`API request failed: ${detail}`);
   }
-  return response.json() as Promise<T>;
+  return parseJsonResponse<T>(response, path);
 }
 
 export const api = {
-  baseUrl: API_BASE_URL,
+  baseUrl: API_BASE_URL || "same-origin",
   status: () => getJson<StatusPayload>("/api/status"),
   adminSession: (password = "") => postJson<AdminSessionPayload>("/api/admin/session", { password }),
   health: () => getJson<HealthPayload>("/api/datasets/health"),

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -399,7 +399,7 @@ function payloadFor(pathname: string, method = "GET") {
 
 function installFetchMock() {
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = new URL(String(input));
+    const url = new URL(String(input), "http://127.0.0.1:5173");
     const method = init?.method ?? "GET";
     const payload = payloadFor(url.pathname, method);
     return new Response(JSON.stringify(payload), {
@@ -525,7 +525,7 @@ describe("App component", () => {
     await user.click(screen.getByRole("button", { name: "Capture current board" }));
     await user.click(screen.getByRole("button", { name: "Disable paper trading" }));
 
-    const requestedPaths = fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname);
+    const requestedPaths = fetchMock.mock.calls.map(([input]) => new URL(String(input), "http://127.0.0.1:5173").pathname);
     expect(requestedPaths).toContain("/api/datasets/watchlist");
     expect(requestedPaths).toContain("/api/datasets/refresh");
     expect(requestedPaths).toContain("/api/discovery/overrides");
@@ -662,7 +662,7 @@ describe("App component", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
-        const path = new URL(String(input)).pathname;
+        const path = new URL(String(input), "http://127.0.0.1:5173").pathname;
         if (path === "/api/status") {
           return new Response(JSON.stringify(statusPayload), { status: 200, headers: { "Content-Type": "application/json" } });
         }
@@ -679,7 +679,7 @@ describe("App component", () => {
     await user.click(screen.getByRole("button", { name: /Run ExplorerSaved/ }));
     expect(await screen.findByText("No saved runs have been created yet. Train a model in the Model Training tab first, then return here.")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /ResearchSentiment/ }));
-    expect(await screen.findByText("API request failed: 500 Server Error")).toBeInTheDocument();
+    expect(await screen.findByText("API request failed: broken")).toBeInTheDocument();
   });
 
   test("renders a table empty state and limited columns", async () => {

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -42,7 +42,7 @@ describe("frontend API client", () => {
       narrative_topic: "",
     });
 
-    const url = new URL(calls[0].url);
+    const url = new URL(calls[0].url, "http://127.0.0.1:5173");
     expect(url.pathname).toBe("/api/research");
     expect(url.searchParams.getAll("platforms")).toEqual(["Truth Social", "X"]);
     expect(url.searchParams.get("keyword")).toBe("tariff rally");
@@ -121,6 +121,25 @@ describe("frontend API client", () => {
     await expect(api.status()).rejects.toThrow("502 Bad Gateway");
   });
 
+  test("rejects HTTP 200 responses that are not API JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response("<!doctype html><title>Vite fallback</title>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+      ),
+    );
+    await expect(api.status()).rejects.toThrow("not the frontend dev server");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{not-json", { status: 200, headers: { "Content-Type": "application/json" } })),
+    );
+    await expect(api.status()).rejects.toThrow("invalid JSON");
+  });
+
   test("surfaces delete and upload HTTP errors", async () => {
     mockFetch(409, { detail: "override locked" }, "Conflict");
     await expect(api.deleteDiscoveryOverride("override-1", "token")).rejects.toThrow("override locked");
@@ -157,7 +176,7 @@ describe("frontend API client", () => {
     await api.liveOps();
     await api.paperPortfolios();
 
-    expect(calls.map((call) => new URL(call.url).pathname)).toEqual([
+    expect(calls.map((call) => new URL(call.url, "http://127.0.0.1:5173").pathname)).toEqual([
       "/api/status",
       "/api/datasets/health",
       "/api/datasets/admin",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
   server: {
     host: "127.0.0.1",
     port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+      },
+    },
   },
 });

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -39,7 +39,7 @@ if [[ -f "$ROOT_DIR/frontend/package.json" ]]; then
     npm run test:coverage --prefix "$ROOT_DIR/frontend"
     echo "==> Frontend UI tests"
     npm exec --prefix "$ROOT_DIR/frontend" playwright install chromium
-    npm run test:ui --prefix "$ROOT_DIR/frontend"
+    ALLCAPS_FRONTEND_TEST_PORT="${ALLCAPS_FRONTEND_TEST_PORT:-5174}" npm run test:ui --prefix "$ROOT_DIR/frontend"
   else
     echo "npm is required for the frontend build but was not found on PATH." >&2
     exit 1


### PR DESCRIPTION
Closes #71

## Summary
- Default the React API client to same-origin `/api/*` calls so local Vite can proxy requests to FastAPI.
- Add a Vite dev-server proxy from `/api` to `http://127.0.0.1:8000` for the Python + React quick start.
- Detect HTTP 200 non-JSON/invalid-JSON API responses and raise actionable errors instead of generic `Load failed` states.
- Make Playwright’s local test port configurable and run repo CI UI tests on an isolated default port to avoid accidentally reusing an unrelated local app.
- Document the local API proxy behavior and when `VITE_ALLCAPS_API_BASE_URL` should be used.

## Root Cause
The React frontend could receive an HTTP 200 response that was actually frontend HTML, not FastAPI JSON. That happens when `/api/*` requests hit the frontend dev server fallback, or when `VITE_ALLCAPS_API_BASE_URL` points at the frontend server. The old client attempted to parse those responses as JSON and surfaced a generic load failure.

## Validation
- `bash scripts/ci.sh`
- Backend coverage: 92% total
- Frontend coverage: 94% statements, 93.76% lines
- Playwright UI tests: 9 passed
- Streamlit smoke test passed