### PR TITLE
Add React motion system

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -1057,6 +1057,16 @@ test("renders the overview shell from API-backed data", async ({ page }) => {
   await expect(page.getByText("Portfolio Alpha")).toBeVisible();
 });
 
+test("renders primary navigation with reduced motion enabled", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Web-first decision workbench" })).toBeVisible();
+  await page.getByRole("button", { name: /Research/ }).click();
+  await expect(page.getByRole("heading", { name: "Sentiment, narratives, and export pack" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Export research pack" })).toBeVisible();
+});
+
 test("shows data admin controls, health rows, and refresh jobs", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("button", { name: /Data Admin/ }).click();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.12",
+        "motion": "^12.38.0",
         "plotly.js-dist-min": "^3.5.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2860,6 +2861,33 @@
         "css-font": "^1.2.0"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4164,6 +4192,47 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/mouse-change": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.12",
+    "motion": "^12.38.0",
     "plotly.js-dist-min": "^3.5.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AnimatePresence, MotionConfig, motion, useReducedMotion } from "motion/react";
 import createPlotlyComponentModule from "react-plotly.js/factory";
 import Plotly from "plotly.js-dist-min";
 import type { Data, Frame, Layout } from "plotly.js";
@@ -33,6 +34,26 @@ const createPlotlyComponent = (
 ) as PlotComponentFactory;
 const Plot = createPlotlyComponent(Plotly);
 
+const editorialEase: [number, number, number, number] = [0.16, 1, 0.3, 1];
+const pageVariants = {
+  initial: { opacity: 0, y: 22, filter: "blur(10px)" },
+  animate: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.52, ease: editorialEase, when: "beforeChildren", staggerChildren: 0.045 },
+  },
+  exit: { opacity: 0, y: -12, filter: "blur(8px)", transition: { duration: 0.22, ease: editorialEase } },
+};
+const revealVariants = {
+  initial: { opacity: 0, y: 18 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.5, ease: editorialEase } },
+};
+const surfaceHover = {
+  y: -5,
+  transition: { duration: 0.22, ease: editorialEase },
+};
+
 type PageKey = "overview" | "research" | "discovery" | "runs" | "replay" | "models" | "data" | "live" | "paper";
 
 const pages: Array<{ key: PageKey; label: string; deck: string }> = [
@@ -52,20 +73,66 @@ function StatusPill({ label, tone = "neutral" }: { label: string; tone?: "neutra
 }
 
 function LoadingBlock({ label }: { label: string }) {
-  return <div className="loading-block">{label}</div>;
+  return (
+    <motion.div className="loading-block" variants={revealVariants} initial="initial" animate="animate">
+      {label}
+    </motion.div>
+  );
 }
 
 function ErrorBlock({ error }: { error: unknown }) {
-  return <div className="error-block">{error instanceof Error ? error.message : "Unable to load API data."}</div>;
+  return (
+    <motion.div className="error-block" variants={revealVariants} initial="initial" animate="animate">
+      {error instanceof Error ? error.message : "Unable to load API data."}
+    </motion.div>
+  );
+}
+
+function MetricValue({ value }: { value: unknown }) {
+  const prefersReducedMotion = useReducedMotion();
+  const numericValue = typeof value === "number" && Number.isFinite(value) ? value : null;
+  const [displayValue, setDisplayValue] = useState<unknown>(value);
+
+  useEffect(() => {
+    if (numericValue === null || prefersReducedMotion) {
+      setDisplayValue(value);
+      return;
+    }
+    const durationMs = 720;
+    const start = performance.now();
+    let animationFrame = 0;
+    const tick = (now: number) => {
+      const progress = Math.min((now - start) / durationMs, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplayValue(numericValue * eased);
+      if (progress < 1) {
+        animationFrame = requestAnimationFrame(tick);
+      }
+    };
+    animationFrame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(animationFrame);
+  }, [numericValue, prefersReducedMotion, value]);
+
+  return <>{formatValue(displayValue)}</>;
+}
+
+function AnimatedPage({ pageKey, children }: { pageKey: PageKey; children: ReactNode }) {
+  return (
+    <motion.div key={pageKey} className="page-motion" variants={pageVariants} initial="initial" animate="animate" exit="exit">
+      {children}
+    </motion.div>
+  );
 }
 
 function MetricCard({ label, value, caption }: { label: string; value: unknown; caption?: string }) {
   return (
-    <article className="metric-card">
+    <motion.article className="metric-card" variants={revealVariants} whileHover={surfaceHover}>
       <span>{label}</span>
-      <strong>{formatValue(value)}</strong>
+      <strong>
+        <MetricValue value={value} />
+      </strong>
       {caption ? <small>{caption}</small> : null}
-    </article>
+    </motion.article>
   );
 }
 
@@ -74,7 +141,7 @@ function PlotlyChart({ figure, title }: { figure?: PlotlyFigure; title: string }
     return <div className="empty-state">No chart data returned yet.</div>;
   }
   return (
-    <div className="chart-frame" aria-label={title}>
+    <motion.div className="chart-frame" aria-label={title} variants={revealVariants} whileHover={surfaceHover}>
       <Plot
         data={(figure.data ?? []) as Data[]}
         layout={
@@ -90,7 +157,7 @@ function PlotlyChart({ figure, title }: { figure?: PlotlyFigure; title: string }
         style={{ width: "100%", height: "100%" }}
         useResizeHandler
       />
-    </div>
+    </motion.div>
   );
 }
 
@@ -106,7 +173,7 @@ function DataTable({ rows, emptyLabel = "No rows returned yet." }: { rows: Recor
   }
 
   return (
-    <div className="table-wrap">
+    <motion.div className="table-wrap" variants={revealVariants}>
       <table>
         <thead>
           <tr>
@@ -125,7 +192,7 @@ function DataTable({ rows, emptyLabel = "No rows returned yet." }: { rows: Recor
           ))}
         </tbody>
       </table>
-    </div>
+    </motion.div>
   );
 }
 
@@ -2448,52 +2515,74 @@ function PaperPerformancePage() {
 export function App() {
   const [activePage, setActivePage] = useState<PageKey>("overview");
   const activeMeta = pages.find((page) => page.key === activePage) ?? pages[0];
+  const pageContent =
+    activePage === "overview" ? (
+      <OverviewPage />
+    ) : activePage === "research" ? (
+      <ResearchPage />
+    ) : activePage === "discovery" ? (
+      <DiscoveryPage />
+    ) : activePage === "runs" ? (
+      <RunExplorerPage />
+    ) : activePage === "replay" ? (
+      <ReplayPage />
+    ) : activePage === "models" ? (
+      <ModelTrainingPage onNavigate={setActivePage} />
+    ) : activePage === "data" ? (
+      <DataAdminPage />
+    ) : activePage === "live" ? (
+      <LiveDecisionPage />
+    ) : (
+      <PaperPerformancePage />
+    );
 
   return (
-    <main className="app-shell">
-      <header className="hero">
-        <div>
-          <p className="eyebrow">AllCaps Web App</p>
-          <h1>Web-first decision workbench</h1>
-          <p>
-            A React and FastAPI decision workbench backed by the existing Python analytics engine.
-          </p>
-        </div>
-        <div className="hero-card">
-          <span>Milestone</span>
-          <strong>React primary cutover</strong>
-          <small>Streamlit fallback retained</small>
-        </div>
-      </header>
+    <MotionConfig reducedMotion="user">
+      <motion.main className="app-shell" initial="initial" animate="animate" variants={pageVariants}>
+        <motion.header className="hero" variants={revealVariants}>
+          <motion.div variants={revealVariants}>
+            <p className="eyebrow">AllCaps Web App</p>
+            <h1>Web-first decision workbench</h1>
+            <p>
+              A React and FastAPI decision workbench backed by the existing Python analytics engine.
+            </p>
+          </motion.div>
+          <motion.div className="hero-card" variants={revealVariants} whileHover={surfaceHover}>
+            <span>Milestone</span>
+            <strong>React primary cutover</strong>
+            <small>Streamlit fallback retained</small>
+          </motion.div>
+        </motion.header>
 
-      <nav className="page-tabs" aria-label="Workbench sections">
-        {pages.map((page) => (
-          <button
-            key={page.key}
-            type="button"
-            className={page.key === activePage ? "active" : ""}
-            onClick={() => setActivePage(page.key)}
-          >
-            <span>{page.label}</span>
-            <small>{page.deck}</small>
-          </button>
-        ))}
-      </nav>
+        <motion.nav className="page-tabs" aria-label="Workbench sections" variants={revealVariants}>
+          {pages.map((page) => (
+            <motion.button
+              key={page.key}
+              type="button"
+              className={page.key === activePage ? "active" : ""}
+              onClick={() => setActivePage(page.key)}
+              whileHover={{ y: -3 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              {page.key === activePage ? (
+                <motion.span className="tab-active-wash" layoutId="active-tab-wash" aria-hidden="true" />
+              ) : null}
+              <span>{page.label}</span>
+              <small>{page.deck}</small>
+            </motion.button>
+          ))}
+        </motion.nav>
 
-      <section className="section-heading">
-        <p className="eyebrow">{activeMeta.label}</p>
-        <h2>{activeMeta.deck}</h2>
-      </section>
-
-      {activePage === "overview" ? <OverviewPage /> : null}
-      {activePage === "research" ? <ResearchPage /> : null}
-      {activePage === "discovery" ? <DiscoveryPage /> : null}
-      {activePage === "runs" ? <RunExplorerPage /> : null}
-      {activePage === "replay" ? <ReplayPage /> : null}
-      {activePage === "models" ? <ModelTrainingPage onNavigate={setActivePage} /> : null}
-      {activePage === "data" ? <DataAdminPage /> : null}
-      {activePage === "live" ? <LiveDecisionPage /> : null}
-      {activePage === "paper" ? <PaperPerformancePage /> : null}
-    </main>
+        <AnimatePresence mode="wait">
+          <AnimatedPage pageKey={activePage}>
+            <motion.section className="section-heading" variants={revealVariants}>
+              <p className="eyebrow">{activeMeta.label}</p>
+              <h2>{activeMeta.deck}</h2>
+            </motion.section>
+            {pageContent}
+          </AnimatedPage>
+        </AnimatePresence>
+      </motion.main>
+    </MotionConfig>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -15,6 +15,11 @@
   --warning: #ba7b16;
   --severe: #9a2f28;
   --shadow: 0 24px 70px rgba(54, 45, 29, 0.18);
+  --shadow-lift: 0 32px 88px rgba(54, 45, 29, 0.24);
+  --motion-fast: 180ms;
+  --motion-medium: 420ms;
+  --motion-slow: 720ms;
+  --motion-ease: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 * {
@@ -25,10 +30,40 @@ body {
   min-width: 320px;
   min-height: 100vh;
   margin: 0;
+  overflow-x: hidden;
   background:
     radial-gradient(circle at 10% 0%, rgba(188, 108, 76, 0.18), transparent 32rem),
     radial-gradient(circle at 90% 8%, rgba(109, 155, 120, 0.26), transparent 28rem),
     linear-gradient(135deg, #f6efe2 0%, #e8eadb 54%, #dfe8d6 100%);
+}
+
+body::before,
+body::after {
+  position: fixed;
+  inset: -18%;
+  z-index: 0;
+  pointer-events: none;
+  content: "";
+}
+
+body::before {
+  opacity: 0.42;
+  background:
+    radial-gradient(circle at 18% 24%, rgba(255, 255, 255, 0.58), transparent 18rem),
+    radial-gradient(circle at 72% 18%, rgba(188, 108, 76, 0.18), transparent 20rem),
+    radial-gradient(circle at 68% 78%, rgba(109, 155, 120, 0.24), transparent 22rem);
+  filter: blur(2px);
+  animation: paperWash 18s var(--motion-ease) infinite alternate;
+}
+
+body::after {
+  opacity: 0.18;
+  background-image:
+    linear-gradient(rgba(23, 32, 24, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(23, 32, 24, 0.08) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(circle at 50% 24%, #000, transparent 68%);
+  animation: gridDrift 28s linear infinite;
 }
 
 button,
@@ -39,6 +74,8 @@ textarea {
 }
 
 .app-shell {
+  position: relative;
+  z-index: 1;
   width: min(1180px, calc(100% - 32px));
   margin: 0 auto;
   padding: 32px 0 56px;
@@ -74,6 +111,10 @@ textarea {
   background: var(--paper);
   box-shadow: var(--shadow);
   backdrop-filter: blur(14px);
+  transition:
+    box-shadow var(--motion-medium) var(--motion-ease),
+    border-color var(--motion-medium) var(--motion-ease),
+    background var(--motion-medium) var(--motion-ease);
 }
 
 .hero-card {
@@ -113,6 +154,7 @@ textarea {
 }
 
 .page-tabs button {
+  position: relative;
   display: grid;
   gap: 4px;
   min-height: 82px;
@@ -123,11 +165,38 @@ textarea {
   border-radius: 20px;
   background: transparent;
   cursor: pointer;
+  overflow: hidden;
+  transition:
+    color var(--motion-fast) var(--motion-ease),
+    background var(--motion-fast) var(--motion-ease),
+    box-shadow var(--motion-fast) var(--motion-ease);
 }
 
 .page-tabs button.active {
   color: #0f1b12;
   background: var(--field);
+}
+
+.page-tabs button:hover,
+.page-tabs button:focus-visible {
+  box-shadow: inset 0 0 0 1px rgba(109, 155, 120, 0.36);
+  outline: none;
+}
+
+.tab-active-wash {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 20% 15%, rgba(255, 255, 255, 0.72), transparent 44%),
+    linear-gradient(135deg, rgba(217, 234, 213, 0.96), rgba(255, 252, 244, 0.72));
+}
+
+.page-tabs button > span:not(.tab-active-wash),
+.page-tabs button > small {
+  position: relative;
+  z-index: 1;
 }
 
 .page-tabs span {
@@ -153,6 +222,31 @@ textarea {
   gap: 18px;
 }
 
+.page-motion {
+  display: grid;
+  gap: 18px;
+}
+
+.page-motion .panel,
+.page-motion .metric-grid,
+.page-motion .chart-grid,
+.page-motion .table-wrap,
+.page-motion .empty-state {
+  animation: editorialRise var(--motion-slow) var(--motion-ease) both;
+}
+
+.page-motion .panel:nth-of-type(2n),
+.page-motion .metric-grid:nth-of-type(2n),
+.page-motion .chart-grid:nth-of-type(2n) {
+  animation-delay: 60ms;
+}
+
+.page-motion .panel:nth-of-type(3n),
+.page-motion .metric-grid:nth-of-type(3n),
+.page-motion .chart-grid:nth-of-type(3n) {
+  animation-delay: 120ms;
+}
+
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -163,6 +257,14 @@ textarea {
   min-height: 132px;
   padding: 18px;
   border-radius: 24px;
+}
+
+.metric-card:hover,
+.metric-card:focus-within,
+.panel:hover,
+.chart-frame:hover {
+  border-color: rgba(109, 155, 120, 0.32);
+  box-shadow: var(--shadow-lift);
 }
 
 .metric-card strong {
@@ -258,6 +360,15 @@ textarea {
   overflow: auto;
   border: 1px solid var(--line);
   border-radius: 20px;
+  background: rgba(255, 252, 244, 0.3);
+  transition:
+    border-color var(--motion-medium) var(--motion-ease),
+    box-shadow var(--motion-medium) var(--motion-ease);
+}
+
+.table-wrap:hover {
+  border-color: rgba(109, 155, 120, 0.3);
+  box-shadow: 0 18px 44px rgba(54, 45, 29, 0.12);
 }
 
 table {
@@ -285,6 +396,22 @@ th {
 td {
   max-width: 280px;
   overflow-wrap: anywhere;
+}
+
+tbody tr {
+  animation: rowReveal var(--motion-medium) var(--motion-ease) both;
+}
+
+tbody tr:nth-child(2n) {
+  animation-delay: 25ms;
+}
+
+tbody tr:nth-child(3n) {
+  animation-delay: 50ms;
+}
+
+tbody tr:hover {
+  background: rgba(217, 234, 213, 0.35);
 }
 
 select {
@@ -359,6 +486,14 @@ select[multiple] {
 .chart-frame {
   width: 100%;
   min-height: 460px;
+  border-radius: 22px;
+  transition:
+    filter var(--motion-medium) var(--motion-ease),
+    box-shadow var(--motion-medium) var(--motion-ease);
+}
+
+.chart-frame:hover {
+  filter: saturate(1.05) contrast(1.02);
 }
 
 .chart-grid {
@@ -407,6 +542,34 @@ select[multiple] {
   cursor: not-allowed;
 }
 
+select,
+input,
+textarea,
+.button-link,
+.action-button {
+  transition:
+    transform var(--motion-fast) var(--motion-ease),
+    box-shadow var(--motion-fast) var(--motion-ease),
+    border-color var(--motion-fast) var(--motion-ease),
+    background var(--motion-fast) var(--motion-ease);
+}
+
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+.button-link:focus-visible,
+.action-button:focus-visible {
+  border-color: var(--field-strong);
+  box-shadow: 0 0 0 4px rgba(109, 155, 120, 0.2);
+  outline: none;
+}
+
+.button-link:hover,
+.action-button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 26px rgba(54, 45, 29, 0.14);
+}
+
 .action-button--danger {
   color: #fff;
   background: var(--severe);
@@ -449,8 +612,70 @@ select[multiple] {
   color: var(--muted);
 }
 
+.loading-block {
+  position: relative;
+  overflow: hidden;
+}
+
+.loading-block::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(110deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+  transform: translateX(-100%);
+  animation: loadingSheen 1.4s var(--motion-ease) infinite;
+}
+
 .error-block {
   color: var(--severe);
+}
+
+@keyframes paperWash {
+  0% {
+    transform: translate3d(-1.5%, -1%, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(1.5%, 1%, 0) scale(1.035);
+  }
+}
+
+@keyframes gridDrift {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(44px, 44px, 0);
+  }
+}
+
+@keyframes editorialRise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+    filter: blur(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+@keyframes rowReveal {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes loadingSheen {
+  to {
+    transform: translateX(100%);
+  }
 }
 
 @media (max-width: 860px) {
@@ -468,5 +693,22 @@ select[multiple] {
 
   .page-tabs {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  body::before,
+  body::after,
+  .loading-block::after {
+    animation: none !important;
   }
 }


### PR DESCRIPTION
Closes #73

## Summary
- Add Motion for React via the `motion` package and wrap the app in user-respecting `MotionConfig`.
- Add page/tab transitions, animated hero/nav surfaces, metric-card count-up behavior, and reveal animations for charts/tables/loading/error states.
- Add an Editorial Luxury ambient paper-wash/grid background plus hover/focus polish across tabs, panels, cards, charts, tables, buttons, and inputs.
- Add `prefers-reduced-motion` CSS fallbacks and a Playwright reduced-motion smoke test.

## User Impact
The React app now feels more polished across all pages while keeping the existing workflows, API contracts, Streamlit fallback, and analytics behavior unchanged.

## Validation
- `bash scripts/ci.sh`
- `npm run build --prefix frontend`
- `npm run test:coverage --prefix frontend` — 94.23% statements / 94% lines
- `ALLCAPS_FRONTEND_TEST_PORT=5174 npm run test:ui --prefix frontend` — 10 passed