### PR TITLE
Professionalize React workflow home

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -1050,10 +1050,16 @@ test.beforeEach(async ({ page }) => {
 test("renders the overview shell from API-backed data", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Web-first decision workbench" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Signal research to portfolio decisions." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Turn political posts into a researched, tested, and monitored portfolio decision." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Prepare Data" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Research Signals" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Build Strategy" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Operate & Audit" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Inspect and deploy deliberately" })).toBeVisible();
   await expect(page.getByText("API base")).toBeVisible();
   await expect(page.getByText("truth_only (42 Truth, 0 X)")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Recent saved runs" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Saved strategy snapshot" })).toBeVisible();
   await expect(page.getByText("Portfolio Alpha")).toBeVisible();
 });
 
@@ -1061,24 +1067,25 @@ test("renders primary navigation with reduced motion enabled", async ({ page }) 
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Web-first decision workbench" })).toBeVisible();
-  await expect(page.getByText("Workflow map", { exact: true })).toBeVisible();
-  await expect(page.getByText("Explore", { exact: true })).toBeVisible();
-  await expect(page.getByText("Build", { exact: true })).toBeVisible();
-  await expect(page.getByText("Operate", { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "Help: Workflow map" }).focus();
-  await expect(page.getByText(/Follow the flow from data and research/)).toBeVisible();
-  await page.getByRole("button", { name: /Research/ }).click();
-  await expect(page.getByRole("heading", { name: "Sentiment, narratives, and export pack" })).toBeVisible();
-  await expect(page.getByText(/Use this page to inspect filtered Trump Truth Social/).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Signal research to portfolio decisions." })).toBeVisible();
+  await expect(page.getByText("Product workflow", { exact: true })).toBeVisible();
+  await expect(page.locator("#workflow-Prepare")).toBeVisible();
+  await expect(page.locator("#workflow-Research")).toBeVisible();
+  await expect(page.locator("#workflow-Build")).toBeVisible();
+  await expect(page.locator("#workflow-Operate")).toBeVisible();
+  await page.getByRole("button", { name: "Help: Product workflow" }).focus();
+  await expect(page.getByText(/Prepare data, research the signal/)).toBeVisible();
+  await page.getByRole("button", { name: "Research: Inspect signals" }).click();
+  await expect(page.getByRole("heading", { name: "Inspect signals" })).toBeVisible();
+  await expect(page.getByText(/Inspect filtered Truth Social/).first()).toBeVisible();
   await expect(page.getByRole("link", { name: "Export research pack" })).toBeVisible();
 });
 
 test("shows data admin controls, health rows, and refresh jobs", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Data Admin/ }).click();
+  await page.getByRole("button", { name: "Data Admin: Prepare datasets" }).click();
 
-  await expect(page.getByRole("heading", { name: "Refresh jobs, watchlist, and data health" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Prepare datasets" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Data Admin Console" })).toBeVisible();
   await expect(page.getByText("Read-only until unlocked")).toBeVisible();
   await page.getByPlaceholder("Admin password").fill("secret");
@@ -1103,9 +1110,9 @@ test("shows data admin controls, health rows, and refresh jobs", async ({ page }
 
 test("shows the migrated research workspace with narratives and export", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Research/ }).click();
+  await page.getByRole("button", { name: "Research: Inspect signals" }).click();
 
-  await expect(page.getByRole("heading", { name: "Sentiment, narratives, and export pack" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Inspect signals" })).toBeVisible();
   await expect(page.getByText("Truth Social-only mode is active")).toBeVisible();
   await expect(page.getByRole("link", { name: "Export research pack" })).toHaveAttribute(
     "href",
@@ -1131,9 +1138,9 @@ test("shows the migrated research workspace with narratives and export", async (
 
 test("shows the migrated discovery workspace with rankings and overrides", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Discovery/ }).click();
+  await page.getByRole("button", { name: "Discovery: X account context" }).click();
 
-  await expect(page.getByRole("heading", { name: "Tracked account ranking workspace" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "X account context" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Discovery workspace" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Discovery admin overrides" })).toBeVisible();
   await expect(page.getByText("Admins can now pin or suppress accounts from this")).toBeVisible();
@@ -1161,9 +1168,9 @@ test("shows the migrated discovery workspace with rankings and overrides", async
 
 test("shows the migrated run explorer with detail and comparison tables", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Run Explorer/ }).click();
+  await page.getByRole("button", { name: "Runs: Compare strategies" }).click();
 
-  await expect(page.getByRole("heading", { name: "Saved model results and comparisons" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Compare strategies" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Run Explorer" })).toBeVisible();
   await expect(page.getByLabel("Selected run")).toHaveValue("run-portfolio-1");
   await expect(page.getByRole("heading", { name: "Run summary" })).toBeVisible();
@@ -1182,9 +1189,9 @@ test("shows the migrated run explorer with detail and comparison tables", async 
 
 test("shows historical replay metrics and attribution tables", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Replay/ }).click();
+  await page.getByRole("button", { name: "Replay: Audit old signals" }).click();
 
-  await expect(page.getByRole("heading", { name: "Historical signal reconstruction" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Audit old signals" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Historical Replay Workspace" })).toBeVisible();
   await expect(page.getByLabel("Replay template run")).toHaveValue("run-asset-1");
   await expect(page.getByLabel("Historical signal session")).toHaveValue("2025-03-03");
@@ -1203,7 +1210,7 @@ test("shows historical replay metrics and attribution tables", async ({ page }) 
 
 test("shows model training forms and submits an admin job", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Model Training/ }).click();
+  await page.getByRole("button", { name: "Training: Build model runs" }).click();
 
   await expect(page.getByRole("heading", { name: "Model Training Job Console" })).toBeVisible();
   await expect(page.getByText("Read-only until unlocked")).toBeVisible();
@@ -1231,7 +1238,7 @@ test("shows model training forms and submits an admin job", async ({ page }) => 
 
 test("shows live ops controls and supports admin actions", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Live Ops/ }).click();
+  await page.getByRole("button", { name: "Live Ops: Deploy and capture" }).click();
 
   await expect(page.getByRole("heading", { name: "Live Ops Console" })).toBeVisible();
   await expect(page.getByText("Stored-data capture only")).toBeVisible();
@@ -1255,7 +1262,7 @@ test("shows live ops controls and supports admin actions", async ({ page }) => {
 
 test("shows paper performance diagnostics and winner distribution", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /Paper \+ Performance/ }).click();
+  await page.getByRole("button", { name: "Audit: Paper and drift" }).click();
 
   await expect(page.getByRole("heading", { name: "Portfolio selector" })).toBeVisible();
   await expect(page.getByRole("combobox")).toContainText("paper-1 - Portfolio Alpha");

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,6 +6,7 @@ const testBaseUrl = `http://127.0.0.1:${testPort}`;
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
+  workers: 2,
   timeout: 30_000,
   expect: {
     timeout: 5_000,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import {
   type RecordRow,
   type ResearchAssetFilters,
   type ResearchFilters,
+  type RunsPayload,
+  type StatusPayload,
 } from "./api";
 import {
   deploymentParamRows,
@@ -60,7 +62,7 @@ type PageMeta = {
   key: PageKey;
   label: string;
   deck: string;
-  workflow: "Start" | "Explore" | "Build" | "Operate";
+  workflow: "Home" | "Prepare" | "Research" | "Build" | "Operate";
   help: string;
   nextStep: string;
 };
@@ -68,75 +70,75 @@ type PageMeta = {
 const pages: PageMeta[] = [
   {
     key: "overview",
-    label: "Overview",
-    deck: "API status and app posture",
-    workflow: "Start",
-    help: "Start here to confirm the API, data posture, and recent saved runs before choosing a workflow.",
-    nextStep: "If the app has data, continue to Research. If core datasets are missing, go to Data Admin first.",
+    label: "Home",
+    deck: "Guided workflow",
+    workflow: "Home",
+    help: "Start here for the shortest path through data readiness, research, model building, deployment, and audit.",
+    nextStep: "Follow the recommended next action, or jump directly into the workflow step that matches your current state.",
   },
   {
     key: "research",
     label: "Research",
-    deck: "Sentiment, narratives, and export pack",
-    workflow: "Explore",
-    help: "Use this page to inspect filtered Trump Truth Social or X-backed sentiment before building models.",
-    nextStep: "Use the export pack when you want a portable evidence bundle, or move to Model Training after validating the slice.",
+    deck: "Inspect signals",
+    workflow: "Research",
+    help: "Inspect filtered Truth Social or X-backed sentiment, narratives, asset reactions, and exportable evidence.",
+    nextStep: "If the signal slice is credible, move to Model Training. If the data looks stale, go back to Data Admin.",
   },
   {
     key: "discovery",
     label: "Discovery",
-    deck: "Tracked account ranking workspace",
-    workflow: "Explore",
-    help: "Discovery ranks non-Trump X accounts that mention Trump. It is optional for Truth Social-only analysis.",
-    nextStep: "Use overrides only when X mention data is loaded and you want to pin or suppress tracked accounts.",
+    deck: "X account context",
+    workflow: "Research",
+    help: "Rank and manage non-Trump X accounts that mention Trump. Skip this for Truth Social-only review.",
+    nextStep: "Use overrides only when X mention data exists and tracked account context should affect downstream features.",
   },
   {
     key: "runs",
-    label: "Run Explorer",
-    deck: "Saved model results and comparisons",
+    label: "Runs",
+    deck: "Compare strategies",
     workflow: "Build",
-    help: "Inspect saved model and portfolio runs. This is analysis, not deployment.",
-    nextStep: "After choosing a portfolio run, deploy it explicitly from Live Ops.",
+    help: "Compare saved model and portfolio runs before choosing a deployment candidate.",
+    nextStep: "After choosing a portfolio run, deploy it explicitly from Live Ops rather than assuming the newest run is live.",
   },
   {
     key: "replay",
     label: "Replay",
-    deck: "Historical signal reconstruction",
-    workflow: "Explore",
-    help: "Replay rebuilds an old asset-model signal using only prior rows so you can audit drift and leakage.",
-    nextStep: "Use replay findings to decide whether a saved asset model is still trustworthy.",
+    deck: "Audit old signals",
+    workflow: "Research",
+    help: "Rebuild an old asset-model signal using only prior rows to audit drift and leakage.",
+    nextStep: "Use replay to explain suspicious sessions before trusting or retraining a model.",
   },
   {
     key: "models",
-    label: "Model Training",
-    deck: "Train and save model runs",
+    label: "Training",
+    deck: "Build model runs",
     workflow: "Build",
     help: "Create single-asset runs, saved-run allocators, or joint portfolio models from stored datasets.",
-    nextStep: "After training finishes, inspect the run in Run Explorer before deploying it in Live Ops.",
+    nextStep: "After training finishes, inspect the saved run before deploying it in Live Ops.",
   },
   {
     key: "data",
     label: "Data Admin",
-    deck: "Refresh jobs, watchlist, and data health",
-    workflow: "Operate",
-    help: "Owns dataset refreshes, watchlist edits, source inputs, manifests, and health checks.",
-    nextStep: "Refresh or fix data here before using Research, Model Training, or Live Ops.",
+    deck: "Prepare datasets",
+    workflow: "Prepare",
+    help: "Refresh datasets, edit the watchlist, check source manifests, and review health warnings.",
+    nextStep: "Once health is acceptable, go to Research to inspect whether the stored posts and market rows are useful.",
   },
   {
     key: "live",
     label: "Live Ops",
-    deck: "Operate deployed portfolio",
+    deck: "Deploy and capture",
     workflow: "Operate",
-    help: "Pin a portfolio run, capture stored-data live boards, and manage paper trading for the deployed strategy.",
-    nextStep: "Use Data Admin for fresh data. Live Ops only captures decisions from currently stored datasets.",
+    help: "Pin a portfolio run, capture stored-data live boards, and manage the deployed paper strategy.",
+    nextStep: "Use Data Admin for fresh data. Live Ops captures decisions only from currently stored datasets.",
   },
   {
     key: "paper",
-    label: "Paper + Performance",
-    deck: "Portfolio audit and drift",
+    label: "Audit",
+    deck: "Paper and drift",
     workflow: "Operate",
-    help: "Review paper portfolio outcomes, benchmark comparison, diagnostics, and drift warnings.",
-    nextStep: "If performance degrades, inspect the deployed run and retrain from Model Training rather than changing live logic here.",
+    help: "Review paper outcomes, benchmark comparison, diagnostics, and deployed-model drift warnings.",
+    nextStep: "If performance degrades, inspect the deployed run and retrain instead of changing live logic here.",
   },
 ];
 
@@ -145,11 +147,70 @@ const workflowGroups: Array<{
   description: string;
   pageKeys: PageKey[];
 }> = [
-  { label: "Start", description: "Check app posture", pageKeys: ["overview"] },
-  { label: "Explore", description: "Inspect signals and context", pageKeys: ["research", "discovery", "replay"] },
-  { label: "Build", description: "Train, compare, and select", pageKeys: ["models", "runs"] },
-  { label: "Operate", description: "Refresh data and run live audit", pageKeys: ["data", "live", "paper"] },
+  { label: "Home", description: "Follow the guided path", pageKeys: ["overview"] },
+  { label: "Prepare", description: "Make datasets trustworthy", pageKeys: ["data"] },
+  { label: "Research", description: "Understand the signal", pageKeys: ["research", "discovery", "replay"] },
+  { label: "Build", description: "Train and compare", pageKeys: ["models", "runs"] },
+  { label: "Operate", description: "Deploy and audit", pageKeys: ["live", "paper"] },
 ];
+
+type WorkflowStep = {
+  id: string;
+  number: string;
+  title: string;
+  summary: string;
+  doneLooksLike: string;
+  primaryPage: PageKey;
+  primaryLabel: string;
+  secondaryPages: PageKey[];
+};
+
+const workflowSteps: WorkflowStep[] = [
+  {
+    id: "prepare-data",
+    number: "1",
+    title: "Prepare Data",
+    summary: "Load Truth Social and optional X mention data, refresh market rows, and confirm health before analysis.",
+    doneLooksLike: "Core datasets are present, source mode is clear, and health warnings are understood.",
+    primaryPage: "data",
+    primaryLabel: "Open Data Admin",
+    secondaryPages: [],
+  },
+  {
+    id: "research-signals",
+    number: "2",
+    title: "Research Signals",
+    summary: "Review filtered sentiment, narratives, asset reactions, Discovery context, and historical replay evidence.",
+    doneLooksLike: "You know which posts, accounts, narratives, and sessions are worth modeling.",
+    primaryPage: "research",
+    primaryLabel: "Open Research",
+    secondaryPages: ["discovery", "replay"],
+  },
+  {
+    id: "build-strategy",
+    number: "3",
+    title: "Build Strategy",
+    summary: "Train single-asset or portfolio models, compare saved runs, and choose a candidate deliberately.",
+    doneLooksLike: "A saved portfolio run has explainable validation results and a clear deployment winner.",
+    primaryPage: "models",
+    primaryLabel: "Open Training",
+    secondaryPages: ["runs"],
+  },
+  {
+    id: "operate-audit",
+    number: "4",
+    title: "Operate & Audit",
+    summary: "Pin the selected portfolio run, capture stored-data decisions, and monitor paper-trading performance.",
+    doneLooksLike: "Live Ops has one pinned run, paper trading is configured, and drift/performance are visible.",
+    primaryPage: "live",
+    primaryLabel: "Open Live Ops",
+    secondaryPages: ["paper"],
+  },
+];
+
+function pageByKey(pageKey: PageKey): PageMeta {
+  return pages.find((page) => page.key === pageKey) ?? pages[0];
+}
 
 function HelpTip({ label, children }: { label: string; children: ReactNode }) {
   const tooltipId = useId();
@@ -1396,43 +1457,133 @@ function RunExplorerPage() {
   );
 }
 
-function OverviewPage() {
+function OverviewPage({ onNavigate }: { onNavigate: (page: PageKey) => void }) {
   const status = useQuery({ queryKey: ["status"], queryFn: api.status });
   const runs = useQuery({ queryKey: ["runs"], queryFn: api.runs });
 
   if (status.isLoading || runs.isLoading) {
-    return <LoadingBlock label="Loading API status..." />;
+    return <LoadingBlock label="Loading workflow home..." />;
   }
   if (status.error || runs.error) {
     return <ErrorBlock error={status.error ?? runs.error} />;
   }
 
-  const payload = status.data;
+  const payload = status.data as StatusPayload | undefined;
+  const savedRuns = runs.data as RunsPayload | undefined;
+  const missingCoreCount = payload?.missing_core_datasets.length ?? 0;
+  const savedRunCount = savedRuns?.count ?? 0;
+  const sourceMode = payload?.source_mode.mode === "truth_only" ? "Truth Social-only" : "Truth Social + X";
+  const recommended =
+    missingCoreCount > 0
+      ? {
+          title: "Prepare the datasets first",
+          summary: `${missingCoreCount} core dataset${missingCoreCount === 1 ? " is" : "s are"} missing. Start with refresh and health checks before interpreting signals.`,
+          page: "data" as PageKey,
+          label: "Go to Data Admin",
+          tone: "warn" as const,
+        }
+      : savedRunCount === 0
+        ? {
+            title: "Train the first strategy",
+            summary: "The data looks present, but there are no saved runs yet. Train a model before using Live Ops.",
+            page: "models" as PageKey,
+            label: "Go to Model Training",
+            tone: "neutral" as const,
+          }
+        : {
+            title: "Inspect and deploy deliberately",
+            summary: `${savedRunCount} saved run${savedRunCount === 1 ? " is" : "s are"} available. Compare results first, then pin the portfolio run in Live Ops.`,
+            page: "runs" as PageKey,
+            label: "Go to Run Explorer",
+            tone: "ok" as const,
+          };
+
   return (
-    <section className="page-grid">
-      <div className="metric-grid">
+    <section className="workflow-home">
+      <article className="panel panel--wide workflow-home__intro">
+        <div className="panel-heading">
+          <div>
+            <p className="eyebrow">Guided workflow</p>
+            <h2>Turn political posts into a researched, tested, and monitored portfolio decision.</h2>
+          </div>
+          <StatusPill label={sourceMode} tone="ok" />
+        </div>
+        <p>
+          Use the workflow below as the shortest safe path through the app: prepare trustworthy data, inspect the signal,
+          build and compare models, then operate one pinned portfolio run with paper-trading audit.
+        </p>
+        <div className="home-action-row">
+          <button type="button" className="action-button" onClick={() => onNavigate(recommended.page)}>
+            {recommended.label}
+          </button>
+          {recommended.page === "runs" ? (
+            <button type="button" className="action-button action-button--secondary" onClick={() => onNavigate("live")}>
+              Go to Live Ops
+            </button>
+          ) : null}
+        </div>
+      </article>
+
+      <article className={`panel panel--wide recommendation-card recommendation-card--${recommended.tone}`}>
+        <div>
+          <p className="eyebrow">Recommended next action</p>
+          <h2>{recommended.title}</h2>
+          <p>{recommended.summary}</p>
+        </div>
+        <button type="button" className="action-button" onClick={() => onNavigate(recommended.page)}>
+          {recommended.label}
+        </button>
+      </article>
+
+      <div className="metric-grid home-status-grid">
         <MetricCard label="App mode" value={payload?.mode} />
         <MetricCard label="Datasets tracked" value={payload?.dataset_count ?? 0} />
-        <MetricCard label="Missing core datasets" value={payload?.missing_core_datasets.length ?? 0} />
-        <MetricCard label="Saved runs" value={runs.data?.count ?? 0} />
+        <MetricCard label="Missing core datasets" value={missingCoreCount} />
+        <MetricCard label="Saved runs" value={savedRunCount} />
       </div>
+
+      <div className="workflow-steps" aria-label="Primary workflow">
+        {workflowSteps.map((step) => (
+          <motion.article className="workflow-step-card" key={step.id} variants={revealVariants} whileHover={surfaceHover}>
+            <div className="workflow-step-card__number">{step.number}</div>
+            <div>
+              <p className="eyebrow">Step {step.number}</p>
+              <h2>{step.title}</h2>
+              <p>{step.summary}</p>
+            </div>
+            <div className="workflow-step-card__done">
+              <strong>Done when</strong>
+              <span>{step.doneLooksLike}</span>
+            </div>
+            <div className="workflow-step-card__actions">
+              <button type="button" className="action-button" onClick={() => onNavigate(step.primaryPage)}>
+                {step.primaryLabel}
+              </button>
+              {step.secondaryPages.map((pageKey) => {
+                const page = pageByKey(pageKey);
+                return (
+                  <button key={pageKey} type="button" className="action-button action-button--secondary" onClick={() => onNavigate(pageKey)}>
+                    Open {page.label}
+                  </button>
+                );
+              })}
+            </div>
+          </motion.article>
+        ))}
+      </div>
+
       <article className="panel panel--wide">
         <div className="panel-heading">
           <div>
-            <p className="eyebrow">React primary checkpoint</p>
-            <h2>React + FastAPI is now the primary app surface.</h2>
+            <p className="eyebrow">System posture</p>
+            <h2>Current data and run snapshot</h2>
           </div>
-          <StatusPill label="Read/write API" tone="ok" />
+          <StatusPill label={`${payload?.source_mode.truth_post_count ?? 0} Truth / ${payload?.source_mode.x_post_count ?? 0} X`} />
         </div>
-        <p>
-          This web app covers the main research, dataset administration, model training,
-          run inspection, Discovery override, live ops, paper-trading, and performance workflows.
-          Streamlit remains available as a fallback shell while the legacy-only surfaces are retired.
-        </p>
         <dl className="detail-list">
           <div>
             <dt>API base</dt>
-            <dd>{api.baseUrl}</dd>
+            <dd>{api.baseUrl || "same origin"}</dd>
           </div>
           <div>
             <dt>State root</dt>
@@ -1446,12 +1597,10 @@ function OverviewPage() {
             </dd>
           </div>
         </dl>
-      </article>
-      <article className="panel panel--wide">
-        <div className="panel-heading">
-          <h2>Recent saved runs</h2>
+        <div className="compact-table-section">
+          <h3>Saved strategy snapshot</h3>
+          <DataTable rows={savedRuns?.runs ?? []} />
         </div>
-        <DataTable rows={runs.data?.runs ?? []} />
       </article>
     </section>
   );
@@ -2626,7 +2775,7 @@ export function App() {
   const activeMeta = pages.find((page) => page.key === activePage) ?? pages[0];
   const pageContent =
     activePage === "overview" ? (
-      <OverviewPage />
+      <OverviewPage onNavigate={setActivePage} />
     ) : activePage === "research" ? (
       <ResearchPage />
     ) : activePage === "discovery" ? (
@@ -2650,26 +2799,35 @@ export function App() {
       <motion.main className="app-shell" initial="initial" animate="animate" variants={pageVariants}>
         <motion.header className="hero" variants={revealVariants}>
           <motion.div variants={revealVariants}>
-            <p className="eyebrow">AllCaps Web App</p>
-            <h1>Web-first decision workbench</h1>
+            <p className="eyebrow">AllCaps</p>
+            <h1>Signal research to portfolio decisions.</h1>
             <p>
-              A React and FastAPI decision workbench backed by the existing Python analytics engine.
+              A workflow-first product for reviewing political social posts, testing market signals, and monitoring one
+              explicit portfolio strategy.
             </p>
+            <div className="hero-actions">
+              <button type="button" className="action-button" onClick={() => setActivePage("overview")}>
+                Start workflow
+              </button>
+              <button type="button" className="action-button action-button--secondary" onClick={() => setActivePage("data")}>
+                Check data
+              </button>
+            </div>
           </motion.div>
           <motion.div className="hero-card" variants={revealVariants} whileHover={surfaceHover}>
-            <span>Milestone</span>
-            <strong>React primary cutover</strong>
-            <small>Streamlit fallback retained</small>
+            <span>Workflow</span>
+            <strong>{"Prepare -> Research -> Build -> Operate"}</strong>
+            <small>Start with data readiness. End with an audited live portfolio decision.</small>
           </motion.div>
         </motion.header>
 
         <div className="workspace-layout">
           <motion.nav className="workflow-rail page-tabs" aria-label="Guided workflow navigation" variants={revealVariants}>
             <div className="workflow-rail__intro">
-              <p className="eyebrow">Workflow map</p>
-              <strong>Choose where you are in the process.</strong>
-              <HelpTip label="Workflow map">
-                Follow the flow from data and research through model building, then operate the selected portfolio run.
+              <p className="eyebrow">Product workflow</p>
+              <strong>Move through the app in order, or jump to the step you need.</strong>
+              <HelpTip label="Product workflow">
+                Prepare data, research the signal, build and compare strategy runs, then operate the selected portfolio.
               </HelpTip>
             </div>
             {workflowGroups.map((group) => (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,13 +1,13 @@
 :root {
   color: #111827;
-  background: #f5f1e8;
+  background: #f6f8fb;
   font-family: "Avenir Next", "Gill Sans", "Trebuchet MS", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   --ink: #111827;
   --muted: #536174;
-  --paper: rgba(255, 253, 247, 0.9);
+  --paper: rgba(255, 255, 255, 0.92);
   --paper-strong: rgba(255, 255, 255, 0.96);
   --line: rgba(21, 42, 74, 0.15);
   --navy: #0b1f3a;
@@ -19,8 +19,8 @@
   --ok: #0f766e;
   --warning: #b45309;
   --severe: #b42318;
-  --shadow: 0 24px 70px rgba(15, 23, 42, 0.14);
-  --shadow-lift: 0 32px 88px rgba(15, 23, 42, 0.2);
+  --shadow: 0 14px 38px rgba(15, 23, 42, 0.08);
+  --shadow-lift: 0 20px 52px rgba(15, 23, 42, 0.13);
   --motion-fast: 180ms;
   --motion-medium: 420ms;
   --motion-slow: 720ms;
@@ -37,9 +37,9 @@ body {
   margin: 0;
   overflow-x: hidden;
   background:
-    radial-gradient(circle at 12% 0%, rgba(31, 111, 178, 0.18), transparent 34rem),
-    radial-gradient(circle at 88% 10%, rgba(11, 31, 58, 0.12), transparent 30rem),
-    linear-gradient(135deg, #fffdf7 0%, #eef4fb 48%, #e6edf7 100%);
+    radial-gradient(circle at 12% 0%, rgba(31, 111, 178, 0.1), transparent 32rem),
+    radial-gradient(circle at 88% 10%, rgba(11, 31, 58, 0.07), transparent 28rem),
+    linear-gradient(135deg, #fbfdff 0%, #f4f7fb 48%, #edf3f9 100%);
 }
 
 body::before,
@@ -52,7 +52,7 @@ body::after {
 }
 
 body::before {
-  opacity: 0.42;
+  opacity: 0.26;
   background:
     radial-gradient(circle at 18% 24%, rgba(255, 255, 255, 0.72), transparent 18rem),
     radial-gradient(circle at 72% 18%, rgba(31, 111, 178, 0.16), transparent 20rem),
@@ -62,7 +62,7 @@ body::before {
 }
 
 body::after {
-  opacity: 0.18;
+  opacity: 0.08;
   background-image:
     linear-gradient(rgba(11, 31, 58, 0.08) 1px, transparent 1px),
     linear-gradient(90deg, rgba(11, 31, 58, 0.08) 1px, transparent 1px);
@@ -88,17 +88,17 @@ textarea {
 
 .hero {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-columns: minmax(0, 1fr) 360px;
   gap: 24px;
   align-items: stretch;
-  margin-bottom: 24px;
+  margin-bottom: 28px;
 }
 
 .hero h1 {
   max-width: 760px;
   margin: 0;
-  font-size: clamp(2.4rem, 7vw, 5.8rem);
-  line-height: 0.9;
+  font-size: clamp(2.4rem, 6vw, 5rem);
+  line-height: 0.94;
   letter-spacing: -0.08em;
 }
 
@@ -108,6 +108,13 @@ textarea {
   font-size: 1.08rem;
 }
 
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 22px;
+}
+
 .hero-card,
 .panel,
 .metric-card,
@@ -115,7 +122,7 @@ textarea {
   border: 1px solid var(--line);
   background: var(--paper);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(14px);
+  backdrop-filter: blur(10px);
   transition:
     box-shadow var(--motion-medium) var(--motion-ease),
     border-color var(--motion-medium) var(--motion-ease),
@@ -128,7 +135,10 @@ textarea {
   justify-content: flex-end;
   min-height: 220px;
   padding: 24px;
-  border-radius: 32px;
+  border-radius: 28px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(239, 246, 255, 0.82)),
+    var(--paper);
 }
 
 .hero-card span,
@@ -164,9 +174,9 @@ textarea {
   position: sticky;
   top: 18px;
   display: grid;
-  gap: 18px;
-  padding: 18px;
-  border-radius: 30px;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 26px;
 }
 
 .workflow-rail__intro {
@@ -175,7 +185,7 @@ textarea {
   gap: 8px;
   padding: 16px;
   color: #fff;
-  border-radius: 22px;
+  border-radius: 20px;
   background:
     radial-gradient(circle at 18% 18%, rgba(255, 255, 255, 0.2), transparent 44%),
     linear-gradient(135deg, var(--navy), var(--navy-soft));
@@ -194,7 +204,7 @@ textarea {
 
 .workflow-group {
   display: grid;
-  gap: 8px;
+  gap: 7px;
 }
 
 .workflow-group__heading {
@@ -218,19 +228,19 @@ textarea {
 
 .workflow-group__pages {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .workflow-page-button {
   position: relative;
   display: grid;
   gap: 4px;
-  min-height: 72px;
-  padding: 14px 15px;
+  min-height: 62px;
+  padding: 12px 14px;
   color: var(--ink);
   text-align: left;
   border: 0;
-  border-radius: 18px;
+  border-radius: 16px;
   background: transparent;
   cursor: pointer;
   overflow: hidden;
@@ -350,11 +360,11 @@ textarea {
   gap: 18px;
   padding: 18px;
   border: 1px solid rgba(31, 111, 178, 0.18);
-  border-radius: 24px;
+  border-radius: 22px;
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.82), rgba(217, 234, 255, 0.58)),
     var(--paper);
-  box-shadow: 0 16px 48px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
 }
 
 .workflow-hint strong {
@@ -374,6 +384,125 @@ textarea {
 .page-grid {
   display: grid;
   gap: 18px;
+}
+
+.workflow-home {
+  display: grid;
+  gap: 18px;
+}
+
+.workflow-home__intro h2 {
+  max-width: 840px;
+  font-size: clamp(1.9rem, 4vw, 3.3rem);
+  line-height: 1;
+  letter-spacing: -0.06em;
+}
+
+.home-action-row,
+.workflow-step-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.recommendation-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(239, 246, 255, 0.78)),
+    var(--paper);
+}
+
+.recommendation-card h2 {
+  margin: 4px 0 0;
+}
+
+.recommendation-card--ok {
+  border-color: rgba(15, 118, 110, 0.22);
+}
+
+.recommendation-card--warn {
+  border-color: rgba(180, 83, 9, 0.28);
+}
+
+.home-status-grid {
+  align-items: stretch;
+}
+
+.workflow-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.workflow-step-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  padding: 20px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow);
+}
+
+.workflow-step-card::before {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 4px;
+  content: "";
+  background: linear-gradient(90deg, var(--accent), rgba(31, 111, 178, 0.16));
+}
+
+.workflow-step-card__number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  margin-bottom: 16px;
+  color: #fff;
+  font-weight: 950;
+  border-radius: 999px;
+  background: var(--navy);
+}
+
+.workflow-step-card h2 {
+  margin: 4px 0 0;
+}
+
+.workflow-step-card p {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.workflow-step-card__done {
+  display: grid;
+  gap: 4px;
+  margin-top: auto;
+  padding-top: 14px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.workflow-step-card__done strong {
+  color: var(--navy);
+}
+
+.compact-table-section {
+  display: grid;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.compact-table-section h3 {
+  margin: 0;
 }
 
 .page-motion {
@@ -418,7 +547,7 @@ textarea {
 .panel:hover,
 .chart-frame:hover {
   border-color: rgba(31, 111, 178, 0.28);
-  box-shadow: var(--shadow-lift);
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);
 }
 
 .metric-card strong {
@@ -431,7 +560,7 @@ textarea {
 
 .panel {
   padding: 22px;
-  border-radius: 28px;
+  border-radius: 24px;
 }
 
 .panel--wide {
@@ -690,6 +819,11 @@ select[multiple] {
   cursor: pointer;
 }
 
+.action-button--secondary {
+  color: var(--navy-soft);
+  background: rgba(255, 255, 255, 0.78);
+}
+
 .action-button:disabled {
   color: var(--muted);
   background: rgba(21, 42, 74, 0.06);
@@ -839,7 +973,9 @@ textarea:focus-visible,
   .filter-grid,
   .chart-grid,
   .workspace-layout,
-  .workflow-hint {
+  .workflow-hint,
+  .workflow-steps,
+  .recommendation-card {
     grid-template-columns: 1fr;
   }
 
@@ -857,6 +993,10 @@ textarea:focus-visible,
 
   .section-heading {
     align-items: flex-start;
+  }
+
+  .recommendation-card .action-button {
+    width: 100%;
   }
 }
 

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -446,51 +446,125 @@ describe("App component", () => {
     const user = userEvent.setup();
     renderApp();
 
-    expect(await screen.findByRole("heading", { name: "Web-first decision workbench" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Signal research to portfolio decisions." })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Turn political posts into a researched, tested, and monitored portfolio decision." })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Prepare Data" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Research Signals" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Build Strategy" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Operate & Audit" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Inspect and deploy deliberately" })).toBeInTheDocument();
     expect(await screen.findByText("truth_only (42 Truth, 0 X)")).toBeInTheDocument();
     expect(screen.getByText("Portfolio Alpha")).toBeInTheDocument();
-    expect(screen.getByText("Workflow map")).toBeInTheDocument();
-    expect(screen.getByText("Explore")).toBeInTheDocument();
+    expect(screen.getByText("Product workflow")).toBeInTheDocument();
+    expect(screen.getByText("Prepare")).toBeInTheDocument();
+    expect(screen.getAllByText("Research").length).toBeGreaterThan(0);
     expect(screen.getByText("Build")).toBeInTheDocument();
     expect(screen.getByText("Operate")).toBeInTheDocument();
-    expect(screen.getAllByText(/Start here to confirm the API/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Follow the flow from data and research/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Start here for the shortest path/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Prepare data, research the signal/)).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Research: Sentiment/ }));
+    await user.click(screen.getByRole("button", { name: /Research: Inspect signals/ }));
     expect(await screen.findByRole("heading", { name: "Research workspace" })).toBeInTheDocument();
     expect(screen.getByText(/Truth Social-only mode is active/)).toBeInTheDocument();
-    expect(screen.getAllByText(/Use this page to inspect filtered Trump Truth Social/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Inspect filtered Truth Social/).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "Export research pack" })).toHaveAttribute("href", expect.stringContaining("/api/research/export"));
     expect(await screen.findByRole("heading", { name: "Multi-asset comparison, event study, and intraday reaction" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Discovery: Tracked/ }));
+    await user.click(screen.getByRole("button", { name: /Discovery: X account context/ }));
     expect(await screen.findByRole("heading", { name: "Discovery workspace" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Discovery admin overrides" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Run Explorer: Saved/ }));
+    await user.click(screen.getByRole("button", { name: /Runs: Compare strategies/ }));
     expect(await screen.findByRole("heading", { name: "Run Explorer" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Variant comparison" })).toBeInTheDocument();
     expect(screen.getByText("run-asset-1: robust score changed")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Replay: Historical/ }));
+    await user.click(screen.getByRole("button", { name: /Replay: Audit old signals/ }));
     expect(await screen.findByRole("heading", { name: "Historical Replay Workspace" })).toBeInTheDocument();
     expect(await screen.findByText("LONG SPY NEXT SESSION")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Model Training: Train/ }));
+    await user.click(screen.getByRole("button", { name: /Training: Build model runs/ }));
     expect(await screen.findByRole("heading", { name: "Model Training Job Console" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Use Joint Portfolio workflow" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Data Admin: Refresh/ }));
+    await user.click(screen.getByRole("button", { name: /Data Admin: Prepare datasets/ }));
     expect(await screen.findByRole("heading", { name: "Data Admin Console" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Watchlist controls" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Live Ops: Operate/ }));
+    await user.click(screen.getByRole("button", { name: /Live Ops: Deploy and capture/ }));
     expect(await screen.findByRole("heading", { name: "Live Ops Console" })).toBeInTheDocument();
     expect(screen.getByText("Stored-data capture only")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Paper \+ Performance: Portfolio/ }));
+    await user.click(screen.getByRole("button", { name: /Audit: Paper and drift/ }));
     expect(await screen.findByRole("heading", { name: "Portfolio selector" })).toBeInTheDocument();
     expect(await screen.findByText("score_outcome_correlation")).toBeInTheDocument();
+  });
+
+  test("drives workflow home calls to action", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(await screen.findByRole("button", { name: "Open Data Admin" }));
+    expect(await screen.findByRole("heading", { name: "Data Admin Console" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Home: Guided workflow" }));
+    await user.click(await screen.findByRole("button", { name: "Open Research" }));
+    expect(await screen.findByRole("heading", { name: "Research workspace" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Home: Guided workflow" }));
+    await user.click(await screen.findByRole("button", { name: "Open Training" }));
+    expect(await screen.findByRole("heading", { name: "Model Training Job Console" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Home: Guided workflow" }));
+    await user.click(await screen.findByRole("button", { name: "Open Runs" }));
+    expect(await screen.findByRole("heading", { name: "Run Explorer" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Home: Guided workflow" }));
+    await user.click(await screen.findByRole("button", { name: "Open Live Ops" }));
+    expect(await screen.findByRole("heading", { name: "Live Ops Console" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Home: Guided workflow" }));
+    await user.click(await screen.findByRole("button", { name: "Open Audit" }));
+    expect(await screen.findByRole("heading", { name: "Portfolio selector" })).toBeInTheDocument();
+  });
+
+  test("recommends data admin when core datasets are missing", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input), "http://127.0.0.1:5173");
+        const method = init?.method ?? "GET";
+        const payload =
+          url.pathname === "/api/status"
+            ? { ...statusPayload, missing_core_datasets: ["normalized_posts", "asset_daily"] }
+            : payloadFor(url.pathname, method);
+        return new Response(JSON.stringify(payload), { status: 200, headers: { "Content-Type": "application/json" } });
+      }),
+    );
+    renderApp();
+
+    expect(await screen.findByRole("heading", { name: "Prepare the datasets first" })).toBeInTheDocument();
+    await user.click(screen.getAllByRole("button", { name: "Go to Data Admin" })[0]);
+    expect(await screen.findByRole("heading", { name: "Data Admin Console" })).toBeInTheDocument();
+  });
+
+  test("recommends model training when data exists without saved runs", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input), "http://127.0.0.1:5173");
+        const method = init?.method ?? "GET";
+        const payload = url.pathname === "/api/runs" ? { count: 0, runs: [] } : payloadFor(url.pathname, method);
+        return new Response(JSON.stringify(payload), { status: 200, headers: { "Content-Type": "application/json" } });
+      }),
+    );
+    renderApp();
+
+    expect(await screen.findByRole("heading", { name: "Train the first strategy" })).toBeInTheDocument();
+    await user.click(screen.getAllByRole("button", { name: "Go to Model Training" })[0]);
+    expect(await screen.findByRole("heading", { name: "Model Training Job Console" })).toBeInTheDocument();
   });
 
   test("supports admin mutations from React pages", async () => {
@@ -498,7 +572,7 @@ describe("App component", () => {
     const fetchMock = installFetchMock();
     renderApp();
 
-    await user.click(await screen.findByRole("button", { name: /Data Admin: Refresh/ }));
+    await user.click(await screen.findByRole("button", { name: /Data Admin: Prepare datasets/ }));
     await user.type(screen.getByPlaceholderText(/password/i), "secret");
     await user.click(screen.getByRole("button", { name: "Unlock admin writes" }));
     expect(await screen.findByText("Unlocked for this browser session")).toBeInTheDocument();
@@ -509,7 +583,7 @@ describe("App component", () => {
     await user.click(screen.getByRole("button", { name: "Start refresh job" }));
     expect(await screen.findByRole("cell", { name: "dataset-refresh-2" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Discovery: Tracked/ }));
+    await user.click(screen.getByRole("button", { name: /Discovery: X account context/ }));
     await user.selectOptions(screen.getByLabelText("Override account"), "acct-muted");
     await user.selectOptions(screen.getByLabelText("Override action"), "suppress");
     await user.type(screen.getByPlaceholderText("Optional rationale"), "Noisy source");
@@ -518,7 +592,7 @@ describe("App component", () => {
     await user.click(screen.getByRole("button", { name: "Delete selected override" }));
     await waitFor(() => expect(screen.queryByText("override-pin")).not.toBeInTheDocument());
 
-    await user.click(screen.getByRole("button", { name: /Model Training: Train/ }));
+    await user.click(screen.getByRole("button", { name: /Training: Build model runs/ }));
     await user.click(screen.getByRole("button", { name: "Use Single Asset workflow" }));
     expect(screen.getByRole("heading", { name: "Single Asset configuration" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Use Saved-Run Portfolio workflow" }));
@@ -527,7 +601,7 @@ describe("App component", () => {
     await user.click(screen.getByRole("button", { name: "Start model training job" }));
     expect(await screen.findByRole("heading", { name: "Latest training result" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Live Ops: Operate/ }));
+    await user.click(screen.getByRole("button", { name: /Live Ops: Deploy and capture/ }));
     await user.click(screen.getByRole("button", { name: "Save pinned portfolio run" }));
     await user.click(screen.getByRole("button", { name: "Capture current board" }));
     await user.click(screen.getByRole("button", { name: "Disable paper trading" }));
@@ -540,13 +614,13 @@ describe("App component", () => {
     expect(requestedPaths).toContain("/api/live/config");
     expect(requestedPaths).toContain("/api/live/capture");
     expect(requestedPaths).toContain("/api/paper/current");
-  });
+  }, 10000);
 
   test("drives read-only research, run, replay, and performance controls", async () => {
     const user = userEvent.setup();
     renderApp();
 
-    await user.click(await screen.findByRole("button", { name: /Research: Sentiment/ }));
+    await user.click(await screen.findByRole("button", { name: /Research: Inspect signals/ }));
     await user.clear(screen.getByLabelText("Start date"));
     await user.type(screen.getByLabelText("Start date"), "2025-01-02");
     await user.clear(screen.getByLabelText("End date"));
@@ -579,7 +653,7 @@ describe("App component", () => {
     await user.type(screen.getByLabelText("Minutes after"), "300");
     expect(await screen.findByRole("heading", { name: "Intraday reaction" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Run Explorer: Saved/ }));
+    await user.click(screen.getByRole("button", { name: /Runs: Compare strategies/ }));
     await user.selectOptions(await screen.findByLabelText("Run type"), "asset_model");
     await user.selectOptions(screen.getByLabelText("Target asset"), "QQQ");
     await user.type(screen.getByPlaceholderText("Run name, id, or asset"), "Baseline");
@@ -590,21 +664,21 @@ describe("App component", () => {
     await user.selectOptions(screen.getByLabelText("Base run"), "run-asset-2");
     await waitFor(() => expect(screen.getAllByText("QQQ Baseline").length).toBeGreaterThan(0));
 
-    await user.click(screen.getByRole("button", { name: /Replay: Historical/ }));
+    await user.click(screen.getByRole("button", { name: /Replay: Audit old signals/ }));
     await user.selectOptions(await screen.findByLabelText("Replay template run"), "run-asset-2");
     await user.selectOptions(screen.getByLabelText("Historical signal session"), "2025-03-04");
     expect(await screen.findByText("LONG SPY NEXT SESSION")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Paper \+ Performance: Portfolio/ }));
+    await user.click(screen.getByRole("button", { name: /Audit: Paper and drift/ }));
     await user.selectOptions(await screen.findByRole("combobox"), "paper 2");
     expect(await screen.findByText("score_outcome_correlation")).toBeInTheDocument();
-  });
+  }, 10000);
 
   test("drives admin configuration controls across model, data, and live ops", async () => {
     const user = userEvent.setup();
     renderApp();
 
-    await user.click(await screen.findByRole("button", { name: /Model Training: Train/ }));
+    await user.click(await screen.findByRole("button", { name: /Training: Build model runs/ }));
     await user.type(screen.getByPlaceholderText("Admin password"), "secret");
     await user.click(screen.getByRole("button", { name: "Unlock admin writes" }));
     expect(await screen.findByText("Unlocked for this browser session")).toBeInTheDocument();
@@ -646,13 +720,13 @@ describe("App component", () => {
     await user.click(screen.getByRole("button", { name: "Start model training job" }));
     expect(await screen.findByText("run-portfolio-2")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Data Admin: Refresh/ }));
+    await user.click(screen.getByRole("button", { name: /Data Admin: Prepare datasets/ }));
     await user.click(screen.getByRole("button", { name: "Reset watchlist" }));
     await user.selectOptions(screen.getByLabelText("Refresh mode"), "full");
     const file = new File(["author,text\nmacro,hello\n"], "mentions.csv", { type: "text/csv" });
     await user.upload(screen.getByLabelText("CSV upload"), file);
 
-    await user.click(screen.getByRole("button", { name: /Live Ops: Operate/ }));
+    await user.click(screen.getByRole("button", { name: /Live Ops: Deploy and capture/ }));
     await user.selectOptions(screen.getByLabelText("Pinned joint portfolio run"), "run-portfolio-1");
     await user.selectOptions(screen.getByLabelText("Fallback mode"), "FLAT");
     await user.clear(screen.getByLabelText("Starting cash"));
@@ -663,7 +737,7 @@ describe("App component", () => {
     await user.type(screen.getByLabelText("Reset cash"), "90000");
     await user.click(screen.getByRole("button", { name: "Reset portfolio" }));
     await waitFor(() => expect(screen.getAllByText("paper-1").length).toBeGreaterThan(0));
-  });
+  }, 10000);
 
   test("shows empty and error states without crashing", async () => {
     vi.stubGlobal(
@@ -683,15 +757,15 @@ describe("App component", () => {
     renderApp();
 
     expect(await screen.findByText("No rows returned yet.")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /Run Explorer: Saved/ }));
+    await user.click(screen.getByRole("button", { name: /Runs: Compare strategies/ }));
     expect(await screen.findByText("No saved runs have been created yet. Train a model in the Model Training tab first, then return here.")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /Research: Sentiment/ }));
+    await user.click(screen.getByRole("button", { name: /Research: Inspect signals/ }));
     expect(await screen.findByText("API request failed: broken")).toBeInTheDocument();
   });
 
   test("renders a table empty state and limited columns", async () => {
     renderApp();
-    const recentRunsHeading = await screen.findByRole("heading", { name: "Recent saved runs" });
+    const recentRunsHeading = await screen.findByRole("heading", { name: "Saved strategy snapshot" });
     const recentRuns = recentRunsHeading.closest("article");
     expect(recentRuns).not.toBeNull();
     expect(within(recentRuns as HTMLElement).getByRole("columnheader", { name: "run id" })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Replaces the status-first Overview with a guided workflow Home while preserving the internal `overview` page key.
- Reorganizes the shell into Prepare, Research, Build, and Operate workflow groups with shorter user-facing labels and workflow CTAs.
- Removes migration-era copy and softens the visual system toward a calmer SaaS product surface.
- Updates unit and Playwright coverage for the new Home, recommendations, CTAs, and exact navigation labels.

Closes #79.

## Validation
- `npm run build --prefix frontend`
- `npm run test:coverage --prefix frontend` (93.86% statements / 93.61% lines)
- `npm run test:ui --prefix frontend`
- `bash scripts/ci.sh`